### PR TITLE
Issue 195 cache control nil

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -28,7 +28,8 @@ module Rack
       end
 
       unless headers['Cache-Control']
-        headers['Cache-Control'] = digest ? @cache_control : @no_cache_control
+        headers['Cache-Control'] =
+          (digest ? @cache_control : @no_cache_control) || []
       end
 
       [status, headers, body]


### PR DESCRIPTION
I tracked issue #195 down to Rack:ETag sending nil for Cache-Control header when there was no body in the response (such as in a redirect). This patch makes sure Cache-Control can never be nil no matter what is passed in.

Is setting a header to an empty array the correct way to tell Rack that you don't want it in the response? I assume this was what used to be accomplished by setting a header to nil.
