### PR TITLE
SPEC is no longer in the project, was getting gemspec errors 

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -15,7 +15,7 @@ Also see http://rack.rubyforge.org.
 EOF
 
   s.files           = Dir['{bin/*,contrib/*,example/*,lib/**/*,test/**/*}'] +
-                        %w(COPYING KNOWN-ISSUES rack.gemspec Rakefile README SPEC)
+                        %w(COPYING KNOWN-ISSUES rack.gemspec Rakefile README)
   s.bindir          = 'bin'
   s.executables     << 'rackup'
   s.require_path    = 'lib'


### PR DESCRIPTION
Fixes the following errors:

rack at /Users/dev/.rvm/gems/ruby-1.9.2-p0@mulu/bundler/gems/rack-1598f873c891 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["SPEC"] are not files
