### PR TITLE
Use equal? to compare form_input to rack.input

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -204,7 +204,7 @@ module Rack
     def POST
       if @env["rack.input"].nil?
         raise "Missing rack.input"
-      elsif @env["rack.request.form_input"].eql? @env["rack.input"]
+      elsif @env["rack.request.form_input"].equal? @env["rack.input"]
         @env["rack.request.form_hash"]
       elsif form_data? || parseable_data?
         unless @env["rack.request.form_hash"] = parse_multipart(env)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -878,6 +878,21 @@ EOF
     lambda{ req.POST }.should.not.raise("input re-processed!")
   end
 
+  should "use form_hash when form_input is a Tempfile" do
+    input = "{foo: 'bar'}"
+
+    rack_input = Tempfile.new("rackspec")
+    rack_input.write(input)
+    rack_input.rewind
+
+    req = Rack::Request.new Rack::MockRequest.env_for("/",
+                      "rack.request.form_hash" => {'foo' => 'bar'},
+                      "rack.request.form_input" => rack_input,
+                      :input => rack_input)
+
+    req.POST.should.equal(req.env['rack.request.form_hash'])
+  end
+
   should "conform to the Rack spec" do
     app = lambda { |env|
       content = Rack::Request.new(env).POST["file"].inspect


### PR DESCRIPTION
I was having issues with rack-contrib's [PostBodyContentTypeParser](https://github.com/rack/rack-contrib/blob/master/lib/rack/contrib/post_body_content_type_parser.rb) when input was large enough to cause Puma and Thin to use Tempfiles as input. POST was not returning `env["rack.request_form_hash"]` as expected

I tracked the issue down to Rack::Request#POST's usage of `eql?`. It doesn't work for comparing tempfiles in 1.9 or 2.0. Changing it to `equal?` worked consistently on 1.8 and 1.9+ .

In 1.8, eql? compares Tempfiles correctly
In 1.9+, t.eql?(t) always returns false

In 1.8, == will change the position of the Tempfile.
In 1.9+, == compares Tempfiles correctly.

Using equal? provides consistent results of equality between 1.8, 1.9,
and 2.0 when comparing Tempfile objects.
