### PR TITLE
Modify GitHub pages domain

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -619,7 +619,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 == Links
 
-Rack:: <http://rack.github.com/>
+Rack:: <http://rack.github.io/>
 Official Rack repositories:: <http://github.com/rack>
 Rack Bug Tracking:: <http://github.com/rack/rack/issues>
 rack-devel mailing list:: <http://groups.google.com/group/rack-devel>

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -12,7 +12,7 @@ the simplest way possible, it unifies and distills the API for web
 servers, web frameworks, and software in between (the so-called
 middleware) into a single method call.
 
-Also see http://rack.github.com/.
+Also see http://rack.github.io/.
 EOF
 
   s.files           = Dir['{bin/*,contrib/*,example/*,lib/**/*,test/**/*}'] +
@@ -25,7 +25,7 @@ EOF
 
   s.author          = 'Christian Neukirchen'
   s.email           = 'chneukirchen@gmail.com'
-  s.homepage        = 'http://rack.github.com/'
+  s.homepage        = 'http://rack.github.io/'
   s.rubyforge_project = 'rack'
 
   s.add_development_dependency 'bacon'


### PR DESCRIPTION
Now this page is served as `rack.github.io`.
- https://github.com/blog/1452-new-github-pages-domain-github-io

If this PR is acceptable, could you update repository description?
![2013-06-11 20 32 19](https://f.cloud.github.com/assets/290782/636654/04f019fa-d28b-11e2-9c6a-49bf697132de.png)
