### PR TITLE
Only remove a constant if it exists.

### DIFF
--- a/lib/rack/backports/uri/common_192.rb
+++ b/lib/rack/backports/uri/common_192.rb
@@ -66,6 +66,6 @@ module URI
     str.gsub(/\+|%\h\h/, TBLDECWWWCOMP_).force_encoding(enc)
   end
 
-  remove_const :WFKV_ if defined?(WFKV_)
+  remove_const :WFKV_ if const_defined?(:WFKV_)
   WFKV_ = '(?:[^%#=;&]*(?:%\h\h[^%#=;&]*)*)' # :nodoc:
 end


### PR DESCRIPTION
This is a modification of an earlier pull request #247. I'm sort of surprised that so many people typed the exact code I did here into comments on that thread, rather than forking and issuing a pull request themselves. So, uh... here's this. I think it fixes some problem people using 1.9.1 were having, but honestly I didn't test it; I just implemented what people said would fix their problem in comments. Would love some feedback if this should be done differently.
