### PR TITLE
Add puma as a potential default alongside thin

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -37,9 +37,11 @@ module Rack
       elsif ENV.include?("REQUEST_METHOD")
         Rack::Handler::CGI
       else
-        begin
+        if defined? Thin
           Rack::Handler::Thin
-        rescue LoadError
+        elsif defined? Puma
+          Rack::Handler::Puma
+        else
           Rack::Handler::WEBrick
         end
       end
@@ -80,6 +82,7 @@ module Rack
     autoload :LSWS, "rack/handler/lsws"
     autoload :SCGI, "rack/handler/scgi"
     autoload :Thin, "rack/handler/thin"
+    autoload :Puma, "rack/handler/puma"
 
     register 'cgi', 'Rack::Handler::CGI'
     register 'fastcgi', 'Rack::Handler::FastCGI'
@@ -90,5 +93,6 @@ module Rack
     register 'lsws', 'Rack::Handler::LSWS'
     register 'scgi', 'Rack::Handler::SCGI'
     register 'thin', 'Rack::Handler::Thin'
+    register 'puma', 'Rack::Handler::Puma'
   end
 end


### PR DESCRIPTION
Thin is great but it is not a preferred alternative to webrick if you are using jruby. This change will allow you to use puma by default just by having `gem 'puma'` in the Gemfile of any rack application. 

[Puma](http://puma.io)
