### PR TITLE
add uWSGI to the list of servers supporting Rack 

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -31,6 +31,7 @@ These web servers include Rack handlers in their distributions:
 * Rainbows!
 * Unicorn
 * unixrack
+* uWSGI
 * Zbatery
 
 Any valid Rack app will run the same on all these handlers, without


### PR DESCRIPTION
Starting from version 1.3 the rack plugin of the uWSGI project is fully rack compliant, so i think it should be mentioned here
