### PR TITLE
Chunked response, encoding issues

### DIFF
--- a/lib/rack/chunked.rb
+++ b/lib/rack/chunked.rb
@@ -23,6 +23,8 @@ module Rack
         @body.each do |chunk|
           size = bytesize(chunk)
           next if size == 0
+
+          chunk = chunk.dup.force_encoding(Encoding::BINARY) if chunk.respond_to?(:force_encoding)
           yield [size.to_s(16), term, chunk, term].join
         end
         yield TAIL


### PR DESCRIPTION
Chunking responses with e.g. UTF-16 bodies fails, since the can't simply be joined with binary encoded content. Please check my solution, not sure if this is the best approach though.
