### PR TITLE
Actually test unsafe directory traversal

### DIFF
--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -63,13 +63,13 @@ describe Rack::File do
   should "not allow unsafe directory traversal" do
     req = Rack::MockRequest.new(Rack::Lint.new(Rack::File.new(DOCROOT)))
 
-    res = req.get("/../README")
+    res = req.get("/../README.rdoc")
     res.should.be.client_error
 
-    res = req.get("../test")
+    res = req.get("../test/spec_file.rb")
     res.should.be.client_error
 
-    res = req.get("..")
+    res = req.get("../README.rdoc")
     res.should.be.client_error
 
     res.should.be.not_found


### PR DESCRIPTION
Points all unsafe directory traversal tests to existing files.

Without this, all tests will pass even when you comment out directory traversal protection in lib/rack/file.rb, since it just falls through to 404 errors.
