### PR TITLE
Skipping empty params inside query what leads to parsing error.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -67,6 +67,7 @@ module Rack
       params = KeySpaceConstrainedParams.new
 
       (qs || '').split(d ? /[#{d}] */n : DEFAULT_SEP).each do |p|
+        next if p.empty?
         k, v = p.split('=', 2).map { |x| unescape(x) }
         next unless k || v
 

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -118,6 +118,8 @@ describe Rack::Utils do
     Rack::Utils.parse_query("&key&").should.equal "key" => nil
     Rack::Utils.parse_query(";key;", ";,").should.equal "key" => nil
     Rack::Utils.parse_query(",key,", ";,").should.equal "key" => nil
+    Rack::Utils.parse_query(";foo=bar,;", ";,").should.equal "foo" => "bar"
+    Rack::Utils.parse_query(",foo=bar;,", ";,").should.equal "foo" => "bar"
   end
 
   should "parse nested query strings correctly" do


### PR DESCRIPTION
I found this problem when webpage on domain www.example.com was saving these strange cookies ("foo=bar,;bar=foo" or ",foo=bar;,") and subdomain was failing because of that.
