### PR TITLE
Fix crash when Rack::Session::Cookie value does not contain "--" delimiter

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -106,8 +106,10 @@ module Rack
           if @secrets.size > 0 && session_data
             session_data, digest = session_data.split("--")
 
-            ok = @secrets.any? do |secret|
-              secret && digest == generate_hmac(session_data, secret)
+            if session_data && digest
+              ok = @secrets.any? do |secret|
+                secret && digest == generate_hmac(session_data, secret)
+              end
             end
 
             session_data = nil unless ok

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -123,6 +123,10 @@ describe Rack::Session::Cookie do
     res = Rack::MockRequest.new(Rack::Session::Cookie.new(incrementor)).
       get("/", "HTTP_COOKIE" => "rack.session=blarghfasel")
     res.body.should.equal '{"counter"=>1}'
+
+    app = Rack::Session::Cookie.new(incrementor, :secret => 'test')
+    res = Rack::MockRequest.new(app).get("/", "HTTP_COOKIE" => "rack.session=")
+    res.body.should.equal '{"counter"=>1}'
   end
 
   bigcookie = lambda do |env|
@@ -176,7 +180,7 @@ describe Rack::Session::Cookie do
     response2 = Rack::MockRequest.new(app).get("/", "HTTP_COOKIE" =>
                                                tampered_with_cookie)
 
-    # Tampared cookie was ignored. Counter is back to 1.
+    # Tampered cookie was ignored. Counter is back to 1.
     response2.body.should.equal '{"counter"=>1}'
   end
 


### PR DESCRIPTION
Previously if the signed cookie value was missing "--" this line would result in two nil values:
    session_data, digest = session_data.split("--")

When session_data and digest are passed through to generate_hmac() and subsequently OpenSSL::HMAC::hexdigest() the latter method would raise "TypeError: can't convert nil into String".

This is my first pull request in a long time so feedback would be very welcome, thanks!
