### PR TITLE
Fixed Rack::Lock so it correctly releases mutexes on throw

### DIFF
--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -13,12 +13,11 @@ module Rack
       old, env[FLAG] = env[FLAG], false
       @mutex.lock
       response = @app.call(env)
-      response[2] = BodyProxy.new(response[2]) { @mutex.unlock }
+      body = BodyProxy.new(response[2]) { @mutex.unlock }
+      response[2] = body
       response
-    rescue Exception
-      @mutex.unlock
-      raise
     ensure
+      @mutex.unlock unless body
       env[FLAG] = old
     end
   end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -134,8 +134,16 @@ describe Rack::Lock do
   should "unlock if the app raises" do
     lock = Lock.new
     env = Rack::MockRequest.env_for("/")
-    app = lock_app(lambda { raise Exception })
+    app = lock_app(lambda { raise Exception }, lock)
     lambda { app.call(env) }.should.raise(Exception)
+    lock.synchronized.should.equal false
+  end
+
+  should "unlock if the app throws" do
+    lock = Lock.new
+    env = Rack::MockRequest.env_for("/")
+    app = lock_app(lambda {|env| throw :bacon }, lock)
+    lambda { app.call(env) }.should.throw(:bacon)
     lock.synchronized.should.equal false
   end
 


### PR DESCRIPTION
- amend it so Rack::Lock releases the mutex on throws as well and raises
- added throw test
- fixed raise test
