### PR TITLE
Escape Dir[] glob characters in path

### DIFF
--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -78,7 +78,7 @@ table { width:100%%; }
 
     def list_directory
       @files = [['../','Parent Directory','','','']]
-      glob = F.join(@path, '*')
+      glob = F.join(@path.gsub(/[*?{}\[\]]/, '\\\\\\&'), '*')
 
       url_head = ([@script_name] + @path_info.split('/')).map do |part|
         Rack::Utils.escape part

--- a/test/cgi/test{1}/file[1]
+++ b/test/cgi/test{1}/file[1]
@@ -1,0 +1,1 @@
+This path has glob characters!

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -67,4 +67,15 @@ describe Rack::Directory do
     res = mr.get("/cgi/test%2bdirectory/test%2bfile")
     res.should.be.ok
   end
+
+  should "escape glob characters" do
+    mr = Rack::MockRequest.new(Rack::Lint.new(app))
+    res = mr.get("/cgi/test%7B1%7D")
+
+    res.should.be.ok
+    res.body.should =~ %r{/cgi/test%7B1%7D/file%5B1%5D}
+
+    res = mr.get("/cgi/test%7B1%7D/file%5B1%5D")
+    res.should.be.ok
+  end
 end


### PR DESCRIPTION
Another episode in my continuing quest to rid the world of unescaped glob characters in `Dir[]` calls.
