### PR TITLE
Add new status codes to `Rack::Utils.HTTP_STATUS_CODES`

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -519,6 +519,9 @@ module Rack
       423  => 'Locked',
       424  => 'Failed Dependency',
       426  => 'Upgrade Required',
+      428  => 'Precondition Required',
+      429  => 'Too Many Requests',
+      431  => 'Request Header Fields Too Large',
       500  => 'Internal Server Error',
       501  => 'Not Implemented',
       502  => 'Bad Gateway',
@@ -528,6 +531,7 @@ module Rack
       506  => 'Variant Also Negotiates',
       507  => 'Insufficient Storage',
       510  => 'Not Extended',
+      511  => 'Network Authentication Required',
     }
 
     # Responses with HTTP status codes that should not have an entity body


### PR DESCRIPTION
From [RFC 6585](http://tools.ietf.org/html/rfc6585):
- 428 [Precondition Required](http://tools.ietf.org/html/rfc6585#section-3)
- 429 [Too Many Requests](http://tools.ietf.org/html/rfc6585#section-4)
- 431 [Request Header Fields Too Large](http://tools.ietf.org/html/rfc6585#section-5)
- 511 [Network Authentication Required](http://tools.ietf.org/html/rfc6585#section-6)
