### PR TITLE
Adds more Rack::Response helpers

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -124,6 +124,7 @@ module Rack
       def bad_request?;   status == 400;                        end
       def forbidden?;     status == 403;                        end
       def not_found?;     status == 404;                        end
+      def unprocessable?; status == 422;                        end
 
       def redirect?;      [301, 302, 303, 307].include? status; end
 

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -218,6 +218,11 @@ describe Rack::Response do
     res.should.be.client_error
     res.should.be.not_found
 
+    res.status = 422
+    res.should.not.be.successful
+    res.should.be.client_error
+    res.should.be.unprocessable
+
     res.status = 501
     res.should.not.be.successful
     res.should.be.server_error


### PR DESCRIPTION
These would be really nice, especially in RSpec-style tests:

``` ruby
response.should be_bad_request   # response.bad_request?
response.should be_unprocessable # response.unprocessable?
```

Adding `unprocessable?` also finishes #252, as noted in the commit message.
