### PR TITLE
Fastcgi binding

### DIFF
--- a/lib/rack/handler/fastcgi.rb
+++ b/lib/rack/handler/fastcgi.rb
@@ -19,8 +19,11 @@ module Rack
   module Handler
     class FastCGI
       def self.run(app, options={})
-        file = options[:File] and STDIN.reopen(UNIXServer.new(file))
-        port = options[:Port] and STDIN.reopen(TCPServer.new(options[:Host], port))
+        if options[:File]
+          file = STDIN.reopen(UNIXServer.new(options[:File]))
+        elsif options[:Port]
+          port = STDIN.reopen(TCPServer.new(options[:Host], options[:Port]))
+        end
         FCGI.each { |request|
           serve request, app
         }


### PR DESCRIPTION
Currently if both a Port and File option are passed to the FastCGI handler, the handler will first bind to the domain socket and replace the correct fd with that, then it will bind to the TCP port, and re-replace the fd with that one. This causes it to be wasteful of resources (it binds to two different kinds of socket but only uses one) and makes it so that if the application passes in default port/host options (as, for example, rackup does) it is impossible to cause the server to correctly listen on the domain socket (in rackup's case, once/if my handler-options patch is accepted, but this is more correct even if that isn't accepted).
