### PR TITLE
URI.valid_encoding? method addition to replace regex that bombs on certain negative cases

### DIFF
--- a/lib/rack/backports/uri/common.rb
+++ b/lib/rack/backports/uri/common.rb
@@ -64,7 +64,27 @@ module URI
       rescue
       end
     end
-    raise ArgumentError, "invalid %-encoding (#{str})" unless /\A(?:%[0-9a-fA-F]{2}|[^%]+)*\z/ =~ str
+    raise ArgumentError, "invalid %-encoding (#{str})" unless valid_encoding?(str)
     str.gsub(/\+|%[0-9a-fA-F]{2}/) {|m| TBLDECWWWCOMP_[m]}
   end
+
+  def self.valid_encoding?(str)
+    in_esc_seq = false
+    esc_char_count = 0
+    str.each_char do |c|
+      if in_esc_seq
+        return false unless c =~ /[0-9A-Fa-f]/
+        esc_char_count += 1
+        if esc_char_count == 2
+          in_esc_seq = false
+          esc_char_count = 0
+        end
+      else
+        in_esc_seq = true if c == '%'
+      end
+    end
+    return false if in_esc_seq
+    return true
+  end
+
 end


### PR DESCRIPTION
Fix to address issue in Ruby's regular expression handling found by John Nunemaker: https://gist.github.com/1079284
