### PR TITLE
fix invalid characters in multipart uploads

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -137,6 +137,9 @@ module Rack
         if filename && filename.scan(/%.?.?/).all? { |s| s =~ /%[0-9a-fA-F]{2}/ }
           filename = Utils.unescape(filename)
         end
+        if filename && String.method_defined?(:valid_encoding?) && !filename.valid_encoding?
+          filename = filename.chars.select { |char| char.valid_encoding? }.join
+        end
         if filename && filename !~ /\\[^\\"]/
           filename = filename.gsub(/\\(.)/, '\1')
         end

--- a/test/multipart/invalid_character
+++ b/test/multipart/invalid_character
@@ -1,0 +1,6 @@
+--AaB03x
+Content-Disposition: form-data; name="files"; filename="invalid√.txt"
+Content-Type: text/plain
+
+contents
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -166,6 +166,20 @@ describe Rack::Multipart do
     params["files"][:tempfile].read.should.equal "contents"
   end
 
+  should "parse multipart upload with filename with invalid characters" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:invalid_character))
+    params = Rack::Multipart.parse_multipart(env)
+    params["files"][:type].should.equal "text/plain"
+    params["files"][:filename].should.match(/invalid/)
+    head = "Content-Disposition: form-data; " +
+      "name=\"files\"; filename=\"invalid\xC3.txt\"\r\n" +
+      "Content-Type: text/plain\r\n"
+    head = head.force_encoding("ASCII-8BIT") if head.respond_to?(:force_encoding)
+    params["files"][:head].should.equal head
+    params["files"][:name].should.equal "files"
+    params["files"][:tempfile].read.should.equal "contents"
+  end
+
   should "not include file params if no file was selected" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:none))
     params = Rack::Multipart.parse_multipart(env)


### PR DESCRIPTION
Fixes invalid characters in multipart uploads by removing all characters which are not valid. Otherwise uploads with invalid characters raise an exception (ArgumentError: invalid byte sequence in UTF-8)
