### PR TITLE
`Rack::MethodOverride` should work also with GET request

### DIFF
--- a/lib/rack/methodoverride.rb
+++ b/lib/rack/methodoverride.rb
@@ -10,15 +10,15 @@ module Rack
     end
 
     def call(env)
-      if env["REQUEST_METHOD"] == "POST"
-        req = Request.new(env)
-        method = req.POST[METHOD_OVERRIDE_PARAM_KEY] ||
-          env[HTTP_METHOD_OVERRIDE_HEADER]
-        method = method.to_s.upcase
-        if HTTP_METHODS.include?(method)
-          env["rack.methodoverride.original_method"] = env["REQUEST_METHOD"]
-          env["REQUEST_METHOD"] = method
-        end
+      req = Request.new(env)
+      method = (req.GET[METHOD_OVERRIDE_PARAM_KEY] ||
+                req.POST[METHOD_OVERRIDE_PARAM_KEY] ||
+                env[HTTP_METHOD_OVERRIDE_HEADER])
+      method = method.to_s.upcase
+
+      if HTTP_METHODS.include?(method)
+        env["rack.methodoverride.original_method"] = env["REQUEST_METHOD"]
+        env["REQUEST_METHOD"] = method
       end
 
       @app.call(env)


### PR DESCRIPTION
Currently `Rack::MethodOverride` kicks in only during POST requests. This is a problem as some browsers (for example Firefox 3.6) send forms with `action='delete'` as GET requests.

From a REST point of view, this is somehow understandable because DELETE request are body-less just like GET requests (see http://www.w3.org/Bugs/Public/show_bug.cgi?id=10671 and http://tech.groups.yahoo.com/group/rest-discuss/message/9962).
