### PR TITLE
Make multipart parser not depend on having a Content-Length header

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -48,13 +48,15 @@ module Rack
         @buf = ""
         @params = Utils::KeySpaceConstrainedParams.new
 
-        @content_length = @env['CONTENT_LENGTH'].to_i
         @io = @env['rack.input']
         @io.rewind
 
         @boundary_size = Utils.bytesize(@boundary) + EOL.size
 
-        @content_length -= @boundary_size
+        if @content_length = @env['CONTENT_LENGTH']
+          @content_length = @content_length.to_i
+          @content_length -= @boundary_size
+        end
         true
       end
 
@@ -104,11 +106,11 @@ module Rack
             body << @buf.slice!(0, @buf.size - (@boundary_size+4))
           end
 
-          content = @io.read(BUFSIZE < @content_length ? BUFSIZE : @content_length)
+          content = @io.read(@content_length && BUFSIZE >= @content_length ? @content_length : BUFSIZE)
           raise EOFError, "bad content body"  if content.nil? || content.empty?
 
           @buf << content
-          @content_length -= content.size
+          @content_length -= content.size if @content_length
         end
 
         [head, filename, content_type, name, body]

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -360,4 +360,11 @@ EOF
     params.should.equal({"description"=>"Very very blue"})
   end
 
+  should "parse multipart upload with no content-length header" do
+    env = Rack::MockRequest.env_for '/', multipart_fixture(:webkit)
+    env['CONTENT_TYPE'] = "multipart/form-data; boundary=----WebKitFormBoundaryWLHCs9qmcJJoyjKR"
+    env.delete 'CONTENT_LENGTH'
+    params = Rack::Multipart.parse_multipart(env)
+    params['profile']['bio'].should.include 'hello'
+  end
 end


### PR DESCRIPTION
Related ...

https://github.com/rails/rails/issues/7556
and
https://github.com/rack/rack/issues/418
