### PR TITLE
Fix request loop on non-stale nonce with time_limit parameter.

### DIFF
--- a/lib/rack/auth/digest/nonce.rb
+++ b/lib/rack/auth/digest/nonce.rb
@@ -38,7 +38,7 @@ module Rack
         end
 
         def stale?
-          !self.class.time_limit.nil? && (@timestamp - Time.now.to_i) < self.class.time_limit
+          !self.class.time_limit.nil? && (Time.now.to_i - @timestamp) > self.class.time_limit
         end
 
         def fresh?

--- a/test/spec_auth_digest.rb
+++ b/test/spec_auth_digest.rb
@@ -153,6 +153,20 @@ describe Rack::Auth::Digest::MD5 do
     end
   end
 
+  should 'not rechallenge if nonce is not stale' do
+    begin
+      Rack::Auth::Digest::Nonce.time_limit = 10
+
+      request_with_digest_auth 'GET', '/', 'Alice', 'correct-password', :wait => 1 do |response|
+        response.status.should.equal 200
+        response.body.to_s.should.equal 'Hi Alice'
+        response.headers['WWW-Authenticate'].should.not =~ /\bstale=true\b/
+      end
+    ensure
+      Rack::Auth::Digest::Nonce.time_limit = nil
+    end
+  end
+
   should 'rechallenge with stale parameter if nonce is stale' do
     begin
       Rack::Auth::Digest::Nonce.time_limit = 1


### PR DESCRIPTION
On HTTP Digest auth (MD5), when `Rack::Auth::Digest::Nonce.time_limit` is set, `stale?` function of `Nonce` always returns `false`.  So user-agent's re-challenges never succeed.  As a consequence, request-response infinitely loops.
