### PR TITLE
Remove never called string

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -70,7 +70,6 @@ module Rack
       (qs || '').split(d ? /[#{d}] */n : DEFAULT_SEP).each do |p|
         next if p.empty?
         k, v = p.split('=', 2).map(&unescaper)
-        next unless k || v
 
         if cur = params[k]
           if cur.class == Array


### PR DESCRIPTION
Previous check `p.empty?` makes sure that p contains at least 1 symbol.
After `.split('=', 2)` k or v or both will turn into some string which means `k || v` will always return true and `next` will never be called.
