### PR TITLE
Correctly count the key space size for nested param queries

### DIFF
--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -188,7 +188,7 @@ describe Rack::Utils do
 
     lambda { Rack::Utils.parse_nested_query("x[y]=1&x[]=1") }.
       should.raise(TypeError).
-      message.should.equal "expected Array (got Hash) for param `x'"
+      message.should.match /expected Array \(got [^)]*\) for param `x'/
 
     lambda { Rack::Utils.parse_nested_query("x[y]=1&x[y][][w]=2") }.
       should.raise(TypeError).


### PR DESCRIPTION
Key space size should only be limited per params' `Hash` instance, as of right now Rack severely overestimates key size of typical nested-params Rails request. This will probably fix #318 and semi-fix #319.
