### PR TITLE
PUT requests with no Content-type header and request body

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -144,11 +144,11 @@ module Rack
     # +FORM_DATA_MEDIA_TYPES+ array.
     #
     # A request body is also assumed to contain form-data when no
-    # Content-Type header is provided and the request_method is POST.
+    # Content-Type header is provided and the request_method is POST or PUT.
     def form_data?
       type = media_type
       meth = env["rack.methodoverride.original_method"] || env['REQUEST_METHOD']
-      (meth == 'POST' && type.nil?) || FORM_DATA_MEDIA_TYPES.include?(type)
+      (['POST', 'PUT'].include?(meth) && type.nil?) || FORM_DATA_MEDIA_TYPES.include?(type)
     end
 
     # Determine whether the request body contains data by checking

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -168,6 +168,19 @@ describe Rack::Request do
     req.body.read.should.equal "foo=bar&quux=bla"
   end
 
+  should "parse POST data when method is PUT and no Content-Type given" do
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/?foo=quux",
+        "REQUEST_METHOD" => 'PUT',
+        :input => "foo=bar&quux=bla")
+    req.content_type.should.be.nil
+    req.media_type.should.be.nil
+    req.query_string.should.equal "foo=quux"
+    req.GET.should.equal "foo" => "quux"
+    req.POST.should.equal "foo" => "bar", "quux" => "bla"
+    req.params.should.equal "foo" => "bar", "quux" => "bla"
+  end
+
   should "parse POST data on PUT when media type is form-data" do
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/?foo=quux",


### PR DESCRIPTION
Hi,

We recently upgraded from Rack 1.0.1 to 1.1 (as part of our move from Rails 2.3.5 to 2.3.10), and noticed that suddenly Rack has stopped looking at request body for PUT requests when Content-Type header is blank.

It looks like this commit https://github.com/rack/rack/commit/aea2d608fe592a665741087a8d6d31fcf26848ec broke the functionality.

Here is a fix with a test.

-Jatinder
