### PR TITLE
Revisit: `Rack::MethodOverride` should work also with GET request

### DIFF
--- a/lib/rack/methodoverride.rb
+++ b/lib/rack/methodoverride.rb
@@ -5,12 +5,15 @@ module Rack
     METHOD_OVERRIDE_PARAM_KEY = "_method".freeze
     HTTP_METHOD_OVERRIDE_HEADER = "HTTP_X_HTTP_METHOD_OVERRIDE".freeze
 
-    def initialize(app)
+    attr_reader :trusted_original_methods
+
+    def initialize(app, trusted_original_methods=["POST"])
       @app = app
+      @trusted_original_methods = trusted_original_methods
     end
 
     def call(env)
-      if env["REQUEST_METHOD"] == "POST"
+      if trusted_method?(env)
         method = method_override(env)
         if HTTP_METHODS.include?(method)
           env["rack.methodoverride.original_method"] = env["REQUEST_METHOD"]
@@ -21,13 +24,26 @@ module Rack
       @app.call(env)
     end
 
+    def trusted_method?(env)
+      trusted_original_methods.include? env["REQUEST_METHOD"]
+    end
+
     def method_override(env)
       req = Request.new(env)
-      method = req.POST[METHOD_OVERRIDE_PARAM_KEY] ||
-        env[HTTP_METHOD_OVERRIDE_HEADER]
+      method = overide_param(req) if trusted_method?(env)
+      method = overide_header(env) unless method
       method.to_s.upcase
     rescue EOFError
       ""
+    end
+
+    def overide_param(req)
+      req.GET[METHOD_OVERRIDE_PARAM_KEY] ||
+        req.POST[METHOD_OVERRIDE_PARAM_KEY]
+    end
+
+    def overide_header(env)
+      env[HTTP_METHOD_OVERRIDE_HEADER]
     end
   end
 end


### PR DESCRIPTION
Here was my reply to a closed ticket: 

There is actually a use case for supporting this. If you want to release a JSONP API. Since JSONP calls are only GET, the only way around this imposed restriction is to either redirect or \
somehow override all incoming calls to simulate "POST" requests. I feel like at the very least, one should be allowed to allow GET calls...

See stripe's API for an example of this in the real world.

Are there any other reasons you can think of that would make supporting GET an issue?

I'd like to reopen #160 for discussion.

Also, I'm attaching a commit I made with tests. If there is any additional validation you would like me to do perhaps to verify that it's a jsonp request or something I will build it too. I want to make sure I'm not opening up some security hole or something.
