### PR TITLE
'deps' Rake task should not assume that 'gem' found on $PATH is the one that should be used

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,14 @@ task :default => [:test]
 desc "Install gem dependencies"
 task :deps do
   require 'rubygems'
+  require 'rbconfig'
   spec = Gem::Specification.load('rack.gemspec')
   spec.dependencies.each do |dep|
     reqs = dep.requirements_list
     reqs = (["-v"] * reqs.size).zip(reqs).flatten
     # Use system over sh, because we want to ignore errors!
-    system "gem", "install", '--conservative', dep.name, *reqs
+    ruby = File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["RUBY_INSTALL_NAME"])
+    system ruby, "-S", "gem", "install", '--conservative', dep.name, *reqs
   end
 end
 


### PR DESCRIPTION
System gem can be arbitrarily old and does not support `--conservative`.

Also, this Ruby runtime has its own `gem` that is more suitable.
