### PR TITLE
fix BodyProxy#close so it works correctly when close invoked more than one time

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -1,7 +1,7 @@
 module Rack
   class BodyProxy
     def initialize(body, &block)
-      @body, @block = body, block
+      @body, @block, @closed = body, block, false
     end
 
     def respond_to?(*args)
@@ -9,9 +9,17 @@ module Rack
     end
 
     def close
-      @body.close if @body.respond_to? :close
-    ensure
-      @block.call
+      return if closed?
+      begin
+        @body.close if @body.respond_to? :close
+      ensure
+        @block.call
+        @closed = true
+      end
+    end
+
+    def closed?
+      @closed
     end
 
     def method_missing(*args, &block)

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -1,0 +1,9 @@
+describe Rack::BodyProxy do
+  should 'not close more than one time' do
+    count = 0
+    proxy = Rack::BodyProxy.new([]) { count += 1 }
+    proxy.close
+    proxy.close
+    count.should == 1
+  end
+end


### PR DESCRIPTION
In Rack::Lock the BodyProxy is initialized with a block { @mutex.unlock }, if this proxy closes many times, @mutex.unlock will be called multiple times and cause an exception.

For example, rack-test will try to close the proxy a second time (https://github.com/brynary/rack-test/blob/master/lib/rack/mock_session.rb#L33), raise "ThreadError: Attempt to unlock a mutex which is not locked", and break lots of my tests :-(
