### PR TITLE
Ensure the session is loaded before checking for empty.

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -111,6 +111,11 @@ module Rack
           @loaded
         end
 
+        def empty?
+          load_for_read!
+          super
+        end
+
       private
 
         def load_for_read!

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -106,11 +106,16 @@ describe Rack::Session::Cookie do
     res = Rack::MockRequest.new(Rack::Session::Cookie.new(incrementor)).get("/")
     res = Rack::MockRequest.new(Rack::Session::Cookie.new(only_session_id)).
       get("/", "HTTP_COOKIE" => res["Set-Cookie"])
+
+    res.body.should.not.equal ""
     old_session_id = res.body
+
     res = Rack::MockRequest.new(Rack::Session::Cookie.new(renewer)).
       get("/", "HTTP_COOKIE" => res["Set-Cookie"])
     res = Rack::MockRequest.new(Rack::Session::Cookie.new(only_session_id)).
       get("/", "HTTP_COOKIE" => res["Set-Cookie"])
+
+    res.body.should.not.equal ""
     res.body.should.not.equal old_session_id
   end
 


### PR DESCRIPTION
Otherwise we can treat an existing session as empty and options
like renew/drop/expire_after would be mistakenly discarded.
