### PR TITLE
Include Darwin in POSIX semantics compatible platforms.

### DIFF
--- a/lib/rack/rewindable_input.rb
+++ b/lib/rack/rewindable_input.rb
@@ -98,7 +98,7 @@ module Rack
     end
 
     def filesystem_has_posix_semantics?
-      RUBY_PLATFORM !~ /(mswin|mingw|cygwin|java/darwin)/
+      RUBY_PLATFORM !~ /(mswin|mingw|cygwin|java|darwin)/
     end
   end
 end


### PR DESCRIPTION
I'm not sure why Darwin wasn't included in the POSIX semantics compatible platforms to allow RewindableInput temp file to be unlinked. It should have been, right?
