### PR TITLE
Handle all exceptions in Rack::Lock

### DIFF
--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -15,7 +15,7 @@ module Rack
       response = @app.call(env)
       response[2] = BodyProxy.new(response[2]) { @mutex.unlock }
       response
-    rescue Exception
+    rescue
       @mutex.unlock
       raise
     ensure


### PR DESCRIPTION
If you use "raise :async" a mutex leaks. In fact if you throw anything that does not inherit off Exception, you get a leak.
