### PR TITLE
Serve *.woff as application/x-font-woff

### DIFF
--- a/lib/rack/mime.rb
+++ b/lib/rack/mime.rb
@@ -598,7 +598,7 @@ module Rack
       ".wmv"       => "video/x-ms-wmv",
       ".wmx"       => "video/x-ms-wmx",
       ".wmz"       => "application/x-ms-wmz",
-      ".woff"      => "application/octet-stream",
+      ".woff"      => "application/x-font-woff",
       ".wpd"       => "application/vnd.wordperfect",
       ".wpl"       => "application/vnd.ms-wpl",
       ".wps"       => "application/vnd.ms-works",


### PR DESCRIPTION
Since Chrome / WebKit wails about woff fonts served with content-type
application/octet-stream, use a more accurate legal MIME type instead:

http://code.google.com/p/chromium/issues/detail?id=70283#c6
http://stackoverflow.com/questions/10149659/resource-interpreted-as-font-but-transferred-with-mime-type-application-octet-st
