### PR TITLE
handle cookies with %uXXXX encoding as sent by IE

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -36,6 +36,10 @@ module Rack
     # target encoding of the string returned, and it defaults to UTF-8
     if defined?(::Encoding)
       def unescape(s, encoding = Encoding::UTF_8)
+        s = s.gsub(/%u[0-9A-F]{4}/) do |unicode_string|
+          utf16char = ["FEFF" + unicode_string[2,4]].pack('H*').force_encoding(Encoding::UTF_16)
+          escape(utf16char.encode(encoding))
+        end
         URI.decode_www_form_component(s, encoding)
       end
     else

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 require 'stringio'
 require 'cgi'
 require 'rack/request'
@@ -392,6 +393,14 @@ describe Rack::Request do
     req.cookies.should.equal "foo" => "bar", "quux" => "h&m"
     req.env.delete("HTTP_COOKIE")
     req.cookies.should.equal({})
+  end
+
+  if defined?(::Encoding)
+    should "parse cookies which use %uXXXX encoding" do
+      req = Rack::Request.new \
+        Rack::MockRequest.env_for("", "HTTP_COOKIE" => "foo=bar;great=%u30AD%u30E3")
+      req.cookies.should.equal "foo" => "bar", "great" => "キャ"
+    end
   end
 
   should "always return the same hash object" do


### PR DESCRIPTION
We are seeing several 500 errors for some incoming requests from IE9 users. Issue there was a cookie set by mixpanel using a different encoding, i.e. %uXXXX to represent UTF-16 characters. 

This is one of the exceptions for instance:

ArgumentError (cannot parse Cookie header: invalid %-encoding (%7B%22all%22%3A%20%7B%22%24initial_referrer%22%3A%20%22http%3A//www.akakura365.net/%u30AD%u30E3%u30CA%u30EB%u30B3%u30FC%u30C8petit/%22%2C%22%24initial_referring_domain%22%3A%
20%22www.akakura365.net%22%7D%2C%22events%22%3A%20%7B%7D%2C%22funnels%22%3A%20%7B%7D%7D))

I added some code which recodes %uXXXX to UTF-8 representation so that the cookie can be parsed correctly and thus the request can be processed.
