### PR TITLE
Use correct content-type for WOFF fonts

### DIFF
--- a/lib/rack/mime.rb
+++ b/lib/rack/mime.rb
@@ -598,7 +598,7 @@ module Rack
       ".wmv"       => "video/x-ms-wmv",
       ".wmx"       => "video/x-ms-wmx",
       ".wmz"       => "application/x-ms-wmz",
-      ".woff"      => "application/octet-stream",
+      ".woff"      => "application/font-woff",
       ".wpd"       => "application/vnd.wordperfect",
       ".wpl"       => "application/vnd.ms-wpl",
       ".wps"       => "application/vnd.ms-works",


### PR DESCRIPTION
The incorrect content type is being used for WOFF fonts.
This causes issues in Firefox. 

As an asides, for those who find this issue, and want their application to use the correct headers NOW:

Add this to your `config.ru`.

`Rack::Mime::MIME_TYPES['.woff'] = 'application/font-woff'`
