### PR TITLE
fixes #246. Silence the warning about redefining this constant from the s

### DIFF
--- a/lib/rack/backports/uri/common_192.rb
+++ b/lib/rack/backports/uri/common_192.rb
@@ -50,5 +50,6 @@ module URI
     str.gsub(/\+|%\h\h/, TBLDECWWWCOMP_).force_encoding(enc)
   end
 
+  remove_const :WFKV_
   WFKV_ = '(?:[^%#=;&]*(?:%\h\h[^%#=;&]*)*)' # :nodoc:
 end


### PR DESCRIPTION
fixes #246. Silence the warning about redefining this constant from the standard library.

I'm not CERTAIN this is the best solution, but it seems like if this constant was redefined on purpose (likely?), then it shouldn't be noisy.
