### PR TITLE
Use to_enum instead of Enumerator.new to remove Ruby 2.0 warnings

### DIFF
--- a/test/spec_chunked.rb
+++ b/test/spec_chunked.rb
@@ -3,18 +3,16 @@ require 'rack/lint'
 require 'rack/mock'
 
 describe Rack::Chunked do
-  ::Enumerator = ::Enumerable::Enumerator unless Object.const_defined?(:Enumerator)
-
   def chunked(app)
     proc do |env|
       app = Rack::Chunked.new(app)
       response = Rack::Lint.new(app).call(env)
       # we want to use body like an array, but it only has #each
-      response[2] = Enumerator.new(response[2]).to_a
+      response[2] = response[2].to_enum.to_a
       response
     end
   end
-  
+
   before do
     @env = Rack::MockRequest.
       env_for('/', 'HTTP_VERSION' => '1.1', 'REQUEST_METHOD' => 'GET')

--- a/test/spec_content_length.rb
+++ b/test/spec_content_length.rb
@@ -1,19 +1,16 @@
-require 'enumerator'
 require 'rack/content_length'
 require 'rack/lint'
 require 'rack/mock'
 
 describe Rack::ContentLength do
-  ::Enumerator = ::Enumerable::Enumerator unless Object.const_defined?(:Enumerator)
-
   def content_length(app)
     Rack::Lint.new Rack::ContentLength.new(app)
   end
-  
+
   def request
     Rack::MockRequest.env_for
   end
-  
+
   should "set Content-Length on Array bodies if none is set" do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
     response = content_length(app).call(request)
@@ -81,6 +78,6 @@ describe Rack::ContentLength do
     response = content_length(app).call(request)
     expected = %w[one two three]
     response[1]['Content-Length'].should.equal expected.join.size.to_s
-    Enumerator.new(response[2]).to_a.should.equal expected
+    response[2].to_enum.to_a.should.equal expected
   end
 end

--- a/test/spec_head.rb
+++ b/test/spec_head.rb
@@ -1,4 +1,3 @@
-require 'enumerator'
 require 'rack/head'
 require 'rack/lint'
 require 'rack/mock'
@@ -16,17 +15,13 @@ describe Rack::Head do
     return response, body
   end
 
-  def enum
-    defined?(Enumerator) ? Enumerator : Enumerable::Enumerator
-  end
-
   should "pass GET, POST, PUT, DELETE, OPTIONS, TRACE requests" do
     %w[GET POST PUT DELETE OPTIONS TRACE].each do |type|
       resp, _ = test_response("REQUEST_METHOD" => type)
 
       resp[0].should.equal(200)
       resp[1].should.equal({"Content-type" => "test/plain", "Content-length" => "3"})
-      enum.new(resp[2]).to_a.should.equal(["foo"])
+      resp[2].to_enum.to_a.should.equal(["foo"])
     end
   end
 
@@ -35,14 +30,14 @@ describe Rack::Head do
 
     resp[0].should.equal(200)
     resp[1].should.equal({"Content-type" => "test/plain", "Content-length" => "3"})
-    enum.new(resp[2]).to_a.should.equal([])
+    resp[2].to_enum.to_a.should.equal([])
   end
 
   should "close the body when it is removed" do
     resp, body = test_response("REQUEST_METHOD" => "HEAD")
     resp[0].should.equal(200)
     resp[1].should.equal({"Content-type" => "test/plain", "Content-length" => "3"})
-    enum.new(resp[2]).to_a.should.equal([])
+    resp[2].to_enum.to_a.should.equal([])
     body.should.be.closed
   end
 end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -1,4 +1,3 @@
-require 'enumerator'
 require 'rack/lint'
 require 'rack/lock'
 require 'rack/mock'
@@ -36,13 +35,11 @@ module LockHelpers
 end
 
 describe Rack::Lock do
-  ::Enumerator = ::Enumerable::Enumerator unless Object.const_defined?(:Enumerator)
-  
   extend LockHelpers
-  
+
   describe 'Proxy' do
     extend LockHelpers
-    
+
     should 'delegate each' do
       env      = Rack::MockRequest.env_for("/")
       response = Class.new {
@@ -115,11 +112,11 @@ describe Rack::Lock do
     env  = Rack::MockRequest.env_for("/")
     body = [200, {"Content-Type" => "text/plain"}, %w{ hi mom }]
     app  = lock_app(lambda { |inner_env| body })
-    
+
     res = app.call(env)
     res[0].should.equal body[0]
     res[1].should.equal body[1]
-    Enumerator.new(res[2]).to_a.should.equal ["hi", "mom"]
+    res[2].to_enum.to_a.should.equal ["hi", "mom"]
   end
 
   should "call synchronize on lock" do

--- a/test/spec_nulllogger.rb
+++ b/test/spec_nulllogger.rb
@@ -1,23 +1,20 @@
-require 'enumerator'
 require 'rack/lint'
 require 'rack/mock'
 require 'rack/nulllogger'
 
 describe Rack::NullLogger do
-  ::Enumerator = ::Enumerable::Enumerator unless Object.const_defined?(:Enumerator)
-  
   should "act as a noop logger" do
     app = lambda { |env|
       env['rack.logger'].warn "b00m"
       [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]]
     }
-    
+
     logger = Rack::Lint.new(Rack::NullLogger.new(app))
-    
+
     res = logger.call(Rack::MockRequest.env_for)
     res[0..1].should.equal [
       200, {'Content-Type' => 'text/plain'}
     ]
-    Enumerator.new(res[2]).to_a.should.equal ["Hello, World!"]
+    res[2].to_enum.to_a.should.equal ["Hello, World!"]
   end
 end


### PR DESCRIPTION
This commit avoid warn message
Enumerator.new without a block is deprecated; use Object#to_enum
