### PR TITLE
Prevent error in Utils.parse_query/KeySpaceConstrainedParams when a key is nil

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -65,6 +65,7 @@ module Rack
 
       (qs || '').split(d ? /[#{d}] */n : DEFAULT_SEP).each do |p|
         k, v = p.split('=', 2).map { |x| unescape(x) }
+        next unless k || v
 
         if cur = params[k]
           if cur.class == Array
@@ -442,7 +443,7 @@ module Rack
       end
 
       def []=(key, value)
-        @size += key.size unless @params.key?(key)
+        @size += key.size if key && !@params.key?(key)
         raise RangeError, 'exceeded available parameter key space' if @size > @limit
         @params[key] = value
       end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -112,6 +112,12 @@ describe Rack::Utils do
     Rack::Utils.parse_query("my+weird+field=q1%212%22%27w%245%267%2Fz8%29%3F").
       should.equal "my weird field" => "q1!2\"'w$5&7/z8)?"
     Rack::Utils.parse_query("foo%3Dbaz=bar").should.equal "foo=baz" => "bar"
+    Rack::Utils.parse_query("=").should.equal "" => ""
+    Rack::Utils.parse_query("=value").should.equal "" => "value"
+    Rack::Utils.parse_query("key=").should.equal "key" => ""
+    Rack::Utils.parse_query("&key&").should.equal "key" => nil
+    Rack::Utils.parse_query(";key;", ";,").should.equal "key" => nil
+    Rack::Utils.parse_query(",key,", ";,").should.equal "key" => nil
   end
 
   should "parse nested query strings correctly" do


### PR DESCRIPTION
Before this when parsing a query string or a cookie string, an error were
raised because of the `key.size` in `KeySpaceConstrainedParams#[]=`.

This caused an error when params contained something parsed as a `nil` key.
