### PR TITLE
provide Rack::Request#update_param and #delete_param

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -227,10 +227,22 @@ module Rack
 
     # Destructively update a parameter, whether it's in GET and/or POST. Returns nil.
     #
-    # The parameter is added to both GET and POST to reduce confusion.
+    # The parameter is updated wherever it was previous defined, so GET, POST, or both. If it wasn't previously defined, it's inserted into GET.
+    #
+    # env['rack.input'] is not touched.
     def update_param(k, v)
-      self.GET[k] = v
-      self.POST[k] = v
+      found = false
+      if self.GET.has_key?(k)
+        found = true
+        self.GET[k] = v
+      end
+      if self.POST.has_key?(k)
+        found = true
+        self.POST[k] = v
+      end
+      unless found
+        self.GET[k] = v
+      end
       @params = nil
       nil
     end
@@ -238,6 +250,8 @@ module Rack
     # Destructively delete a parameter, whether it's in GET or POST. Returns the value of the deleted parameter.
     #
     # If the parameter is in both GET and POST, the POST value takes precedence since that's how #params works.
+    #
+    # env['rack.input'] is not touched.
     def delete_param(k)
       v = [ self.POST.delete(k), self.GET.delete(k) ].compact.first
       @params = nil

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -451,6 +451,26 @@ describe Rack::Request do
     req2.params.should.equal 'foo' => 'bar'
   end
 
+  should "modify params hash by changing only GET" do
+    e = Rack::MockRequest.env_for("?foo=duhget")
+    req = Rack::Request.new(e)
+    req.GET.should.equal 'foo' => 'duhget'
+    req.POST.should.equal({})
+    req.update_param 'foo', 'bar'
+    req.GET.should.equal 'foo' => 'bar'
+    req.POST.should.equal({})
+  end
+
+  should "modify params hash by changing only POST" do
+    e = Rack::MockRequest.env_for("", "REQUEST_METHOD" => 'POST', :input => "foo=duhpost")
+    req = Rack::Request.new(e)
+    req.GET.should.equal({})
+    req.POST.should.equal 'foo' => 'duhpost'
+    req.update_param 'foo', 'bar'
+    req.GET.should.equal({})
+    req.POST.should.equal 'foo' => 'bar'
+  end
+
   should "modify params hash, even if param is defined in both POST and GET" do
     e = Rack::MockRequest.env_for("?foo=duhget", "REQUEST_METHOD" => 'POST', :input => "foo=duhpost")
     req1 = Rack::Request.new(e)


### PR DESCRIPTION
Includes tests.

I needed in my own app and I saw people asking in Stack Overflow:

http://stackoverflow.com/questions/6046705/add-api-key-on-every-request-with-rack-middleware
http://stackoverflow.com/questions/5028958/rack-and-rack-request-form-vars-rack-request-form-hash

This would fix both problems, I think.
