### PR TITLE
Remove has_rdoc= method from gemspec

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -19,7 +19,6 @@ EOF
   s.bindir          = 'bin'
   s.executables     << 'rackup'
   s.require_path    = 'lib'
-  s.has_rdoc        = true
   s.extra_rdoc_files = ['README', 'KNOWN-ISSUES']
   s.test_files      = Dir['test/spec_*.rb']
 


### PR DESCRIPTION
This was throwing the following warning on rubygems 1.7:

> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.

Specification#has_rdoc= is deprecated as of rubygems version 1.7.0.
