### PR TITLE
parse Accept-Encoding header loosely.

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -278,14 +278,13 @@ module Rack
     end
 
     def accept_encoding
-      @env["HTTP_ACCEPT_ENCODING"].to_s.split(/,\s*/).map do |part|
-        m = /^([^\s,]+?)(?:;\s*q=(\d+(?:\.\d+)?))?$/.match(part) # From WEBrick
-
-        if m
-          [m[1], (m[2] || 1.0).to_f]
-        else
-          raise "Invalid value for Accept-Encoding: #{part.inspect}"
+      @env["HTTP_ACCEPT_ENCODING"].to_s.split(/\s*,\s*/).map do |part|
+        encoding, parameters = part.split(/\s*;\s*/, 2)
+        quality = 1.0
+        if parameters and /\Aq=([\d.]+)/ =~ parameters
+          quality = $1.to_f
         end
+        [encoding, quality]
       end
     end
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -735,7 +735,8 @@ EOF
     parser.call("compress;q=0.5, gzip;q=1.0").should.equal([["compress", 0.5], ["gzip", 1.0]])
     parser.call("gzip;q=1.0, identity; q=0.5, *;q=0").should.equal([["gzip", 1.0], ["identity", 0.5], ["*", 0] ])
 
-    lambda { parser.call("gzip ; q=1.0") }.should.raise(RuntimeError)
+    parser.call("gzip ; q=0.9").should.equal([["gzip", 0.9]])
+    parser.call("gzip ; deflate").should.equal([["gzip", 1.0]])
   end
 
   should 'provide ip information' do


### PR DESCRIPTION
After this commit, Rack::Request#accept_encoding doesn't
raise an exception for invalid Accept-Encoding value.

If Rack::Request#accept_encoding may raise an exception,
Rack::Middleware::Deflater may also raise an exception.
Because Rack::Middleware::Deflater dosn't rescue an
exception from Rack::Request#accept_encoding.

On the exception case, it seems that either returning "400
Bad Request" or just ignoring invalid value is better
behavior. This patch uses the latter solution.
