### PR TITLE
Not all responses contain a Content-Type header

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -146,8 +146,7 @@ module Rack
       @status = status.to_i
 
       @original_headers = headers
-      @headers = Rack::Utils::HeaderHash.new("Content-Type" => "text/html").
-        merge(headers)
+      @headers = Rack::Utils::HeaderHash.new(headers)
 
       @body = ""
       body.each { |part| @body << part }

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -186,6 +186,18 @@ describe Rack::MockRequest do
 end
 
 describe Rack::MockResponse do
+  should "contain specified headers" do
+    headers = {
+      "X-UA-Compatible" => "IE=Edge,chrome=1",
+      "ETag"            => "\"5af83e3196bf99f440f31f2e1a6c9afe\"",
+      "Cache-Control"   => "max-age=0, private, must-revalidate",
+      "X-Runtime"       => "0.002101"
+    }
+
+    res = Rack::MockResponse.new(304, headers, [" "])
+    res.headers.to_hash.should.equal headers
+  end
+
   should "provide access to the HTTP status" do
     res = Rack::MockRequest.new(app).get("")
     res.should.be.successful


### PR DESCRIPTION
Not all responses contain a Content-Type header, so we should not add one by default.  Adding the Content-Type header causes rails tests to fail, and causes me to cry.

![sad](http://ragecomic.appspot.com/packs/sad/images/Baww.png)
