### PR TITLE
session's fetch method is not alias of []

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -60,7 +60,10 @@ module Rack
           load_for_read!
           @data[key.to_s]
         end
-        alias :fetch :[]
+
+        def fetch(key, default="")
+          self.[](key) || default
+        end
 
         def has_key?(key)
           load_for_read!


### PR DESCRIPTION
fetch should return default value when key not match any of keys.
