### PR TITLE
prevent crash when cookie doesn't contain "--"

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -55,7 +55,7 @@ module Rack
 
         if @secret && session_data
           session_data, digest = session_data.split("--")
-          session_data = nil  unless Utils.secure_compare(digest, generate_hmac(session_data))
+          session_data = nil  unless session_data && digest && Utils.secure_compare(digest, generate_hmac(session_data))
         end
 
         begin

--- a/test/spec_rack_session_cookie.rb
+++ b/test/spec_rack_session_cookie.rb
@@ -52,6 +52,11 @@ context "Rack::Session::Cookie" do
     res = Rack::MockRequest.new(Rack::Session::Cookie.new(incrementor)).
       get("/", "HTTP_COOKIE" => "rack.session=blarghfasel")
     res.body.should.equal '{"counter"=>1}'
+
+    app = Rack::Session::Cookie.new(incrementor, :secret => 'test')
+    res = Rack::MockRequest.new(app).get("/", "HTTP_COOKIE" => "rack.session=")
+    res.body.should.equal '{"counter"=>1}'
+
   end
 
   bigcookie = lambda { |env|


### PR DESCRIPTION
This backports 881ce764f3fd70a20c5800892a132f1e6c8e7c50 so that rack won't crash when there isn't a "--" in the rack_session cookie
