### PR TITLE
add delegate of to_io method for native function like rb_io_get_io.

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -432,7 +432,7 @@ module Rack
 
       REQUIRED_METHODS = [
         :read, :write, :read_nonblock, :write_nonblock, :flush, :close,
-        :close_read, :close_write, :closed?
+        :close_read, :close_write, :closed?, :to_io
       ]
 
       def_delegators :@io, *REQUIRED_METHODS


### PR DESCRIPTION
When I passed HijackWrapper instances to IO::select, it raises TypeError because this method calls rb_io_get_io, a native function, only accepts IO instances.
Add "to_io" method for converting the wrappers to IO instances automatically.
