### PR TITLE
Delete session cookies when session is empty

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -302,6 +302,8 @@ module Rack
             env["rack.errors"].puts("Warning! #{self.class.name} failed to save session. Content dropped.")
           elsif options[:defer] and not options[:renew]
             env["rack.errors"].puts("Defering cookie for #{session_id}") if $VERBOSE
+          elsif session.empty?
+            delete_cookie(env, headers)
           else
             cookie = Hash.new
             cookie[:value] = data
@@ -320,6 +322,10 @@ module Rack
           if request.cookies[@key] != cookie[:value] || cookie[:expires]
             Utils.set_cookie_header!(headers, @key, cookie)
           end
+        end
+
+        def delete_cookie(env, headers)
+          Utils.delete_cookie_header!(headers, @key)
         end
 
         # All thread safety and session retrival proceedures should occur here.


### PR DESCRIPTION
Rack::Session::Cookie (presumably amongst others) sets a cookie even if the session is empty. This is unfortunate because it means that it's very difficult for caching systems like Varnish to detect and cache logged out content.

This patch changes the Session::Abstract::Id class so that rather than setting cookies for an empty session it deletes them. 
