### PR TITLE
allow multi-line comments in the config file

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -32,7 +32,7 @@ module Rack
           options = opts.parse! $1.split(/\s+/)
         end
         cfgfile.sub!(/^__END__\n.*/, '')
-        app = eval "Rack::Builder.new {( " + cfgfile + "\n )}.to_app",
+        app = eval "Rack::Builder.new {\n" + cfgfile + "\n}.to_app",
           TOPLEVEL_BINDING, config
       else
         require config

--- a/test/builder/comment.ru
+++ b/test/builder/comment.ru
@@ -1,0 +1,4 @@
+=begin
+
+=end
+run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -136,6 +136,12 @@ describe Rack::Builder do
       Rack::MockRequest.new(app).get("/").body.to_s.should.equal 'OK'
     end
 
+    it "supports multi-line comments" do
+      lambda {
+        Rack::Builder.parse_file config_file('comment.ru')
+      }.should.not.raise(SyntaxError)
+    end
+
     it "requires anything not ending in .ru" do
       $: << File.dirname(__FILE__)
       app, options = Rack::Builder.parse_file 'builder/anything'


### PR DESCRIPTION
this is a simple fix with test to ensure multi-line comments can be used in *.ru files
