### PR TITLE
Rack::MockResponse#initialize does not handle nil values.

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -149,7 +149,7 @@ module Rack
       @headers = Rack::Utils::HeaderHash.new
       headers.each { |field, values|
         @headers[field] = values
-        @headers[field] = ""  if values.empty?
+        @headers[field] = ""  if (values.nil? || values.empty?)
       }
 
       @body = ""


### PR DESCRIPTION
If a response is returned where one of the Headers has the value of `nil`, `Rack::MockResponse#initialize` will attempt to call `empty?` on NilClass.
