### PR TITLE
Ability for rackup/Rack::Server to accept handler-specific options on the command line

### DIFF
--- a/lib/rack/handler/fastcgi.rb
+++ b/lib/rack/handler/fastcgi.rb
@@ -28,6 +28,14 @@ module Rack
           serve request, app
         }
       end
+      
+      def self.valid_options
+        {
+          "Host=HOST" => "Hostname to listen on (default: localhost)",
+          "Port=PORT" => "Port to listen on (default: 8080)",
+          "File=PATH" => "Creates a Domain socket at PATH instead of a TCP socket. Ignores Host and Port if set.",
+        }
+      end
 
       def self.serve(request, app)
         env = request.env

--- a/lib/rack/handler/mongrel.rb
+++ b/lib/rack/handler/mongrel.rb
@@ -38,6 +38,16 @@ module Rack
         server.run.join
       end
 
+      def self.valid_options
+        {
+          "Host=HOST" => "Hostname to listen on (default: localhost)",
+          "Port=PORT" => "Port to listen on (default: 8080)",
+          "Processors=N" => "Number of concurrent processors to accept (default: 950)",
+          "Timeout=N" => "Time before a request is dropped for inactivity (default: 60)",
+          "Throttle=N" => "Throttle time between socket.accept calls in hundredths of a second (default: 0)",
+        }
+      end
+
       def initialize(app)
         @app = app
       end

--- a/lib/rack/handler/scgi.rb
+++ b/lib/rack/handler/scgi.rb
@@ -9,10 +9,18 @@ module Rack
       attr_accessor :app
 
       def self.run(app, options=nil)
+        options[:Socket] = UNIXServer.new(options[:File]) if options[:File]
         new(options.merge(:app=>app,
                           :host=>options[:Host],
                           :port=>options[:Port],
                           :socket=>options[:Socket])).listen
+      end
+      
+      def self.valid_options
+        {
+          "Host=HOST" => "Hostname to listen on (default: localhost)",
+          "Port=PORT" => "Port to listen on (default: 8080)",
+        }
       end
 
       def initialize(settings = {})

--- a/lib/rack/handler/thin.rb
+++ b/lib/rack/handler/thin.rb
@@ -12,6 +12,13 @@ module Rack
         yield server if block_given?
         server.start
       end
+
+      def self.valid_options
+        {
+          "Host=HOST" => "Hostname to listen on (default: localhost)",
+          "Port=PORT" => "Port to listen on (default: 8080)",
+        }
+      end
     end
   end
 end

--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -12,6 +12,13 @@ module Rack
         yield @server  if block_given?
         @server.start
       end
+      
+      def self.valid_options
+        {
+          "Host=HOST" => "Hostname to listen on (default: localhost)",
+          "Port=PORT" => "Port to listen on (default: 8080)",
+        }
+      end
 
       def self.shutdown
         @server.shutdown

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -47,6 +47,12 @@ module Rack
           opts.on("-p", "--port PORT", "use PORT (default: 9292)") { |port|
             options[:Port] = port
           }
+          
+          opts.on("-O", "--option NAME[=VALUE]", "pass VALUE to the server as option NAME. If no VALUE, sets it to true. Run '#{$0} -s SERVER -h' to get a list of options for SERVER") { |name|
+            name, value = name.split('=', 2)
+            value = true if value.nil?
+            options[name.to_sym] = value              
+          }
 
           opts.on("-E", "--env ENVIRONMENT", "use ENVIRONMENT for defaults (default: development)") { |e|
             options[:environment] = e
@@ -65,6 +71,8 @@ module Rack
 
           opts.on_tail("-h", "-?", "--help", "Show this message") do
             puts opts
+            puts handler_opts(options)
+            
             exit
           end
 
@@ -83,6 +91,28 @@ module Rack
 
         options[:config] = args.last if args.last
         options
+      end
+      
+      def handler_opts(options)
+        begin
+          info = []
+          server = Rack::Handler.get(options[:server]) || Rack::Handler.default(options)
+          if server && server.respond_to?(:valid_options)
+            info << ""
+            info << "Server-specific options for #{server.name}:"
+          
+            has_options = false
+            server.valid_options.each do |name, description|
+              next if name.to_s.match(/^(Host|Port)[^a-zA-Z]/) # ignore handler's host and port options, we do our own.
+              info << "  -O %-21s %s" % [name, description]
+              has_options = true
+            end
+            return "" if !has_options
+          end
+          info.join("\n")
+        rescue NameError
+          return "Warning: Could not find handler specified (#{options[:server] || 'default'}) to determine handler-specific options"
+        end
       end
     end
 


### PR DESCRIPTION
(originally Ticket 41 on Lighthouse, but pull requests are awesome so I'm moving it over here -- there is history to this patch, so the lighthouse page may be useful reading to see how it got here at http://rack.lighthouseapp.com/projects/22435/tickets/41-patch-improved-rackups-ability-to-handle-handler-specific-options#ticket-41-12).

This patch makes it so that Rack::Server accepts a new command line option, "-O", that will pass the option named to the handler's option hash. It also adds an expectation that handlers provide a method, called valid_options, that returns a hash of potential options and descriptions thereof. This allows for rackup -h to give information about a handler if "-s Handler -h" is passed in (and provides the options for the default handler if not).
