### PR TITLE
Fix documentation about nginx x-accel-redirect

### DIFF
--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -41,7 +41,7 @@ module Rack
   #     proxy_set_header   X-Forwarded-For     $proxy_add_x_forwarded_for;
   #
   #     proxy_set_header   X-Sendfile-Type     X-Accel-Redirect;
-  #     proxy_set_header   X-Accel-Mapping     /files/=/var/www/;
+  #     proxy_set_header   X-Accel-Mapping     /var/www/=/files/;
   #
   #     proxy_pass         http://127.0.0.1:8080/;
   #   }


### PR DESCRIPTION
According to my experience (and my actual nginx configurations), the x-accel-mapping header seems to been wrong in the example (NGINX section of documentation). Very confusing for a new user :)
