### PR TITLE
Remove .to_sym in Authorization scheme

### DIFF
--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -21,7 +21,10 @@ module Rack
       end
 
       def scheme
-        @scheme ||= parts.first.downcase.to_sym
+        @scheme ||= begin
+          scheme_string = parts.first.downcase
+          ['basic', 'digest'].include?(scheme_string) ? scheme_string.to_sym : scheme_string
+        end
       end
 
       def params


### PR DESCRIPTION
Hello, `.to_sym` should never be applied on user input. Thus I recommend you to change `scheme` method:

```
  def scheme
    @scheme ||= parts.first.downcase.to_sym
  end
```
