### PR TITLE
[Regression] Rack::Utils.escape only accept strings in Ruby 1.8.7 + $KCODE = 'U'

### DIFF
--- a/lib/rack/backports/uri/common.rb
+++ b/lib/rack/backports/uri/common.rb
@@ -10,7 +10,7 @@ module URI
   TBLENCWWWCOMP_ = {} # :nodoc:
   TBLDECWWWCOMP_ = {} # :nodoc:
 
-  # Encode given +str+ to URL-encoded form data.
+  # Encode given +s+ to URL-encoded form data.
   #
   # This method doesn't convert *, -, ., 0-9, A-Z, _, a-z, but does convert SP
   # (ASCII space) to + and converts others to %XX.
@@ -19,7 +19,8 @@ module URI
   # http://www.w3.org/TR/html5/forms.html#url-encoded-form-data
   #
   # See URI.decode_www_form_component, URI.encode_www_form
-  def self.encode_www_form_component(str)
+  def self.encode_www_form_component(s)
+    str = s.to_s
     if RUBY_VERSION < "1.9" && $KCODE =~ /u/i
       str.gsub(/([^ a-zA-Z0-9_.-]+)/) do
         '%' + $1.unpack('H2' * Rack::Utils.bytesize($1)).join('%').upcase
@@ -37,7 +38,6 @@ module URI
         rescue
         end
       end
-      str = str.to_s
       str.gsub(/[^*\-.0-9A-Z_a-z]/) {|m| TBLENCWWWCOMP_[m]}
     end
   end

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -18,7 +18,7 @@ module Rack
   # applications adopted from all kinds of Ruby libraries.
 
   module Utils
-    # URI escapes a string. (CGI style space to +)
+    # URI escapes. (CGI style space to +)
     def escape(s)
       URI.encode_www_form_component(s)
     end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -41,6 +41,14 @@ describe Rack::Utils do
     end
   end
 
+  should "escape objects that responds to to_s" do
+    default_kcode, $KCODE = $KCODE, 'U'
+
+    Rack::Utils.escape(:id).should.equal "id"
+
+    $KCODE = default_kcode
+  end
+
   if "".respond_to?(:encode)
     should "escape non-UTF8 strings" do
       Rack::Utils.escape("ø".encode("ISO-8859-1")).should.equal "%F8"


### PR DESCRIPTION
Related issue https://github.com/rails/rails/issues/2107
