### PR TITLE
Fixed parsing of nested query strings

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -83,7 +83,7 @@ module Rack
         child_key = $1
         params[k] ||= []
         raise TypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
-        if params[k].last.is_a?(Hash) && !params[k].last.key?(child_key)
+        if params[k].last.is_a?(Hash) && !params[k].last.key?(child_key) && !recursive_query_key?(params[k].last, child_key)
           normalize_params(params[k].last, child_key, v)
         else
           params[k] << normalize_params({}, child_key, v)
@@ -97,6 +97,23 @@ module Rack
       return params
     end
     module_function :normalize_params
+
+    # Test if given key is a nested one like [a][b]
+    # and if given params string does contain that key.
+    # Returns true or false.
+    def recursive_query_key?(params, key)
+      return false unless key.match(%r(\]\[))
+      test = params
+      for k in key.scan(/\[([^\[\]]+)\]/).first
+        if test.key?(k)
+          test = test[k]
+        else
+          return false
+        end
+      end
+      true
+    end
+    module_function :recursive_query_key?
 
     def build_query(params)
       params.map { |k, v|

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -105,6 +105,9 @@ describe Rack::Utils do
     Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][w]=a&x[y][][z]=2&x[y][][w]=3").
       should.equal "x" => {"y" => [{"z" => "1", "w" => "a"}, {"z" => "2", "w" => "3"}]}
 
+    Rack::Utils.parse_nested_query("x[y][][z][a]=1&x[y][][z][a]=2").
+      should.equal "x" => {"y" => [{"z" => {"a" => "1"}}, {"z" => {"a" => "2"}}]}
+
     lambda { Rack::Utils.parse_nested_query("x[y]=1&x[y]z=2") }.
       should.raise(TypeError).
       message.should.equal "expected Hash (got String) for param `y'"


### PR DESCRIPTION
Testing for nested keys in query strings was not sufficient, thus a query like x[y][][z][a]=1&x[y][][z][a]=2 could not be parsed properly.
