### PR TITLE
build queries containing boolean values

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -92,7 +92,11 @@ module Rack
       return if k.empty?
 
       if after == ""
-        params[k] = v
+        if v == "false" || v == "true"
+          params[k] = eval(v)
+        else
+          params[k] = v
+        end
       elsif after == "[]"
         params[k] ||= []
         raise TypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -238,7 +238,8 @@ describe Rack::Utils do
       {"x" => {"y" => [{"v" => {"w" => "1"}}]}},
       {"x" => {"y" => [{"z" => "1", "v" => {"w" => "2"}}]}},
       {"x" => {"y" => [{"z" => "1"}, {"z" => "2"}]}},
-      {"x" => {"y" => [{"z" => "1", "w" => "a"}, {"z" => "2", "w" => "3"}]}}
+      {"x" => {"y" => [{"z" => "1", "w" => "a"}, {"z" => "2", "w" => "3"}]}},
+      {"foo" => false}, {"foo" => {"bar" => true}}
     ].each { |params|
       qs = Rack::Utils.build_nested_query(params)
       Rack::Utils.parse_nested_query(qs).should.equal params


### PR DESCRIPTION
fixes generated queries with empty values when value is a boolean

``` ruby
Rack::Utils.build_nested_query(:foo => true)
```

currently produces `foo=`
now produces `foo=true`
