### PR TITLE
Fix Rack::Builder usage example

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -17,7 +17,7 @@ module Rack
   #
   #  app = Rack::Builder.app do
   #    use Rack::CommonLogger
-  #    lambda { |env| [200, {'Content-Type' => 'text/plain'}, 'OK'] }
+  #    run lambda { |env| [200, {'Content-Type' => 'text/plain'}, 'OK'] }
   #  end
   #
   # +use+ adds a middleware to the stack, +run+ dispatches to an application.


### PR DESCRIPTION
Example of using Rack::Builder with simple lambda-style apps is currently broken. This trivial commit fixes that. 
