### PR TITLE
Remove warnings: 'not used variable' and 'shadowing outer variable'

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -5,7 +5,6 @@ require 'tempfile'
 require 'rack/multipart'
 
 major, minor, patch = RUBY_VERSION.split('.').map { |v| v.to_i }
-ruby_engine = defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'
 
 if major == 1 && minor < 9
   require 'rack/backports/uri/common_18'

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -139,7 +139,7 @@ describe Rack::Lock do
   should "unlock if the app throws" do
     lock = Lock.new
     env = Rack::MockRequest.env_for("/")
-    app = lock_app(lambda {|env| throw :bacon }, lock)
+    app = lock_app(lambda {|_| throw :bacon }, lock)
     lambda { app.call(env) }.should.throw(:bacon)
     lock.synchronized.should.equal false
   end


### PR DESCRIPTION
Got the following warning when running Rails tests:

```
rack-1.4.3/lib/rack/utils.rb:8: warning: assigned but unused variable - ruby_engine
```

The other warning was found when running rack own tests. I believe this can be safely applied to rack-1.4 branch - let me know if a pull request is necessary.
