### PR TITLE
Update Lobster example

### DIFF
--- a/example/protectedlobster.rb
+++ b/example/protectedlobster.rb
@@ -11,4 +11,4 @@ protected_lobster.realm = 'Lobster 2.0'
 
 pretty_protected_lobster = Rack::ShowStatus.new(Rack::ShowExceptions.new(protected_lobster))
 
-Rack::Handler::WEBrick.run pretty_protected_lobster, :Port => 9292
+Rack::Server.start :app => pretty_protected_lobster, :Port => 9292

--- a/lib/rack/lobster.rb
+++ b/lib/rack/lobster.rb
@@ -59,7 +59,7 @@ end
 if $0 == __FILE__
   require 'rack'
   require 'rack/showexceptions'
-  Rack::Handler::WEBrick.run \
-    Rack::ShowExceptions.new(Rack::Lint.new(Rack::Lobster.new)),
-    :Port => 9292
+  Rack::Server.start(
+    :app => Rack::ShowExceptions.new(Rack::Lint.new(Rack::Lobster.new)), :Port => 9292
+  )
 end


### PR DESCRIPTION
The motivation for this PR is:
- The sample apps uses the WEBrick handler directly. This breaks signal management (CTRL-C for example) and doesn't allow Rack to pick the default server.
