### PR TITLE
Add 205 Reset Content to the list of statuses without a message body

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -146,11 +146,11 @@ consisting of lines (for multiple header values, e.g. multiple
 The lines must not contain characters below 037.
 === The Content-Type
 There must be a <tt>Content-Type</tt>, except when the
-+Status+ is 1xx, 204 or 304, in which case there must be none
++Status+ is 1xx, 204, 205 or 304, in which case there must be none
 given.
 === The Content-Length
 There must not be a <tt>Content-Length</tt> header when the
-+Status+ is 1xx, 204 or 304.
++Status+ is 1xx, 204, 205 or 304.
 === The Body
 The Body must respond to +each+
 and must only yield String values.

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -464,7 +464,7 @@ module Rack
     def check_content_type(status, headers)
       headers.each { |key, value|
         ## There must be a <tt>Content-Type</tt>, except when the
-        ## +Status+ is 1xx, 204 or 304, in which case there must be none
+        ## +Status+ is 1xx, 204, 205 or 304, in which case there must be none
         ## given.
         if key.downcase == "content-type"
           assert("Content-Type header found in #{status} response, not allowed") {
@@ -483,7 +483,7 @@ module Rack
       headers.each { |key, value|
         if key.downcase == 'content-length'
           ## There must not be a <tt>Content-Length</tt> header when the
-          ## +Status+ is 1xx, 204 or 304.
+          ## +Status+ is 1xx, 204, 205 or 304.
           assert("Content-Length header found in #{status} response, not allowed") {
             not Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include? status.to_i
           }

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -182,7 +182,7 @@ module Rack
     end
 
     def empty?
-      [201, 204, 304].include? status
+      [201, 204, 205, 304].include? status
     end
   end
 end

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -71,7 +71,7 @@ module Rack
     def finish(&block)
       @block = block
 
-      if [204, 304].include?(status.to_i)
+      if [204, 205, 304].include?(status.to_i)
         header.delete "Content-Type"
         header.delete "Content-Length"
         [status.to_i, header, []]

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -459,7 +459,7 @@ module Rack
     }
 
     # Responses with HTTP status codes that should not have an entity body
-    STATUS_WITH_NO_ENTITY_BODY = Set.new((100..199).to_a << 204 << 304)
+    STATUS_WITH_NO_ENTITY_BODY = Set.new((100..199).to_a << 204 << 205 << 304)
 
     SYMBOL_TO_STATUS_CODE = Hash[*HTTP_STATUS_CODES.map { |code, message|
       [message.downcase.gsub(/\s|-/, '_').to_sym, code]

--- a/test/spec_chunked.rb
+++ b/test/spec_chunked.rb
@@ -49,7 +49,7 @@ describe Rack::Chunked do
     body.join.should.equal 'Hello World!'
   end
 
-  [100, 204, 304].each do |status_code|
+  [100, 204, 205, 304].each do |status_code|
     should "not modify response when status code is #{status_code}" do
       app = lambda { |env| [status_code, {}, []] }
       status, headers, _ = Rack::Chunked.new(app).call(@env)

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -241,7 +241,7 @@ describe Rack::Lint do
     }.should.raise(Rack::Lint::LintError).
       message.should.match(/No Content-Type/)
 
-    [100, 101, 204, 304].each do |status|
+    [100, 101, 204, 205, 304].each do |status|
       lambda {
         Rack::Lint.new(lambda { |env|
                          [status, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
@@ -252,7 +252,7 @@ describe Rack::Lint do
   end
 
   should "notice content-length errors" do
-    [100, 101, 204, 304].each do |status|
+    [100, 101, 204, 205, 304].each do |status|
       lambda {
         Rack::Lint.new(lambda { |env|
                          [status, {"Content-length" => "0"}, []]


### PR DESCRIPTION
This simple commit adds 204 Reset Content to the list of statues without a message body.  From [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.6):

> The server has fulfilled the request and the user agent SHOULD reset the document view which caused the request to be sent. This response is primarily intended to allow input for actions to take place via user input, followed by a clearing of the form in which the input is given so that the user can easily initiate another input action. **The response MUST NOT include an entity.**
