### PR TITLE
Fixes crash in ConditionalGet when passed a malformed HTTP_IF_MODIFIED_SINCE timestamp

### DIFF
--- a/lib/rack/conditionalget.rb
+++ b/lib/rack/conditionalget.rb
@@ -56,6 +56,7 @@ module Rack
 
     def modified_since?(modified_since, headers)
       last_modified = to_rfc2822(headers['Last-Modified']) and
+        modified_since and
         modified_since >= last_modified
     end
 

--- a/test/spec_conditionalget.rb
+++ b/test/spec_conditionalget.rb
@@ -83,4 +83,16 @@ describe Rack::ConditionalGet do
     response.body.should.equal 'TEST'
   end
 
+  should "not affect requests with malformed HTTP_IF_NONE_MATCH" do
+    bad_timestamp = Time.now.strftime('%Y-%m-%d %H:%M:%S %z')
+    app = Rack::ConditionalGet.new(lambda { |env|
+      [200,{'Last-Modified'=>(Time.now - 3600).httpdate}, ['TEST']] })
+
+    response = Rack::MockRequest.new(app).
+      get("/", 'HTTP_IF_MODIFIED_SINCE' => bad_timestamp)
+
+    response.status.should.equal 200
+    response.body.should.equal 'TEST'
+  end
+
 end


### PR DESCRIPTION
When clients passed a bad IfModifiedSince header we were seing this crash: 

```
NoMethodError: undefined method `>=' for nil:NilClass
    /Users/nick/Code/lib/rack/lib/rack/conditionalget.rb:60:in `modified_since?'
```

ConditionalGet was only checking if the header existed and not if the casting to_rfc2822 was successful.
