### PR TITLE
Rack::Static :index can handle multiple folders

### DIFF
--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -26,7 +26,7 @@ module Rack
   # directory but uses index.html as default route for "/"
   #
   #     use Rack::Static, :urls => [""], :root => 'public', :index =>
-  #     'public/index.html'
+  #     'index.html'
   #
   # Set a fixed Cache-Control header for all served files:
   #
@@ -45,7 +45,7 @@ module Rack
     end
 
     def overwrite_file_path(path)
-      @urls.kind_of?(Hash) && @urls.key?(path) || @index && path == '/'
+      @urls.kind_of?(Hash) && @urls.key?(path) || @index && path =~ /\/$/
     end
 
     def route_file(path)
@@ -60,7 +60,7 @@ module Rack
       path = env["PATH_INFO"]
 
       if can_serve(path)
-        env["PATH_INFO"] = (path == '/' ? @index : @urls[path]) if overwrite_file_path(path)
+        env["PATH_INFO"] = (path =~ /\/$/ ? path + @index : @urls[path]) if overwrite_file_path(path)
         @file_server.call(env)
       else
         @app.call(env)

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -11,7 +11,7 @@ describe Rack::Static do
   root = File.expand_path(File.dirname(__FILE__))
 
   OPTIONS = {:urls => ["/cgi"], :root => root}
-  STATIC_OPTIONS = {:urls => [""], :root => root, :index => 'static/index.html'}
+  STATIC_OPTIONS = {:urls => [""], :root => "#{root}/static", :index => 'index.html'}
   HASH_OPTIONS = {:urls => {"/cgi/sekret" => 'cgi/test'}, :root => root}
 
   @request = Rack::MockRequest.new(Rack::Static.new(DummyApp.new, OPTIONS))
@@ -35,12 +35,19 @@ describe Rack::Static do
     res.body.should == "Hello World"
   end
 
-  it "calls index file when requesting root" do
+  it "calls index file when requesting root in the given folder" do
     res = @static_request.get("/")
     res.should.be.ok
     res.body.should =~ /index!/
+
+    res = @static_request.get("/other/")
+    res.should.be.not_found
+
+    res = @static_request.get("/another/")
+    res.should.be.ok
+    res.body.should =~ /another index!/
   end
-  
+
   it "doesn't call index file if :index option was omitted" do
     res = @request.get("/")
     res.body.should == "Hello World"

--- a/test/static/another/index.html
+++ b/test/static/another/index.html
@@ -1,0 +1,1 @@
+another index!


### PR DESCRIPTION
- Tries to serve the defined :index in every folder
- Useful for documentation like nanoc.
