### PR TITLE
Stop overwriting existing pidfiles.

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -329,8 +329,11 @@ module Rack
       end
 
       def write_pid
-        ::File.open(options[:pid], 'w'){ |f| f.write("#{Process.pid}") }
+        ::File.open(options[:pid], ::File::CREAT | ::File::EXCL | ::File::WRONLY ){ |f| f.write("#{Process.pid}") }
         at_exit { ::File.delete(options[:pid]) if ::File.exist?(options[:pid]) }
+      rescue Errno::EEXIST
+        check_pid!
+        retry
       end
 
       def check_pid!


### PR DESCRIPTION
A race condition can arise when two servers are started simultaneously. Both
instances may complete the check for an existing pidfile before either one
writes it.

Now the pidfile is opened with `::File::EXCL`, which raises an error if the file
already exists. This error is handled by retrying the check and the write.
