### PR TITLE
Fix bug in sendfile.rb

### DIFF
--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -130,7 +130,7 @@ module Rack
           body = []
         when '', nil
         else
-          env['rack.errors'].puts "Unknown x-sendfile variation: '#{variation}'.\n"
+          env['rack.errors'].puts "Unknown x-sendfile variation: '#{type}'.\n"
         end
       end
       [status, headers, body]


### PR DESCRIPTION
The error message called `variation` without the env leading to an `ArgumentError`. It should call `type` instead.
