### PR TITLE
Overlap un-compatibility previous param when parsing url query string

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -110,21 +110,30 @@ module Rack
       if after == ""
         params[k] = v
       elsif after == "[]"
-        params[k] ||= []
-        raise TypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
+        # Overlap un-compatibility previous
+        if params[k].nil? || !params[k].is_a?(Array)
+          params[k] = []
+        end
+
         params[k] << v
       elsif after =~ %r(^\[\]\[([^\[\]]+)\]$) || after =~ %r(^\[\](.+)$)
+        # Overlap un-compatibility previous
+        if params[k].nil? || !params[k].is_a?(Array)
+          params[k] = []
+        end
+
         child_key = $1
-        params[k] ||= []
-        raise TypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
         if params_hash_type?(params[k].last) && !params[k].last.key?(child_key)
           normalize_params(params[k].last, child_key, v)
         else
           params[k] << normalize_params(params.class.new, child_key, v)
         end
       else
-        params[k] ||= params.class.new
-        raise TypeError, "expected Hash (got #{params[k].class.name}) for param `#{k}'" unless params_hash_type?(params[k])
+        # Overlap un-compatibility previous
+        if params[k].nil? || !params_hash_type?(params[k])
+          params[k] = KeySpaceConstrainedParams.new
+        end
+
         params[k] = normalize_params(params[k], after, v)
       end
 


### PR DESCRIPTION
It should not raise exception when parsing url query string. Because rack should not restrict how user accesses resources. This pull request use _L2R_ principle for un-compatibility params overlap.
