### PR TITLE
Handle existing rack.session where the app modifies session vars

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -120,6 +120,11 @@ module Rack
           super
         end
 
+        def merge!(hash)
+          load_for_write!
+          super
+        end
+
       private
 
         def load_for_read!

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -338,4 +338,11 @@ describe Rack::Session::Cookie do
     response = response_for(:app => session_id, :request => request)
     response.body.should.match(/foo/)
   end
+
+  it "allows modifying session data with session data from middleware in front" do
+    request = { 'rack.session' => { :foo => 'bar' }}
+    response = response_for(:app => incrementor, :request => request)
+    response.body.should.match(/counter/)
+    response.body.should.match(/foo/)
+  end
 end


### PR DESCRIPTION
ID#prepare_session calls merge! on the newly-created SessionHash, but this method is not overridden to parse existing data. As such, if the app modifies session values, it winds up discarding the entire previous session.

I saw there was already a spec for a non-session-modifying app which ran fine, but failed exactly like I was experiencing when I used the example incrementing app.

For me, this was breaking Rack::Test while testing a Sinatra app.
