### PR TITLE
fix instance variable not initialized warning in Rack::Deflater::GzipStream

### DIFF
--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -68,6 +68,7 @@ module Rack
       def initialize(body, mtime)
         @body = body
         @mtime = mtime
+        @closed = false
       end
 
       def each(&block)


### PR DESCRIPTION
Found while testing changes in #554, I saw `deflater.rb:92: warning: instance variable @closed not initialized`. This removes the warning.
