### PR TITLE
Quick note to reduce mystery of Abstract::Session::ID

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -34,6 +34,9 @@ module Rack
       # recommended to change its value.
       #
       # Is Rack::Utils::Context compatible.
+      #
+      # Not included by default; you must require 'rack/session/abstract/id'
+      # to use.
 
       class ID
         DEFAULT_OPTIONS = {


### PR DESCRIPTION
Took me a few minutes of head-scratching to figure this one out.
