### PR TITLE
Don't load the backport for uri/common.rb when running 1.9.3-p125 and beyond

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -10,7 +10,7 @@ if major == 1 && minor < 9
   require 'rack/backports/uri/common_18'
 elsif major == 1 && minor == 9 && patch < 3
   require 'rack/backports/uri/common_192'
-elsif major == 1 && minor == 9 && patch == 3
+elsif major == 1 && minor == 9 && patch == 3 && RUBY_PATCHLEVEL < 125
   require 'rack/backports/uri/common_193'
 else
   require 'uri/common'


### PR DESCRIPTION
As explained in #357, the code in backports/uri/common_193 is now present in 1.9.3-p125, so it should be loaded only under 1.9.3-p0.
