### PR TITLE
Fix cookie deletion with path specified

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -228,6 +228,8 @@ module Rack
       cookies.reject! { |cookie|
         if value[:domain]
           cookie =~ /\A#{escape(key)}=.*domain=#{value[:domain]}/
+        elsif value[:path]
+          cookie =~ /\A#{escape(key)}=.*path=#{value[:path]}/
         else
           cookie =~ /\A#{escape(key)}=/
         end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -109,6 +109,18 @@ describe Rack::Response do
                                          "foo=; domain=sample.example.com; expires=Thu, 01-Jan-1970 00:00:00 GMT"].join("\n")
   end
 
+  it "can delete cookies with the same name with different paths" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :path => "/"}
+    response.set_cookie "foo", {:value => "bar", :path => "/path"}
+    response["Set-Cookie"].should.equal ["foo=bar; path=/",
+                                         "foo=bar; path=/path"].join("\n")
+
+    response.delete_cookie "foo", :path => "/path"
+    response["Set-Cookie"].should.equal ["foo=bar; path=/",
+                                         "foo=; path=/path; expires=Thu, 01-Jan-1970 00:00:00 GMT"].join("\n")
+  end
+
   it "can do redirects" do
     response = Rack::Response.new
     response.redirect "/foo"


### PR DESCRIPTION
The annoying thing about this bug is that if you:
- create two cookies, one with a path of "/" and the other with a path of "/path"
- delete one cookie with path=/path set
- modify the cookie with path=/

The modified cookie with path=/ won't be set to the client. :(
