### PR TITLE
Rack::Static should only serve static files on GET and HEAD

### DIFF
--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -40,10 +40,14 @@ module Rack
     def call(env)
       path = env["PATH_INFO"]
 
-      unless @urls.kind_of? Hash
-        can_serve = @urls.any? { |url| path.index(url) == 0 }
+      if ['GET', 'HEAD'].include?(env["REQUEST_METHOD"])
+        unless @urls.kind_of? Hash
+          can_serve = @urls.any? { |url| path.index(url) == 0 }
+        else
+          can_serve = @urls.key? path
+        end
       else
-        can_serve = @urls.key? path
+        can_sere = false
       end
 
       if can_serve


### PR DESCRIPTION
Perhaps there is a reason for the current behavior that escapes me, but it seems wrong to have Rack::Static serve static files on, say, a POST request.
