### PR TITLE
Extract several methods from Rack::File#serving

### DIFF
--- a/lib/rack/file.rb
+++ b/lib/rack/file.rb
@@ -132,29 +132,23 @@ module Rack
     end
 
     # The MIME type for the contents of the file located at @path
-    #
-    # This method can be overridden to specify custom MIME types for certain files,
-    # or (in addition to response_body) to modify the content of files
-    # before serving them
     def mime_type
-      @mime_type ||= Mime.mime_type(F.extname(@path), @default_mime)
+      Mime.mime_type(F.extname(@path), @default_mime)
     end
 
     def filesize
       # If response_body is present, use its size.
-      @filesize ||= Rack::Utils.bytesize(response_body) if response_body
+      return Rack::Utils.bytesize(response_body) if response_body
 
       #   We check via File::size? whether this file provides size info
       #   via stat (e.g. /proc files often don't), otherwise we have to
       #   figure it out by reading the whole file into memory.
-      @filesize ||= F.size?(@path) || Utils.bytesize(F.read(@path))
+      F.size?(@path) || Utils.bytesize(F.read(@path))
     end
 
     # By default, the response body for file requests is nil.
     # In this case, the response body will be generated later
     # from the file at @path
-    #
-    # This method can be overridden to allow processing of files before serving.
     def response_body
       nil
     end


### PR DESCRIPTION
## Extracted methods:
- mime_type
- filesize
- response_body
## Motivation
1. The method is [somewhat complicated](codeclimate)
2. Extracting pieces of the method into their own functions really improves your ability to extend the class to customize it.
## Example of Customization

Let's say you have a basic Rack::Directory setup.

``` ruby
run Rack::Directory.new(".")
```

But you have a lot of markdown files in the directory, and you want to compile and render them on the fly. That requires modifying the mime type, the response body, and the filesize.

By extracting the methods out of `Rack::File#serving`, you only have to overwrite two methods (file_size is calculated based on the new `response_body`

The `config.ru` would look something like this:

``` ruby
require 'redcarpet'
require 'rack/mime'

def markdown_compiler
  Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)
end

class Rack::File
  # Overwrite
  def mime_type
    @mime ||= Rack::Mime.mime_type(F.extname(@path), @default_mime)
    markdown? ? 'text/html' : @mime
  end

  # Overwrite
  def response_body
    if markdown?
      @response_body ||= markdown_compiler.render(F.read(@path))
    else
      nil
    end
  end

  def markdown?
    F.extname(@path) == '.md'
  end
end

run Rack::Directory.new(".")
```
## Other stuff

This doesn't change the behavior of Rack, it just makes it easier to customize and to work on in the future. Because of that, I didn't write any tests. Let me know if I should.
