### PR TITLE
Add protection against a malformed or malicious HTTP request causing an infinite loop 

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -531,6 +531,7 @@ module Rack
           loop do
             read_buffer = input.gets
             break if read_buffer == boundary + EOL
+            raise EOFError, "bad content body" if read_buffer.nil?
           end
 
           rx = /(?:#{EOL})?#{Regexp.quote boundary}(#{EOL}|--)/n


### PR DESCRIPTION
Add protection against a malformed or malicious HTTP request causing an infinite loop

In this case, a HTTP request with \n instead of \r\n will throw the server into an infinite loop
