### PR TITLE
Stringify the keys in SessionHash#merge

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -122,7 +122,7 @@ module Rack
 
         def merge!(hash)
           load_for_write!
-          super
+          super(stringify_keys(hash))
         end
 
       private


### PR DESCRIPTION
As mentioned in #427 the merge! method does not take care of stringifying the keys. That leads to errors if you add symbol (or other non-string) keys as the values will never be read as the fetch converts everything to a string:

```
def [](key)
    load_for_read!
    super(key.to_s)
end
```
