### PR TITLE
Skips Etag even if Cache-Control has a no-cache value together with other options

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -46,7 +46,7 @@ module Rack
       end
 
       def skip_caching?(headers)
-        headers['Cache-Control'] == 'no-cache' ||
+        (headers['Cache-Control'] && headers['Cache-Control'].include?('no-cache')) ||
           headers.key?('ETag') || headers.key?('Last-Modified')
       end
 

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -75,7 +75,7 @@ describe Rack::ETag do
   end
 
   should "not set ETag if no-cache is given" do
-    app = lambda { |env| [200, {'Cache-Control' => 'no-cache'}, ['Hello, World!']] }
+    app = lambda { |env| [200, {'Cache-Control' => 'no-cache, must-revalidate'}, ['Hello, World!']] }
     response = Rack::ETag.new(app).call({})
     response[1]['ETag'].should.be.nil
   end


### PR DESCRIPTION
While developing a Rack proxy, I noticed that Etags were being applied to the response, even tough the "Cache-Control" header was set with "no-cache". The thing is, "Cache-Control" had more than one option set, specifically "no-cache, must-revalidate", and Rack ETag middleware was skipping only if "Cache-Control" is set exactly to "no-cache". This patch should fix that behavior.
