### PR TITLE
Restore Ruby 1.9.1 compatibility

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -1,12 +1,12 @@
 # -*- encoding: binary -*-
-
 require 'fileutils'
 require 'set'
 require 'tempfile'
-
 require 'rack/multipart'
 
-if RUBY_VERSION[/^\d+\.\d+/] == '1.8'
+major, minor, patch = RUBY_VERSION.split('.')
+
+if (major == 1 && minor < 9) || (major == 1 && minor == 9 && patch < 2)
   # pull in backports
   require 'rack/backports/uri/common'
 else

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -1,5 +1,4 @@
 # -*- encoding: utf-8 -*-
-
 require 'rack/utils'
 require 'rack/mock'
 


### PR DESCRIPTION
The latest Rack release (1.3.0) breaks on Ruby 1.9.1 with the error:

```
NoMethodError: undefined method `decode_www_form_component' for URI:Module
```

Apparently, `URI.encode_www_form_component` and `URI.encode_www_form_component` weren't added until Ruby 1.9.2.

This patch restores Ruby 1.9.1 compatibility.
