### PR TITLE
Fix for Issue #299

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -104,10 +104,11 @@ module Rack
           request = Rack::Request.new(env)
           session_data = request.cookies[@key]
 
-          if (@secret || @old_secret) && session_data
+          if @secret && session_data
             session_data, digest = session_data.split("--")
-            if (digest != generate_hmac(session_data, @secret)) && (digest != generate_hmac(session_data, @old_secret))
-              session_data = nil
+            unless digest == generate_hmac(session_data, @secret)
+              # Clear the session data if secret doesn't match and old secret doesn't match
+              session_data = nil if (@old_secret.nil? || (digest != generate_hmac(session_data, @old_secret)))
             end
           end
 

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -147,6 +147,10 @@ describe Rack::Session::Cookie do
     res = Rack::MockRequest.new(Rack::Session::Cookie.new(incrementor, :secret => 'test')).
       get("/", "HTTP_COOKIE" => cookie)
     res.body.should.equal '{"counter"=>3}'
+    cookie = res["Set-Cookie"]
+    res = Rack::MockRequest.new(Rack::Session::Cookie.new(incrementor, :secret => 'another secret')).
+      get("/", "HTTP_COOKIE" => cookie)
+    res.body.should.equal '{"counter"=>1}'
   end
 
   it "loads from a cookie wih accept-only integrity hash for graceful key rotation" do


### PR DESCRIPTION
Allow old_secret to be optional so we don't break backwards compatibility
Fix for Issue #299
