### PR TITLE
Include link to RFC3875 (CGI 1.1 specification)

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -49,7 +49,7 @@ below.
                            variables should correspond with
                            the presence or absence of the
                            appropriate HTTP header in the
-                           request.
+                           request. See <a href="https://tools.ietf.org/html/rfc3875#section-4.1.18">RFC3875 section 4.1.18</a> for specific behavior.
 In addition to this, the Rack environment must include these
 Rack-specific variables:
 <tt>rack.version</tt>:: The Array [1,1], representing this version of Rack.


### PR DESCRIPTION
... and the section describing how headers are to be translated into HTTP_xxx names.

This link defines important behaviors not described in the Rack SPEC, including:
- dash to underscore translation
- uppercase-ness
- that multi-value headers must be rewritten to single-value with the same semantics (presumably as described in RFC2616 section 4.2)
