### PR TITLE
Allow specifying a default handler

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -53,7 +53,9 @@ module Rack
         Rack::Handler::FastCGI
       elsif ENV.include?("REQUEST_METHOD")
         Rack::Handler::CGI
-      else
+     elsif ENV.include?("RACK_HANDLER")
+        self.get(ENV["RACK_HANDLER"])
+     else
         pick ['thin', 'puma', 'webrick']
       end
     end


### PR DESCRIPTION
While it's nice that Rack tries to pick from a few common default handlers, we are in a situation where we need Puma in our Gemfile but DO NOT want it as our default handler in development. This allows us to specify our own default before Rack tries to pick one for us.
