### PR TITLE
Fix for files and directories with + as a character in the file name b0rking Rack::Directory

### DIFF
--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -56,7 +56,7 @@ table { width:100%%; }
     def _call(env)
       @env = env
       @script_name = env['SCRIPT_NAME']
-      @path_info = Utils.unescape(env['PATH_INFO'])
+      @path_info = env['PATH_INFO']
 
       if forbidden = check_forbidden
         forbidden

--- a/lib/rack/file.rb
+++ b/lib/rack/file.rb
@@ -32,7 +32,7 @@ module Rack
     F = ::File
 
     def _call(env)
-      @path_info = Utils.unescape(env["PATH_INFO"])
+      @path_info = env["PATH_INFO"]
       parts = @path_info.split SEPS
 
       return fail(403, "Forbidden")  if parts.include? ".."


### PR DESCRIPTION
Having a + in file and path names is a perfectly cromulent thing, and unescaping the name magically turns those + es into  es