### PR TITLE
Simple fix to add Rakefile into gemspec

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -15,7 +15,7 @@ Also see http://rack.rubyforge.org.
 EOF
 
   s.files           = Dir['{bin/*,contrib/*,example/*,lib/**/*,test/**/*}'] +
-                        %w(COPYING KNOWN-ISSUES rack.gemspec README SPEC)
+                        %w(COPYING KNOWN-ISSUES rack.gemspec Rakefile README SPEC)
   s.bindir          = 'bin'
   s.executables     << 'rackup'
   s.require_path    = 'lib'


### PR DESCRIPTION
I was curious as to why the Rakefile was not shipped as part of the gem.  I'd like to be able to execute all tests upon installation.  Only one line change. 

stahnma
