### PR TITLE
Removed Rack::Session::Cookie::Reverse.

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -73,12 +73,6 @@ module Rack
         def decode(str); str; end
       end
 
-      # Reverse string encoding. (trollface)
-      class Reverse
-        def encode(str); str.reverse; end
-        def decode(str); str.reverse; end
-      end
-
       attr_reader :coder
 
       def initialize(app, options={})


### PR DESCRIPTION
- Is not used anywhere.
- Has no tests.
- Appears to be a joke (seriousface).
