### PR TITLE
HTTP_X_FORWARDED_PROTO can be chained

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -66,7 +66,7 @@ module Rack
       if @env['HTTPS'] == 'on'
         'https'
       elsif @env['HTTP_X_FORWARDED_PROTO']
-        @env['HTTP_X_FORWARDED_PROTO']
+        @env['HTTP_X_FORWARDED_PROTO'].split(',')[0]
       else
         @env["rack.url_scheme"]
       end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -253,6 +253,10 @@ describe Rack::Request do
     request = Rack::Request.new(Rack::MockRequest.env_for("/", 'HTTP_X_FORWARDED_PROTO' => 'https'))
     request.scheme.should.equal "https"
     request.should.be.ssl?
+    
+    request = Rack::Request.new(Rack::MockRequest.env_for("/", 'HTTP_X_FORWARDED_PROTO' => 'https, http, http'))
+    request.scheme.should.equal "https"
+    request.should.be.ssl
   end
 
   should "parse cookies" do


### PR DESCRIPTION
The HTTP_X_FORWARDED_PROTO is not necessarily equal to "http" or "https". Lighttpd's mod_proxy, for example, chains the values. So you can end up with values equal to "https, http, http" when you have several reverse proxies ("https" will always be the first one if the request is encrypted).
