### PR TITLE
Support for HTTP_X_FORWARDED_{PORT,SSL}

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -70,11 +70,13 @@ module Rack
         @env['HTTP_HOST'] || "#{@env['SERVER_NAME'] || @env['SERVER_ADDR']}:#{@env['SERVER_PORT']}"
       end
     end
-    
+
     def port
-      host, port = host_with_port.split(/:/)
-      
-      (port || @env["SERVER_PORT"]).to_i
+      (host_with_port.split(/:/)[1] or if @env["HTTP_X_FORWARDED_HOST"]
+        @env["HTTP_X_FORWARDED_PORT"] or @env["HTTP_X_FORWARDED_SSL"] == "on" ? 443 : 80
+      else
+        @env["SERVER_PORT"]
+      end).to_i
     end
 
     def host

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -68,6 +68,14 @@ describe Rack::Request do
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org")
     req.port.should.equal 80
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "HTTP_X_FORWARDED_SSL" => "on")
+    req.port.should.equal 443
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "HTTP_X_FORWARDED_PORT" => "9393")
+    req.port.should.equal 9393
   end
 
   should "parse the query string" do


### PR DESCRIPTION
I was having issues with Rack::Cache serving files from one proxied host for another because the server port was passed through. This is fixed in master (defaulting to port 80), but there are several other HTTP_X_FORWARDED_\* situations that aren't accommodated (namely where \* is SSL or PORT). This branch has a fix for it. Feel free to liberally reformat.
