### PR TITLE
Handle POST data with no Content-Type properly

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -164,13 +164,9 @@ module Rack
     # "application/x-www-form-urlencoded" or "multipart/form-data". The
     # list of form-data media types can be modified through the
     # +FORM_DATA_MEDIA_TYPES+ array.
-    #
-    # A request body is also assumed to contain form-data when no
-    # Content-Type header is provided and the request_method is POST.
     def form_data?
       type = media_type
-      meth = env["rack.methodoverride.original_method"] || env['REQUEST_METHOD']
-      (meth == 'POST' && type.nil?) || FORM_DATA_MEDIA_TYPES.include?(type)
+      FORM_DATA_MEDIA_TYPES.include?(type)
     end
 
     # Determine whether the request body contains data by checking


### PR DESCRIPTION
This commit fixes an issue with Rack where it erroneously assumes 
that a POST request with no Content-Type should be treated as 
"application/x-www-form-urlencoded" or "multipart/form-data" causing 
failures when binary data is posted.

This is related to the following Sinatra issue: 
https://github.com/sinatra/sinatra/issues/514

Section 7.2.1 of the HTTP/1.1 spec 
(http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1) says:

Any HTTP/1.1 message containing an entity-body SHOULD include a 
Content-Type header field defining the media type of that body. 
If and only if the media type is not given by a Content-Type field, 
the recipient MAY attempt to guess the media type via inspection of 
its content and/or the name extension(s) of the URI used to identify 
the resource. If the media type remains unknown, the recipient SHOULD 
treat it as type "application/octet-stream".

Please let me know if there are any questions/concerns over the change.

-Competent Hack
