### PR TITLE
Restore Ruby 1.8.6 compatibility

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -128,19 +128,14 @@ module Rack
     end
     module_function :build_nested_query
 
-    ESCAPE_HTML = {
-      "&" => "&amp;",
-      "<" => "&lt;",
-      ">" => "&gt;",
-      "'" => "&#x27;",
-      '"' => "&quot;",
-      "/" => "&#x2F;"
-    }
-    ESCAPE_HTML_PATTERN = Regexp.union(*ESCAPE_HTML.keys)
-
     # Escape ampersands, brackets and quotes to their HTML/XML entities.
     def escape_html(string)
-      string.to_s.gsub(ESCAPE_HTML_PATTERN){|c| ESCAPE_HTML[c] }
+      string.to_s.gsub("&", "&amp;").
+        gsub("<", "&lt;").
+        gsub(">", "&gt;").
+        gsub("'", "&#x27;").
+        gsub('"', "&quot;").
+        gsub('/', "&#x2F;")
     end
     module_function :escape_html
 


### PR DESCRIPTION
This reverts commit b4d0dc76b2d0b8b4b7160b689ecb019ea9e8d2b3, which breaks on Ruby 1.8.6 with the error `union: can't convert Array into String (TypeError)`

I would argue that this single performance gain is not worth blocking all 1.8.6 users.

Related question: Is there a good reason not to use `CGI.escapeHTML`? I don't think it escapes slashes, but it should handle all the other characters.
