### PR TITLE
Require 'stringio' to fix a NameError in the BodyProxy tests.

### DIFF
--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -1,4 +1,5 @@
 require 'rack/body_proxy'
+require 'stringio'
 
 describe Rack::BodyProxy do
   should 'call each on the wrapped body' do


### PR DESCRIPTION
Require 'stringio' to fix a NameError in the BodyProxy tests. Tested on Ruby 1.9.3-p0.
