### PR TITLE
Refactor Rack::Static and improve directory index support

### DIFF
--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -53,6 +53,19 @@ describe Rack::Static do
     res.body.should =~ /another index!/
   end
 
+  it "calls index file for existing folders without specific root request" do
+    res = @static_request.get("")
+    res.should.be.ok
+    res.body.should =~ /index!/
+
+    res = @static_request.get("/other")
+    res.should.be.not_found
+
+    res = @static_request.get("/another")
+    res.should.be.ok
+    res.body.should =~ /another index!/
+  end
+
   it "doesn't call index file if :index option was omitted" do
     res = @request.get("/")
     res.body.should == "Hello World"


### PR DESCRIPTION
This is a reissue of #403, rebased and with test.

This patch makes the the Rack::Static code a little more efficient and readable. At the same time it adds support for existent directory index support --instead of just checking for a trailing /, failing that it will check to see if the the path is an actual directory on disk. This is indispensable in some use cases where a trailing slash can not be insured, but the directories index file still needs to be served.

If necessary we can add a new configuration option to conditionally support this new directory behaviour, but I did not do so presently b/c I suspect it would be a YAGNI.
