### PR TITLE
Minor error in documentation regarding the order of parameters in HTTP_X_

### DIFF
--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -41,16 +41,15 @@ module Rack
   #     proxy_set_header   X-Forwarded-For     $proxy_add_x_forwarded_for;
   #
   #     proxy_set_header   X-Sendfile-Type     X-Accel-Redirect;
-  #     proxy_set_header   X-Accel-Mapping     /var/www/=/files/;
+  #     proxy_set_header   X-Accel-Mapping     /files/=/var/www/;
   #
   #     proxy_pass         http://127.0.0.1:8080/;
   #   }
   #
   # Note that the X-Sendfile-Type header must be set exactly as shown above. The
-  # X-Accel-Mapping header should specify the by the location on the file system,
-  # followed by an equals sign (=), followed name of the private URL pattern
-  # that it maps to. The middleware performs a simple substitution on the
-  # resulting path.
+  # X-Accel-Mapping header should specify the internal URI path, followed by an
+  # equals sign (=), followed name of the location in the file system that it maps
+  # to. The middleware performs a simple substitution on the resulting path.
   #
   # See Also: http://wiki.codemongers.com/NginxXSendfile
   #


### PR DESCRIPTION
Minor error in documentation regarding the order of parameters in HTTP_X_ACCEL_MAPPING.
