### PR TITLE
Don't set blank Cache-Control header in Rack::ETag

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -28,8 +28,11 @@ module Rack
       end
 
       unless headers['Cache-Control']
-        headers['Cache-Control'] =
-          (digest ? @cache_control : @no_cache_control) || ""
+        if digest
+          headers['Cache-Control'] = @cache_control if @cache_control
+        else
+          headers['Cache-Control'] = @no_cache_control if @no_cache_control
+        end
       end
 
       [status, headers, body]

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -54,6 +54,12 @@ describe Rack::ETag do
     response[1]['Cache-Control'].should.equal 'public'
   end
 
+  should "not set Cache-Control if directive isn't present" do
+    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+    response = etag(app, nil, nil).call(request)
+    response[1]['Cache-Control'].should.equal nil
+  end
+
   should "not change ETag if it is already set" do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain', 'ETag' => '"abc"'}, ["Hello, World!"]] }
     response = etag(app).call(request)


### PR DESCRIPTION
A Cache-Control header with an empty string is meaningless (confusing, even, to those inspecting response headers) and slightly wasteful.
