### PR TITLE
Set HttpOnly for cookies using :http_only

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -274,7 +274,7 @@ module Rack
         expires = "; expires=" +
           rfc2822(value[:expires].clone.gmtime) if value[:expires]
         secure = "; secure"  if value[:secure]
-        httponly = "; HttpOnly" if value[:httponly]
+        httponly = "; HttpOnly" if (value.key?(:httponly) ? value[:httponly] : value[:http_only])
         value = value[:value]
       end
       value = [value] unless Array === value

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -85,6 +85,18 @@ describe Rack::Response do
     response["Set-Cookie"].should.equal "foo=bar; HttpOnly"
   end
 
+  it "can set http only cookies with :http_only" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :http_only => true}
+    response["Set-Cookie"].should.equal "foo=bar; HttpOnly"
+  end
+
+  it "can set prefers :httponly for http only cookie setting when :httponly and :http_only provided" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :httponly => false, :http_only => true}
+    response["Set-Cookie"].should.equal "foo=bar"
+  end
+
   it "can delete cookies" do
     response = Rack::Response.new
     response.set_cookie "foo", "bar"


### PR DESCRIPTION
There's been a few times I've wanted to set HttpOnly on cookies and knowing [RFC 6265 specifies it as HttpOnly](http://tools.ietf.org/html/rfc6265#section-5.2.6) I regularly translate that as `:http_only` in my head due to the capitalization. However, this never works!

To that end I've added the ability to specify `:http_only` but with `:httponly` being preferred if it is specified so it should be non-breaking.
