### PR TITLE
Fix `Rack::Request#port` when `X-Forwarded-Host` contains no explicit port segment

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -98,6 +98,8 @@ module Rack
         port.to_i
       elsif ssl?
         443
+      elsif @env.has_key?("HTTP_X_FORWARDED_HOST")
+        80
       else
         @env["SERVER_PORT"].to_i
       end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -84,6 +84,14 @@ describe Rack::Request do
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "HTTP_X_FORWARDED_PORT" => "9393")
     req.port.should.equal 9393
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org:9393", "SERVER_PORT" => "80")
+    req.port.should.equal 9393
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "SERVER_PORT" => "9393")
+    req.port.should.equal 80
   end
 
   should "figure out the correct host with port" do
@@ -102,6 +110,10 @@ describe Rack::Request do
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org:9292")
     req.host_with_port.should.equal "example.org:9292"
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "SERVER_PORT" => "9393")
+    req.host_with_port.should.equal "example.org"
   end
 
   should "parse the query string" do


### PR DESCRIPTION
Hiya,

Here's the brief rationale:
- Apache, for example, defines `X-Forwarded-Host` as: "The original host requested by the client in the Host HTTP request header."
- Of the `Host` header, the HTTP spec says: "A "host" without any trailing port information implies the default port for the service requested (e.g., "80" for an HTTP URL)."
- Therefore, an `X-Forwarded-Host` without any trailing port information ought to imply that the forwarded port should be the default port. At the moment rack will use the SERVER_PORT, which may be wrong (as the backend server may be on a different port to the front-end proxy).

Some other notes:
- Rails is not affected as it overrides this code in `ActionDispatch::Http::URL`
- For an example of this being a problem, try putting a Sinatra app which does a redirect behind, e.g. Apache.
- I looked into this problem in detail a while back, here: https://github.com/jonleighton/redirect_test. You don't really need to read all that though as a lot of it is irrelevant.

Thanks,
Jon
