### PR TITLE
Rack::MethodOverride : use params[] instead of POST[] on the request

### DIFF
--- a/lib/rack/methodoverride.rb
+++ b/lib/rack/methodoverride.rb
@@ -12,7 +12,7 @@ module Rack
     def call(env)
       if env["REQUEST_METHOD"] == "POST"
         req = Request.new(env)
-        method = req.POST[METHOD_OVERRIDE_PARAM_KEY] ||
+        method = req.params[METHOD_OVERRIDE_PARAM_KEY] ||
           env[HTTP_METHOD_OVERRIDE_HEADER]
         method = method.to_s.upcase
         if HTTP_METHODS.include?(method)

--- a/test/spec_methodoverride.rb
+++ b/test/spec_methodoverride.rb
@@ -19,6 +19,14 @@ describe Rack::MethodOverride do
     req.env["REQUEST_METHOD"].should.equal "PUT"
   end
 
+  should "modify REQUEST_METHOD for POST requests when _method query parameter is set" do
+    env = Rack::MockRequest.env_for("/?_method=delete", :method => "POST")
+    app = Rack::MethodOverride.new(lambda{|envx| Rack::Request.new(envx) })
+    req = app.call(env)
+
+    req.env["REQUEST_METHOD"].should.equal "DELETE"
+  end
+  
   should "modify REQUEST_METHOD for POST requests when X-HTTP-Method-Override is set" do
     env = Rack::MockRequest.env_for("/",
             :method => "POST",


### PR DESCRIPTION
In cases where the body of a post is not form encoded and for various reasons methods other than get and post are not allowed, allow _method to be set in the query-string.
