### PR TITLE
tweak Cascade docs

### DIFF
--- a/lib/rack/cascade.rb
+++ b/lib/rack/cascade.rb
@@ -1,6 +1,6 @@
 module Rack
-  # Rack::Cascade tries an request on several apps, and returns the
-  # first response that is not 404 (or in a list of configurable
+  # Rack::Cascade tries a request on several apps, and returns the
+  # first response that is not 404 or 405 (or in a list of configurable
   # status codes).
 
   class Cascade


### PR DESCRIPTION
Fixes a small typo /an/a and adds 405 to docs.
