### PR TITLE
dup object passed into block before appending it to parts

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -55,7 +55,7 @@ module Rack
 
       def digest_body(body)
         parts = []
-        body.each { |part| parts << part }
+        body.each { |part| parts << part.dup }
         string_body = parts.join
         digest = Digest::MD5.hexdigest(string_body) unless string_body.empty?
         [digest, parts]


### PR DESCRIPTION
This fixes #571. See issue for full details of what the actual bug is.
