### PR TITLE
Add UnescapeError exception

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -37,14 +37,10 @@ module Rack
 
     # Unescapes a URI escaped string with +encoding+. +encoding+ will be the
     # target encoding of the string returned, and it defaults to UTF-8
-    if defined?(::Encoding)
-      def unescape(s, encoding = Encoding::UTF_8)
-        URI.decode_www_form_component(s, encoding)
-      end
-    else
-      def unescape(s, encoding = nil)
-        URI.decode_www_form_component(s, encoding)
-      end
+    def unescape(s, encoding = defined?(::Encoding) ? Encoding::UTF_8 : nil)
+      URI.decode_www_form_component(s, encoding)
+    rescue ArgumentError => e
+      raise UnescapeError, e.message
     end
     module_function :unescape
 
@@ -619,4 +615,6 @@ module Rack
     Multipart = Rack::Multipart
 
   end
+
+  class UnescapeError < ArgumentError; end
 end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -101,6 +101,14 @@ describe Rack::Utils do
       should.equal "q1!2\"'w$5&7/z8)?\\"
   end
 
+  should "raise exception on incorrect escape sequence" do
+    lambda {
+      Rack::Utils.unescape("25-04-2013%2:07:35")
+    }.should.raise(Rack::UnescapeError)
+    # Backward API compatibility check
+    Rack::UnescapeError.new.should.is_a(ArgumentError)
+  end
+
   should "parse query strings correctly" do
     Rack::Utils.parse_query("foo=bar").
       should.equal "foo" => "bar"


### PR DESCRIPTION
Raise UnescapeError exception instead of ArgumentError
when url has malformed escape sequence.

Currently there is no way to rescue malformed urls and take some custom actions because ArgumentError is too general.

Small refactoring as a bonus.
