### PR TITLE
honor HTTP_X_FORWARDED_SCHEME in Rack#scheme

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -72,6 +72,8 @@ module Rack
         'https'
       elsif @env['HTTP_X_FORWARDED_SSL'] == 'on'
         'https'
+      elsif @env['HTTP_X_FORWARDED_SCHEME']
+        @env['HTTP_X_FORWARDED_SCHEME']
       elsif @env['HTTP_X_FORWARDED_PROTO']
         @env['HTTP_X_FORWARDED_PROTO'].split(',')[0]
       else


### PR DESCRIPTION
This makes Rack play nice with the following Nginx line:

``` nginx
proxy_set_header X-Forwarded-Scheme $scheme;
```

which is more flexible than a hardwired

``` nginx
proxy_set_header X-Forwarded-Ssl on;
```
