### PR TITLE
Fixed a Regexp that allows bad urls to DoS you.

### DIFF
--- a/lib/rack/backports/uri/common.rb
+++ b/lib/rack/backports/uri/common.rb
@@ -64,7 +64,7 @@ module URI
       rescue
       end
     end
-    raise ArgumentError, "invalid %-encoding (#{str})" unless /\A(?:%[0-9a-fA-F]{2}|[^%]+)*\z/ =~ str
+    raise ArgumentError, "invalid %-encoding (#{str})" unless /\A(?:%[0-9a-fA-F]{2}|[^%])*\z/ =~ str
     str.gsub(/\+|%[0-9a-fA-F]{2}/) {|m| TBLDECWWWCOMP_[m]}
   end
 end


### PR DESCRIPTION
One thing you need to know about Ruby's Regexp engine is that it handles the nesting of arbitrary-length patterns very poorly in cases where it needs to backtrack.

My patch changed this:
    /\A(?:%[0-9a-fA-F]{2}|[^%]+)*\z/ =~ str

To this:
    /\A(?:%[0-9a-fA-F]{2}|[^%])*\z/ =~ str

It is important because if str is something like "abcdefghijklmnopqrstuvwxyz1234567890%" you are going to be sitting around while the Regexp engine tries every possible friggin combination of matches before it gives up.  By removing the variable length + off the [^%] it only has the option to grab one so no permutation cycling is necessary.

That's just how it is.
