### PR TITLE
HTTP_X_FORWARDED_PROTO - Chained proxies.

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -75,7 +75,7 @@ module Rack
       elsif @env['HTTP_X_FORWARDED_SCHEME']
         @env['HTTP_X_FORWARDED_SCHEME']
       elsif @env['HTTP_X_FORWARDED_PROTO']
-        @env['HTTP_X_FORWARDED_PROTO'].split(',')[0]
+        @env['HTTP_X_FORWARDED_PROTO'].split(',').any?{|x| x.strip == 'https' } ? "https" : "http"
       else
         @env["rack.url_scheme"]
       end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -370,6 +370,14 @@ describe Rack::Request do
     request = Rack::Request.new(Rack::MockRequest.env_for("/", 'HTTP_X_FORWARDED_PROTO' => 'https, http, http'))
     request.scheme.should.equal "https"
     request.should.be.ssl?
+    
+    request = Rack::Request.new(Rack::MockRequest.env_for("/", 'HTTP_X_FORWARDED_PROTO' => 'http, http, http'))
+    request.scheme.should.equal "http"
+    request.should.be.not.ssl?
+    
+    request = Rack::Request.new(Rack::MockRequest.env_for("/", 'HTTP_X_FORWARDED_PROTO' => 'http, http, https'))
+    request.scheme.should.equal "https"
+    request.should.be.ssl?
   end
 
   should "parse cookies" do


### PR DESCRIPTION
Schema fix: HTTP_X_FORWARDED_PROTO = "http, https, http" is a valid request - Chained proxies.
