### PR TITLE
do not default referer to '/'

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -189,9 +189,9 @@ module Rack
       keys.map{|key| params[key] }
     end
 
-    # the referer of the client or '/'
+    # the referer of the client
     def referer
-      @env['HTTP_REFERER'] || '/'
+      @env['HTTP_REFERER']
     end
     alias referrer referer
 


### PR DESCRIPTION
```
[05:43] <alus> why does request.referer default to "/"?
[05:48] <alus> this right here: http://github.com/rack/rack/blob/f49b6e8738c1d621bbd3e136c611c2ef9f784d02/lib/rack/request.rb#L194
[05:48] <alus> why is that? it seems like a bad idea...
[07:24] <raggi> alus: agreed, please make patch / issue
```
