### PR TITLE
rackup: include the value of each -I command line option in $LOAD_PATH

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -26,7 +26,7 @@ module Rack
 
           opts.on("-I", "--include PATH",
                   "specify $LOAD_PATH (may be used more than once)") { |path|
-            options[:include] = path.split(":")
+            (options[:include] ||= []).concat(path.split(":"))
           }
 
           opts.on("-r", "--require LIBRARY",


### PR DESCRIPTION
`rackup -h` says '-I' can be used more than once.  However, instead of adding
each value to $LOAD_PATH, rackup would discard the value of all but the last
'-I' option.

Signed-off-by: Anurag Priyam anurag08priyam@gmail.com

---

ruby adds the value of each -I option to $LOAD_PATH.

$ ruby -I . -I .. -e 'puts $LOAD_PATH'
