### PR TITLE
mongrel rack.url_scheme was hardcoded to http

### DIFF
--- a/lib/rack/handler/mongrel.rb
+++ b/lib/rack/handler/mongrel.rb
@@ -60,7 +60,7 @@ module Rack
                      "rack.multiprocess" => false, # ???
                      "rack.run_once" => false,
 
-                     "rack.url_scheme" => "http",
+                     "rack.url_scheme" => ["yes", "on", "1"].include?(env["HTTPS"]) ? "https" : "http"
                    })
         env["QUERY_STRING"] ||= ""
 


### PR DESCRIPTION
It should take env['HTTPS'] into account, the same way that the other handlers do:
  https://github.com/rack/rack/blob/master/lib/rack/handler/fastcgi.rb#L48
  https://github.com/rack/rack/blob/master/lib/rack/handler/lsws.rb#L27
  https://github.com/rack/rack/blob/master/lib/rack/handler/scgi.rb#L43
