### PR TITLE
Fix initializing Response objects with differently-cased Content-Type headers

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -21,8 +21,8 @@ module Rack
 
     def initialize(body=[], status=200, header={}, &block)
       @status = status.to_i
-      @header = Utils::HeaderHash.new({"Content-Type" => "text/html"}.
-                                      merge(header))
+      @header = Utils::HeaderHash.new("Content-Type" => "text/html").
+                                      merge(header)
 
       @writer = lambda { |x| @body << x }
       @block = nil

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -42,6 +42,11 @@ describe Rack::Response do
     response["Content-Type"].should.equal "text/plain"
   end
 
+  it "can override the initial Content-Type with a different case" do
+    response = Rack::Response.new("", 200, "content-type" => "text/plain")
+    response["Content-Type"].should.equal "text/plain"
+  end
+
   it "can set cookies" do
     response = Rack::Response.new
 


### PR DESCRIPTION
Fixes this bug:

```
response = Rack::Response.new("", 200, "content-type" => "text/plain")
response["Content-Type"] # => "text/html"
```
