### PR TITLE
Create an array when multiple instances of the same query parameter are used

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -108,7 +108,15 @@ module Rack
       return if k.empty?
 
       if after == ""
-        params[k] = v
+        if cur = params[k]
+          if cur.class == Array
+            params[k] << v
+          else
+            params[k] = [cur, v]
+          end
+        else
+          params[k] = v
+        end
       elsif after == "[]"
         params[k] ||= []
         raise TypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -134,7 +134,7 @@ describe Rack::Utils do
       should.equal "foo" => "\"bar\""
 
     Rack::Utils.parse_nested_query("foo=bar&foo=quux").
-      should.equal "foo" => "quux"
+      should.equal "foo" => ["bar", "quux"]
     Rack::Utils.parse_nested_query("foo&foo=").
       should.equal "foo" => ""
     Rack::Utils.parse_nested_query("foo=1&bar=2").
@@ -170,7 +170,7 @@ describe Rack::Utils do
     Rack::Utils.parse_nested_query("x[y][z][]=1").
       should.equal "x" => {"y" => {"z" => ["1"]}}
     Rack::Utils.parse_nested_query("x[y][z]=1&x[y][z]=2").
-      should.equal "x" => {"y" => {"z" => "2"}}
+      should.equal "x" => {"y" => {"z" => ["1", "2"]}}
     Rack::Utils.parse_nested_query("x[y][z][]=1&x[y][z][]=2").
       should.equal "x" => {"y" => {"z" => ["1", "2"]}}
 


### PR DESCRIPTION
This PR is sure to cause controversy, but it seems like broken behavior to disallow the ability for specifying multiple variables to create an array instead of having the last one win. I understand the use of the bracket hash notation and _maybe_ this could be modified to only operate on root variables instead of nested ones, but that seems just as broken/magical to me.
