### PR TITLE
Add default port to webrick

### DIFF
--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -7,6 +7,7 @@ module Rack
     class WEBrick < ::WEBrick::HTTPServlet::AbstractServlet
       def self.run(app, options={})
         options[:BindAddress] = options.delete(:Host) if options[:Host]
+        options[:Port] ||= 8080
         @server = ::WEBrick::HTTPServer.new(options)
         @server.mount "/", Rack::Handler::WEBrick, app
         yield @server  if block_given?


### PR DESCRIPTION
Unsure if you care, but the default port for webrick was 80, not 8080 as documented. Other handlers may have the same problem, will check/fix if there's interest.
