### PR TITLE
Use Response#status instead of @status in response helpers

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -112,19 +112,19 @@ module Rack
     alias headers header
 
     module Helpers
-      def invalid?;       @status < 100 || @status >= 600;       end
+      def invalid?;       status < 100 || status >= 600;        end
 
-      def informational?; @status >= 100 && @status < 200;       end
-      def successful?;    @status >= 200 && @status < 300;       end
-      def redirection?;   @status >= 300 && @status < 400;       end
-      def client_error?;  @status >= 400 && @status < 500;       end
-      def server_error?;  @status >= 500 && @status < 600;       end
+      def informational?; status >= 100 && status < 200;        end
+      def successful?;    status >= 200 && status < 300;        end
+      def redirection?;   status >= 300 && status < 400;        end
+      def client_error?;  status >= 400 && status < 500;        end
+      def server_error?;  status >= 500 && status < 600;        end
 
-      def ok?;            @status == 200;                        end
-      def forbidden?;     @status == 403;                        end
-      def not_found?;     @status == 404;                        end
+      def ok?;            status == 200;                        end
+      def forbidden?;     status == 403;                        end
+      def not_found?;     status == 404;                        end
 
-      def redirect?;      [301, 302, 303, 307].include? @status; end
+      def redirect?;      [301, 302, 303, 307].include? status; end
 
       # Headers
       attr_reader :headers, :original_headers


### PR DESCRIPTION
Rack::Client::Response inherits from Rack::Response and delegates the helper methods to it's own internal response. Everything works fine except the helpers that use @status like #server_error? and #successful? since @status can't be delegated.
