### PR TITLE
Set __LINE__ correctly for rackup files.

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -38,7 +38,7 @@ module Rack
         end
         cfgfile.sub!(/^__END__\n.*\Z/m, '')
         app = eval "Rack::Builder.new {\n" + cfgfile + "\n}.to_app",
-          TOPLEVEL_BINDING, config
+          TOPLEVEL_BINDING, config, 0
       else
         require config
         app = Object.const_get(::File.basename(config, '.rb').capitalize)

--- a/test/builder/line.ru
+++ b/test/builder/line.ru
@@ -1,0 +1,1 @@
+run lambda{ |env| [200, {'Content-Type' => 'text/plain'}, [__LINE__.to_s]] }

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -197,5 +197,11 @@ describe Rack::Builder do
       Rack::MockRequest.new(app).get("/").body.to_s.should.equal 'OK'
       $:.pop
     end
+
+    it "sets __LINE__ correctly" do
+      app, options = Rack::Builder.parse_file config_file('line.ru')
+      options = nil # ignored, prevents warning
+      Rack::MockRequest.new(app).get("/").body.to_s.should.equal '1'
+    end
   end
 end


### PR DESCRIPTION
Before this change the line numbers were off by one, which broke
debugging tools like Pry in addition to causing a smidgen of user
confusion.

Reported-At: https://github.com/pry/pry/issues/571
