### PR TITLE
Added 'text/cache-manifest' for the suggested Application Cache extension

### DIFF
--- a/lib/rack/mime.rb
+++ b/lib/rack/mime.rb
@@ -48,6 +48,7 @@ module Rack
       ".aif"       => "audio/x-aiff",
       ".aiff"      => "audio/x-aiff",
       ".ami"       => "application/vnd.amiga.ami",
+      ".appcache"  => "text/cache-manifest",
       ".apr"       => "application/vnd.lotus-approach",
       ".asc"       => "application/pgp-signature",
       ".asf"       => "video/x-ms-asf",


### PR DESCRIPTION
I'd like to see this patch accepted because Application Cache will not work without the correct mime-type, having a sane default in rack will remove an extra step for all rack users.

I couldn't locate any tests to cover this, but if you point me in the right direction I'll add an additional commit.

For reference: http://developers.whatwg.org/offline
