### PR TITLE
Changed the Memcache serialization format

### DIFF
--- a/lib/rack/session/memcache.rb
+++ b/lib/rack/session/memcache.rb
@@ -50,10 +50,11 @@ module Rack
         with_lock(env, [nil, {}]) do
           unless sid and session = @pool.get(sid)
             sid, session = generate_sid, {}
-            unless /^STORED/ =~ @pool.add(sid, session)
+            unless /^STORED/ =~ @pool.add(sid, JSON.generate(session))
               raise "Session collision on '#{sid.inspect}'"
             end
           end
+          session = session.class == String ? JSON.parse(session) : session
           [sid, session]
         end
       end
@@ -63,7 +64,7 @@ module Rack
         expiry = expiry.nil? ? 0 : expiry + 1
 
         with_lock(env, false) do
-          @pool.set session_id, new_session, expiry
+          @pool.set session_id, JSON.generate(new_session), expiry
           session_id
         end
       end

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -35,4 +35,5 @@ EOF
   s.add_development_dependency 'memcache-client'
   s.add_development_dependency 'mongrel'
   s.add_development_dependency 'thin'
+  s.add_development_dependency 'json'
 end


### PR DESCRIPTION
I needed to read the session data from outside rack and the session values wasn't in a standard way.

I changed the Rack::Session::Memcache to serialize using json. I ran all tests with no error after this patch.

Cheers,

Jonas
