### PR TITLE
Rack::BodyProxy should execute block even on failures.

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -11,8 +11,11 @@ module Rack
     def close
       return if @closed
       @closed = true
-      @body.close if @body.respond_to? :close
-      @block.call
+      begin
+        @body.close if @body.respond_to? :close
+      ensure
+        @block.call
+      end
     end
 
     def closed?

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -1,4 +1,5 @@
 require 'rack/body_proxy'
+require 'stringio'
 
 describe Rack::BodyProxy do
   should 'call each on the wrapped body' do
@@ -29,6 +30,22 @@ describe Rack::BodyProxy do
     proxy  = Rack::BodyProxy.new([]) { called = true }
     called.should.equal false
     proxy.close
+    called.should.equal true
+  end
+
+  should 'call the passed block on close even if there is an exception' do
+    object = Object.new
+    def object.close() raise "No!" end
+    called = false
+
+    begin
+      proxy  = Rack::BodyProxy.new(object) { called = true }
+      called.should.equal false
+      proxy.close
+    rescue RuntimeError => e
+    end
+
+    raise "Expected exception to have been raised" unless e
     called.should.equal true
   end
 


### PR DESCRIPTION
In general, Rack frameworks are moving logic to close hooks in order
to support async behavior increasing the chance an exception will
happen on close. Most servers will actually die if there is an exception
on close, but such exceptions can also happen in the test environment.
In such cases, we can accidentally leave a mutex locked, a database
connection not collected and so forth, therefore, we need to ensure
the block is called regardless closing the body failed.
