### PR TITLE
Avoid having the whole body in memory by hashing parts incrementally in Rack::Etag

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -23,7 +23,7 @@ module Rack
       status, headers, body = @app.call(env)
 
       if etag_status?(status) && etag_body?(body) && !skip_caching?(headers)
-        digest, body = digest_body(body)
+        digest = digest_body(body)
         headers['ETag'] = %("#{digest}") if digest
       end
 
@@ -51,11 +51,13 @@ module Rack
       end
 
       def digest_body(body)
-        parts = []
-        body.each { |part| parts << part }
-        string_body = parts.join
-        digest = Digest::MD5.hexdigest(string_body) unless string_body.empty?
-        [digest, parts]
+        digest = Digest::MD5.new
+        empty = true
+        body.each do |part|
+          empty = false if empty && !part.empty?
+          digest.update(part)
+        end
+        digest.to_s unless empty
       end
   end
 end


### PR DESCRIPTION
Hi guys,
My previous attempt to incrementally hash the response body in Rack::Etag wasn't taking into account a440ffb48bcb15f0cf05dd5c3e8e31772cec8ab9 (Etag middleware should not return a digest if body is empty and should also allow a default cache directive when no caching is done.) thus introducing a regression.
I'm sorry about this and I've updated my patch so it should be OK now.
Peace!
