### PR TITLE
Added specific test when X-Forwarded-For is 'unknown'

### DIFF
--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -930,6 +930,11 @@ EOF
     res.body.should.equal '1.2.3.4'
 
     res = mock.get '/',
+      'REMOTE_ADDR' => '1.2.3.4',
+      'HTTP_X_FORWARDED_FOR' => 'unknown'
+    res.body.should.equal '1.2.3.4'
+
+    res = mock.get '/',
       'REMOTE_ADDR' => '127.0.0.1',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
     res.body.should.equal '3.4.5.6'


### PR DESCRIPTION
The new version of Squid sets X-Forwarded-For to 'unkown' by default.
This currently is a problem in Rails 3, fortunately not in Rack.
Added this test for regression purposes only.
Also see http://www.squid-cache.org/Doc/config/forwarded_for/

As requested by Konstantin :)
