### PR TITLE
Just use CGI.escape/unescape.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -3,27 +3,22 @@
 require 'fileutils'
 require 'set'
 require 'tempfile'
+require 'cgi'
 
 module Rack
   # Rack::Utils contains a grab-bag of useful methods for writing web
   # applications adopted from all kinds of Ruby libraries.
 
   module Utils
-    # Performs URI escaping so that you can construct proper
-    # query strings faster.  Use this rather than the cgi.rb
-    # version since it's faster.  (Stolen from Camping).
+    # URI escapes a string.
     def escape(s)
-      s.to_s.gsub(/([^ a-zA-Z0-9_.-]+)/u) {
-        '%'+$1.unpack('H2'*bytesize($1)).join('%').upcase
-      }.tr(' ', '+')
+      CGI.escape(s.to_s)
     end
     module_function :escape
 
-    # Unescapes a URI escaped string. (Stolen from Camping).
+    # Unescapes a URI escaped string.
     def unescape(s)
-      s.tr('+', ' ').gsub(/((?:%[0-9a-fA-F]{2})+)/n){
-        [$1.delete('%')].pack('H*')
-      }
+      CGI.unescape(s)
     end
     module_function :unescape
 

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'rack/utils'
 require 'rack/mock'
 
@@ -16,6 +18,12 @@ describe Rack::Utils do
     matz_name_sep = "\xE3\x81\xBE\xE3\x81\xA4 \xE3\x82\x82\xE3\x81\xA8".unpack("a*")[0] # Matsu moto
     matz_name_sep.force_encoding("UTF-8") if matz_name_sep.respond_to? :force_encoding
     Rack::Utils.escape(matz_name_sep).should.equal '%E3%81%BE%E3%81%A4+%E3%82%82%E3%81%A8'
+  end
+
+  if "".respond_to?(:encode)
+    should "escape non-UTF8 strings" do
+      Rack::Utils.escape("ø".encode("ISO-8859-1")).should.equal "%F8"
+    end
   end
 
   should "unescape correctly" do


### PR DESCRIPTION
The previous definitions were virtually identical to those provided
by CGI in 1.8.7/1.9.2, except that Rack::Utils.escape failed on non-
UTF8 encoded input.

Tested on 1.8.7, 1.9.2 and JRuby.

See comment thread here: https://github.com/rack/rack/commit/d8a980f937629274992b72b6c03f8518d17eaa50
