### PR TITLE
handle nil value for parameter for build query

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -113,7 +113,7 @@ module Rack
         if v.class == Array
           build_query(v.map { |x| [k, x] })
         else
-          "#{escape(k)}=#{escape(v)}"
+          v ? "#{escape(k)}=#{escape(v)}" : escape(k)
         end
       }.join("&")
     end


### PR DESCRIPTION
For strange urls like that : http://www.michele-delaunay.net/delaunay/index.php?post/2011/08/27/Deux-%22rat%C3%A9s%22-de-l-Universit%C3%A9-d-%C3%A9t%C3%A9-de-la-Rochelle

the parameter is post/2011/08/27/Deux-%22rat%C3%A9s%22-de-l-Universit%C3%A9-d-%C3%A9t%C3%A9-de-la-Rochelle but it does not have any value

This small change reflects this behaviour on the build_query utils method so that it does not add =
