### PR TITLE
Validate header names according to RFC 2616

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -202,9 +202,7 @@ server, and must not be sent back to the client.
 The header keys must be Strings.
 The header must not contain a +Status+ key,
 contain keys with <tt>:</tt> or newlines in their name,
-contain keys names that end in <tt>-</tt> or <tt>_</tt>,
-but only contain keys that consist of
-letters, digits, <tt>_</tt> or <tt>-</tt> and start with a letter.
+but only contain keys that match the token rule according to RFC 2616.
 The values of the header must be Strings,
 consisting of lines (for multiple header values, e.g. multiple
 <tt>Set-Cookie</tt> values) seperated by "\n".

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -574,11 +574,8 @@ module Rack
         assert("header must not contain Status") { key.downcase != "status" }
         ## contain keys with <tt>:</tt> or newlines in their name,
         assert("header names must not contain : or \\n") { key !~ /[:\n]/ }
-        ## contain keys names that end in <tt>-</tt> or <tt>_</tt>,
-        assert("header names must not end in - or _") { key !~ /[-_]\z/ }
-        ## but only contain keys that consist of
-        ## letters, digits, <tt>_</tt> or <tt>-</tt> and start with a letter.
-        assert("invalid header name: #{key}") { key =~ /\A[a-zA-Z][a-zA-Z0-9_-]*\z/ }
+        ## The header must match the token rule according to RFC 2616
+        assert("invalid header name: #{key}") { key =~ /\A[\!#\$%&'\*\+-.0-9A-Z\^_`a-z\|~]+\z/ }
 
         ## The values of the header must be Strings,
         assert("a header value must be a String, but the value of " +

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -191,17 +191,10 @@ describe Rack::Lint do
 
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, {"Content-" => "text/plain"}, []]
+                       [200, {"([{<quark>}])?" => "text/plain"}, []]
                      }).call(env({}))
     }.should.raise(Rack::Lint::LintError).
-      message.should.match(/must not end/)
-
-    lambda {
-      Rack::Lint.new(lambda { |env|
-                       [200, {"..%%quark%%.." => "text/plain"}, []]
-                     }).call(env({}))
-    }.should.raise(Rack::Lint::LintError).
-      message.should.equal("invalid header name: ..%%quark%%..")
+      message.should.equal("invalid header name: ([{<quark>}])?")
 
     lambda {
       Rack::Lint.new(lambda { |env|


### PR DESCRIPTION
Header name validation rules are too strict. [RFC 2616](http://pretty-rfc.herokuapp.com/RFC2616) allows any ASCII character, with a few exceptions. See http://pretty-rfc.herokuapp.com/RFC2616#basic.rules, or:

```
message-header = field-name ":" [ field-value ]
field-name     = token

token          = 1*<any CHAR except CTLs or separators>
CHAR           = <any US-ASCII character (octets 0 - 127)>
separators     = "(" | ")" | "<" | ">" | "@"
                     | "," | ";" | ":" | "\" | <">
                     | "/" | "[" | "]" | "?" | "="
                     | "{" | "}" | SP | HT
CTL            = <any US-ASCII control character
                 (octets 0 - 31) and DEL (127)>
SP             = <US-ASCII SP, space (32)>
HT             = <US-ASCII HT, horizontal-tab (9)>
```

This commit loosens the restrictions in `Rack::Lint`.
