### PR TITLE
Wrong version

### DIFF
--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -20,7 +20,7 @@ module Rack
 
   # Return the Rack release as a dotted string.
   def self.release
-    "1.3"
+    "1.4"
   end
 
   autoload :Builder, "rack/builder"


### PR DESCRIPTION
This error cause some gems that support different rack version (like omniauth) to work incorrectly.
