### PR TITLE
Ensure request.POST always raises EOFError on bad input

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -201,7 +201,6 @@ module Rack
       elsif @env["rack.request.form_input"].eql? @env["rack.input"]
         @env["rack.request.form_hash"]
       elsif form_data? || parseable_data?
-        @env["rack.request.form_input"] = @env["rack.input"]
         unless @env["rack.request.form_hash"] = parse_multipart(env)
           form_vars = @env["rack.input"].read
 
@@ -214,6 +213,7 @@ module Rack
 
           @env["rack.input"].rewind
         end
+        @env["rack.request.form_input"] = @env["rack.input"]
         @env["rack.request.form_hash"]
       else
         {}

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -779,6 +779,20 @@ EOF
     lambda { req.POST }.should.raise(EOFError)
   end
 
+  should "consistently raise EOFError on bad multipart form data" do
+    input = <<EOF
+--AaB03x\r
+content-disposition: form-data; name="huge"; filename="huge"\r
+EOF
+    req = Rack::Request.new Rack::MockRequest.env_for("/",
+                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_LENGTH" => input.size,
+                      :input => input)
+
+    lambda { req.POST }.should.raise(EOFError)
+    lambda { req.POST }.should.raise(EOFError)
+  end
+
   should "correctly parse the part name from Content-Id header" do
     input = <<EOF
 --AaB03x\r


### PR DESCRIPTION
Before this fix, if you had a bad multipart request, request.POST would only raise EOFError the first time it was called, and would then return nil on subsequent invocations.  This would typically result in the cryptic "can't convert nil into Hash" as a result of calling request.params.

WDYT?
