### PR TITLE
Rack::URLMap should match on paths that include a file extension

### DIFF
--- a/lib/rack/urlmap.rb
+++ b/lib/rack/urlmap.rb
@@ -57,7 +57,8 @@ module Rack
         next unless m = match.match(path.to_s)
 
         rest = m[1]
-        next unless !rest || rest.empty? || rest[0] == ?/
+        comparison_path = rest.gsub(/\.\w+\Z/, '') # strip extension
+        next unless !comparison_path || comparison_path.empty? || comparison_path[0] == ?/
 
         env['SCRIPT_NAME'] = (script_name + location)
         env['PATH_INFO'] = rest

--- a/test/spec_urlmap.rb
+++ b/test/spec_urlmap.rb
@@ -32,6 +32,27 @@ describe Rack::URLMap do
     res["X-ScriptName"].should.equal "/foo"
     res["X-PathInfo"].should.equal "/"
 
+    res = Rack::MockRequest.new(map).get('/foo.json')
+    res.should.be.ok
+    res["X-ScriptName"].should.equal "/foo"
+    res["X-PathInfo"].should.equal ".json"
+
+    res = Rack::MockRequest.new(map).get('/foo.json/bar')
+    res.should.be.not_found
+
+    res = Rack::MockRequest.new(map).get('/foo.bar-json')
+    res.should.be.not_found
+
+    res = Rack::MockRequest.new(map).get('/foo/.json')
+    res.should.be.ok
+    res["X-ScriptName"].should.equal "/foo"
+    res["X-PathInfo"].should.equal "/.json"
+
+    res = Rack::MockRequest.new(map).get('/foo/bar.json')
+    res.should.be.ok
+    res["X-ScriptName"].should.equal "/foo/bar"
+    res["X-PathInfo"].should.equal ".json"
+
     res = Rack::MockRequest.new(map).get("/foo/bar")
     res.should.be.ok
     res["X-ScriptName"].should.equal "/foo/bar"


### PR DESCRIPTION
Requests to paths that included a file extension were not properly routing from
a URLMap. For example, the following URLMap:

Rack::URLMap.new('/widgets' => Widgets.new)

would fail to resolve 'GET /widgets.json', instead a 404 is returned. I wasn't 100% certain this behavior was correct as implemented. It would seem to make sense that file extensions should omitted when resolving the mapping.
