### PR TITLE
Method for OptionParser makes it easier for applications to reuse.

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -3,9 +3,8 @@ require 'optparse'
 module Rack
   class Server
     class Options
-      def parse!(args)
-        options = {}
-        opt_parser = OptionParser.new("", 24, '  ') do |opts|
+      def opt_parser(options={})
+        @opt_parser ||= OptionParser.new("", 24, '  ') do |opts|
           opts.banner = "Usage: rackup [ruby options] [rack options] [rackup config]"
 
           opts.separator ""
@@ -81,9 +80,13 @@ module Rack
             exit
           end
         end
+      end
+
+      def parse!(args)
+        options = {}
 
         begin
-          opt_parser.parse! args
+          opt_parser(options).parse! args
         rescue OptionParser::InvalidOption => e
           warn e.message
           abort opt_parser.to_s


### PR DESCRIPTION
I separated the option parser into a cached method, so that it can be reused by other applications. I presently find myself in this situation where I am creating a CLI front-end for starting up a rack server, but need to support a couple of additional options. Rather then having to duplicate all these options in my own OptionParser it would be convenient to just augment Racks built-in one. 
