### PR TITLE
Don't set content-type on responses without body

### DIFF
--- a/lib/rack/content_type.rb
+++ b/lib/rack/content_type.rb
@@ -9,6 +9,8 @@ module Rack
   #
   # When no content type argument is provided, "text/html" is assumed.
   class ContentType
+    include Rack::Utils
+
     def initialize(app, content_type = "text/html")
       @app, @content_type = app, content_type
     end
@@ -16,7 +18,11 @@ module Rack
     def call(env)
       status, headers, body = @app.call(env)
       headers = Utils::HeaderHash.new(headers)
-      headers['Content-Type'] ||= @content_type
+
+      unless STATUS_WITH_NO_ENTITY_BODY.include?(status)
+        headers['Content-Type'] ||= @content_type
+      end
+
       [status, headers, body]
     end
   end

--- a/test/spec_content_type.rb
+++ b/test/spec_content_type.rb
@@ -26,4 +26,10 @@ describe Rack::ContentType do
     headers.to_a.select { |k,v| k.downcase == "content-type" }.
       should.equal [["CONTENT-Type","foo/bar"]]
   end
+
+  should "not set Content-Type on 304 responses" do
+    app = lambda { |env| [304, {}, []] }
+    response = Rack::ContentType.new(app, "text/html").call({})
+    response[1]['Content-Type'].should.equal nil
+  end
 end


### PR DESCRIPTION
304, 204, 1xx responses should not have a content type header. Just like the ContentLength middleware, the ContentType middleware should not set such a header.
