### PR TITLE
Fix Warnings in Utils.escape for 1.9.2

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -13,7 +13,7 @@ module Rack
     # query strings faster.  Use this rather than the cgi.rb
     # version since it's faster.  (Stolen from Camping).
     def escape(s)
-      s.to_s.gsub(/([^ a-zA-Z0-9_.-]+)/n) {
+      s.to_s.gsub(/([^ a-zA-Z0-9_.-]+)/u) {
         '%'+$1.unpack('H2'*bytesize($1)).join('%').upcase
       }.tr(' ', '+')
     end


### PR DESCRIPTION
Rack was generating warnings in 1.9.2: ...rack/utils.rb:16: warning: regexp match /.../n against to UTF-8 string

We modified the regex to support UTF-8 and verified all tests still pass in commonly used Ruby versions. See commit message for more information.
