### PR TITLE
"a middleware" is grammatically meaningless

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -25,7 +25,7 @@ module Rack
   #
   #  run app
   #
-  # +use+ adds a middleware to the stack, +run+ dispatches to an application.
+  # +use+ adds middleware to the stack, +run+ dispatches to an application.
   # You can use +map+ to construct a Rack::URLMap in a convenient way.
 
   class Builder
@@ -55,7 +55,7 @@ module Rack
       self.new(default_app, &block).to_app
     end
 
-    # Specifies a middleware to use in a stack.
+    # Specifies middleware to use in a stack.
     #
     #   class Middleware
     #     def initialize(app)

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -256,7 +256,7 @@ describe Rack::Session::Cookie do
     response.body.should.not.be.nil
   end
 
-  it "can handle a middleware that inspects the env" do
+  it "can handle middleware that inspects the env" do
     class TestEnvInspector
       def initialize(app)
         @app = app


### PR DESCRIPTION
fixes #332
