### PR TITLE
Removed default pid file from help text

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -66,7 +66,7 @@ module Rack
             options[:daemonize] = d ? true : false
           }
 
-          opts.on("-P", "--pid FILE", "file to store PID (default: rack.pid)") { |f|
+          opts.on("-P", "--pid FILE", "file to store PID") { |f|
             options[:pid] = ::File.expand_path(f)
           }
 


### PR DESCRIPTION
The -h printed that the rack.pid is the default pidfile. However, there doesn't seem to be any default pid file at all. Removed the default comment from the help string.
