### PR TITLE
fix Rack::Lock, use same logic for Rack::CommonLogger

### DIFF
--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -24,6 +24,7 @@ module Rack
   end
 
   autoload :Builder, "rack/builder"
+  autoload :BodyProxy, "rack/body_proxy"
   autoload :Cascade, "rack/cascade"
   autoload :Chunked, "rack/chunked"
   autoload :CommonLogger, "rack/commonlogger"

--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -1,0 +1,21 @@
+module Rack
+  class BodyProxy < defined?(BasicObject) ? BasicObject : Object
+    def initialize(body, &block)
+      @body, @block = body, block
+    end
+
+    def respond_to?(*args)
+      super or @body.respond_to?(*args)
+    end
+
+    def close
+      @body.close if @body.respond_to? :close
+    ensure
+      @block.call
+    end
+
+    def method_missing(*args, &block)
+      @body.__send__(*args, &block)
+    end
+  end
+end

--- a/lib/rack/commonlogger.rb
+++ b/lib/rack/commonlogger.rb
@@ -1,3 +1,5 @@
+require 'rack/body_proxy'
+
 module Rack
   # Rack::CommonLogger forwards every request to an +app+ given, and
   # logs a line in the Apache common log format to the +logger+, or
@@ -17,7 +19,7 @@ module Rack
       began_at = Time.now
       status, header, body = @app.call(env)
       header = Utils::HeaderHash.new(header)
-      log(env, status, header, began_at)
+      body = BodyProxy.new(body) { log(env, status, header, began_at) }
       [status, header, body]
     end
 

--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -1,27 +1,8 @@
 require 'thread'
+require 'rack/body_proxy'
 
 module Rack
   class Lock
-    class Proxy < Struct.new(:target, :mutex) # :nodoc:
-      def each
-        target.each { |x| yield x }
-      end
-
-      def close
-        target.close if target.respond_to?(:close)
-      ensure
-        mutex.unlock
-      end
-
-      def to_path
-        target.to_path
-      end
-
-      def respond_to?(sym)
-        sym.to_sym == :close || target.respond_to?(sym)
-      end
-    end
-
     FLAG = 'rack.multithread'.freeze
 
     def initialize(app, mutex = Mutex.new)
@@ -32,7 +13,7 @@ module Rack
       old, env[FLAG] = env[FLAG], false
       @mutex.lock
       response = @app.call(env)
-      response[2] = Proxy.new(response[2], @mutex)
+      response[2] = BodyProxy.new(response[2]) { @mutex.unlock }
       response
     rescue Exception
       @mutex.unlock


### PR DESCRIPTION
`Rack::Lock` was broken (defined `respond_to?` but not `method_missing`), so I fixed that and extracted the body proxy, so it can be used by other middleware, like `Rack::CommonLogger`.

@tenderlove It is impossible to use this for `Rack::Runtime`, as you suggested in your blog post, since `Rack::Runtime` is setting a header. This is caused by the nature of HTTP, not by Rack. Also, shifting all processing into `each` is a super bad idea and will eventually lead to PHP style error pages (status code 200, after half the HTML has been sent through the wire, there's suddenly some MySQL error). I would also not consider `Rack::Runtime` as broken, but we might want to specify that it's only measuring `call`, not `each`. But if you actually use `Rack::Runtime`, instead of just doing some stupid example code, you are probably aware of it, as the header actually arrives after about the time it has measured. Following the same logic you used to demo how broken it is, it's also possible to show that doing all processing in `each` is not faster than doing it in `call`, maybe even a little slower.
