### PR TITLE
Fixed Rack::ContentLength#call don't set Content-Length

### DIFF
--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -18,8 +18,15 @@ module Rack
          !headers['Transfer-Encoding'] &&
          (body.respond_to?(:to_ary) || body.respond_to?(:to_str))
 
-        body = [body] if body.respond_to?(:to_str) # rack 0.4 compat
-        length = body.to_ary.inject(0) { |len, part| len + bytesize(part) }
+        length = 0
+        if body.respond_to?(:to_ary)
+          obody = body
+          body = []
+          obody.each { |part| body << part; length += bytesize(part) }
+          obody.close if obody.respond_to?(:close)
+        elsif body.respond_to?(:to_str)
+          length = body.to_str.size
+        end
         headers['Content-Length'] = length.to_s
       end
 

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -78,6 +78,7 @@ module Rack
       end
     end
     alias to_a finish           # For *response
+    alias to_ary finish         # For implicit-splat on Ruby 1.9.2
 
     def each(&callback)
       @body.each(&callback)


### PR DESCRIPTION
Rack::ContentLength#call don't set Content-Length when `body` is a instance of Rack::Response.

Is this intended behavior?
