### PR TITLE
Fix non-ASCII POST data in a request.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -84,6 +84,9 @@ module Rack
       return if k.empty?
 
       if after == ""
+	if v.respond_to?(:force_encoding) and v =~ /[\x80-\xFF]/m
+	  v.force_encoding(Encoding::UTF_8)
+	end
         params[k] = v
       elsif after == "[]"
         params[k] ||= []


### PR DESCRIPTION
Allow to pass non-ASCII chars in fields of a form over POST request correclty. Forcing the non-ASCII strings to UTF-8 charset.
