### PR TITLE
Support instance and local vars in DSL via Docile gem

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -1,3 +1,5 @@
+require 'docile'
+
 module Rack
   # Rack::Builder implements a small DSL to iteratively construct Rack
   # applications.
@@ -52,7 +54,7 @@ module Rack
 
     def initialize(default_app = nil,&block)
       @use, @map, @run = [], nil, default_app
-      instance_eval(&block) if block_given?
+      Docile.dsl_eval(self, &block) if block_given?
     end
 
     def self.app(default_app = nil, &block)

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -28,6 +28,8 @@ EOF
   s.homepage        = 'http://rack.github.io/'
   s.rubyforge_project = 'rack'
 
+  s.add_dependency 'docile'
+
   s.add_development_dependency 'bacon'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This commit uses the Docile gem to make the Rack DSL handle
more Ruby usage cases, such as using instance and local
variables from within the context of the DSL.
