### PR TITLE
Allow EOFError exception to be passed through

### DIFF
--- a/lib/rack/methodoverride.rb
+++ b/lib/rack/methodoverride.rb
@@ -26,8 +26,6 @@ module Rack
       method = req.POST[METHOD_OVERRIDE_PARAM_KEY] ||
         env[HTTP_METHOD_OVERRIDE_HEADER]
       method.to_s.upcase
-    rescue EOFError
-      ""
     end
   end
 end

--- a/test/spec_methodoverride.rb
+++ b/test/spec_methodoverride.rb
@@ -65,7 +65,10 @@ EOF
                       "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size.to_s,
                       :method => "POST", :input => input)
-    app.call env
+    begin
+      app.call env
+    rescue EOFError
+    end
 
     env["REQUEST_METHOD"].should.equal "POST"
   end


### PR DESCRIPTION
The commit https://github.com/rack/rack/commit/5f4bb6022a10cab144e4485e61e842b8d14a7936 prevents Rack::MethodOverride from overriding the HTTP method if a multipart POST request is malformed.  However it also consumes the error exception.  This pull request restores the behavior of allowing the exception to continue, while ensuring the HTTP method is not overridden.

For Rails, consuming the exception causes the request to still be delivered to the application, but without any request parameters.  Depending on the type of error in the multipart body, Rails may or may not log an error.
