### PR TITLE
Removed :app option documentation

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -122,16 +122,6 @@ module Rack
     # Providing an options hash will prevent ARGV parsing and will not include
     # any default options.
     #
-    # This method can be used to very easily launch a CGI application, for
-    # example:
-    #
-    #  Rack::Server.start(
-    #    :app => lambda do |e|
-    #      [200, {'Content-Type' => 'text/html'}, ['hello world']]
-    #    end,
-    #    :server => 'cgi'
-    #  )
-    #
     # Further options available here are documented on Rack::Server#initialize
     def self.start(options = nil)
       new(options).start
@@ -140,8 +130,6 @@ module Rack
     attr_writer :options
 
     # Options may include:
-    # * :app
-    #     a rack application to run (overrides :config)
     # * :config
     #     a rackup configuration file path to load (.ru)
     # * :environment


### PR DESCRIPTION
Removed :app option documentation, since it isn't supported anymore - can't find it in the code, and an exception is raised if it is supplied. (It'd be nice to have this option back though, by the way.)
