### PR TITLE
Include Max-Age in Set-Cookie header

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -223,6 +223,7 @@ module Rack
       when Hash
         domain  = "; domain="  + value[:domain] if value[:domain]
         path    = "; path="    + value[:path]   if value[:path]
+        max_age = "; max-age=" + value[:max_age] if value[:max_age]
         # According to RFC 2109, we need dashes here.
         # N.B.: cgi.rb uses spaces...
         expires = "; expires=" +
@@ -234,7 +235,7 @@ module Rack
       value = [value] unless Array === value
       cookie = escape(key) + "=" +
         value.map { |v| escape v }.join("&") +
-        "#{domain}#{path}#{expires}#{secure}#{httponly}"
+        "#{domain}#{path}#{max_age}#{expires}#{secure}#{httponly}"
 
       case header["Set-Cookie"]
       when nil, ''
@@ -273,6 +274,7 @@ module Rack
 
       set_cookie_header!(header, key,
                  {:value => '', :path => nil, :domain => nil,
+                   :max_age => '0',
                    :expires => Time.at(0) }.merge(value))
 
       nil

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -92,7 +92,7 @@ describe Rack::Response do
     response.delete_cookie "foo"
     response["Set-Cookie"].should.equal [
       "foo2=bar2",
-      "foo=; expires=Thu, 01-Jan-1970 00:00:00 GMT"
+      "foo=; max-age=0; expires=Thu, 01-Jan-1970 00:00:00 GMT"
     ].join("\n")
   end
 
@@ -102,10 +102,10 @@ describe Rack::Response do
     response.set_cookie "foo", {:value => "bar", :domain => ".example.com"}
     response["Set-Cookie"].should.equal ["foo=bar; domain=sample.example.com", "foo=bar; domain=.example.com"].join("\n")
     response.delete_cookie "foo", :domain => ".example.com"
-    response["Set-Cookie"].should.equal ["foo=bar; domain=sample.example.com", "foo=; domain=.example.com; expires=Thu, 01-Jan-1970 00:00:00 GMT"].join("\n")
+    response["Set-Cookie"].should.equal ["foo=bar; domain=sample.example.com", "foo=; domain=.example.com; max-age=0; expires=Thu, 01-Jan-1970 00:00:00 GMT"].join("\n")
     response.delete_cookie "foo", :domain => "sample.example.com"
-    response["Set-Cookie"].should.equal ["foo=; domain=.example.com; expires=Thu, 01-Jan-1970 00:00:00 GMT",
-                                         "foo=; domain=sample.example.com; expires=Thu, 01-Jan-1970 00:00:00 GMT"].join("\n")
+    response["Set-Cookie"].should.equal ["foo=; domain=.example.com; max-age=0; expires=Thu, 01-Jan-1970 00:00:00 GMT",
+                                         "foo=; domain=sample.example.com; max-age=0; expires=Thu, 01-Jan-1970 00:00:00 GMT"].join("\n")
   end
 
   it "can delete cookies with the same name with different paths" do
@@ -117,7 +117,7 @@ describe Rack::Response do
 
     response.delete_cookie "foo", :path => "/path"
     response["Set-Cookie"].should.equal ["foo=bar; path=/",
-                                         "foo=; path=/path; expires=Thu, 01-Jan-1970 00:00:00 GMT"].join("\n")
+                                         "foo=; path=/path; max-age=0; expires=Thu, 01-Jan-1970 00:00:00 GMT"].join("\n")
   end
 
   it "can do redirects" do


### PR DESCRIPTION
Allows `:max_age` to be passed to `set_cookie_header!`. If passed, includes `max-age` in the `Set-Cookie` header. Sets `max-age=0;` when the cookie header is deleted.

Apologies, since I know you just closed a [similar pull request](https://github.com/rack/rack/pull/264). At least [two folks](http://stackoverflow.com/questions/12271207/in-rails-how-can-i-set-a-cookies-max-age) seem to think it worthwhile. :) Let me know could be improved or tested.

(Re: browsers, [one source says](http://mrcoles.com/blog/cookies-max-age-vs-expires/) IE will ignore `max-age` and fall back to `expires`.)
