### PR TITLE
Memcache fixes

### DIFF
--- a/test/spec_session_memcache.rb
+++ b/test/spec_session_memcache.rb
@@ -188,7 +188,7 @@ begin
         else
           session[:f][:g][:h] = :j
         end
-        [200, {}, session.inspect]
+        [200, {}, [session.inspect]]
       end
       pool = Rack::Session::Memcache.new(hash_check)
       req = Rack::MockRequest.new(pool)


### PR DESCRIPTION
Makes memcache session specs pass on 1.9.2p0.
