### PR TITLE
Request should return cookies, also when initially not set.

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -233,8 +233,8 @@ module Rack
       hash   = @env["rack.request.cookie_hash"] ||= {}
       string = @env["HTTP_COOKIE"]
 
-      hash.clear unless string
       return hash if string == @env["rack.request.cookie_string"]
+      hash.clear
 
       # According to RFC 2109:
       #   If multiple cookies satisfy the criteria above, they are ordered in

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -357,6 +357,15 @@ describe Rack::Request do
     hash = req.cookies
     req.env.delete("HTTP_COOKIE")
     req.cookies.should.equal(hash)
+    req.env["HTTP_COOKIE"] = "zoo=m"
+    req.cookies.should.equal(hash)
+  end
+
+  should "modify the cookies hash in place" do
+    req = Rack::Request.new(Rack::MockRequest.env_for(""))
+    req.cookies.should.equal({})
+    req.cookies['foo'] = 'bar'
+    req.cookies.should.equal 'foo' => 'bar'
   end
 
   should "raise any errors on every request" do


### PR DESCRIPTION
The last expectation fails. Whatever is put in the cookies hash disappears into a void. This commit fixes that.

``` ruby
    req = Rack::Request.new(Rack::MockRequest.env_for(""))
    req.cookies.should.equal({})
    req.cookies['foo'] = 'bar'
    req.cookies.should.equal 'foo' => 'bar'
```
