### PR TITLE
Conditional get is causing exceptions during regular usage

### DIFF
--- a/lib/rack/conditionalget.rb
+++ b/lib/rack/conditionalget.rb
@@ -61,7 +61,16 @@ module Rack
     end
 
     def to_rfc2822(since)
-      Time.rfc2822(since) rescue nil
+      # shortest possible valid date is the obsolete: 1 Nov 97 09:55 A
+      # anything shorter is invalid, this avoids exceptions for common cases
+      # most common being the empty string
+      if since && since.length >= 16
+        # NOTE: there is no trivial way to write this in a non execption way
+        #   _rfc2822 returns a hash but is not that usable
+        Time.rfc2822(since) rescue nil
+      else
+        nil
+      end
     end
   end
 end


### PR DESCRIPTION
Conditional get is causing exceptions during regular usage, most commonly we see HTTP_IF_MODIFIED_SINCE set to the empty string. 

Caught this while profiling using rack-mini-profiler

```
Exceptions (2 raised during request)

ArgumentError not RFC 2822 compliant date: ""
/usr/local/rvm/rubies/ruby-2.0.0-p0-turbo/lib/ruby/2.0.0/time.rb:456:in `rfc2822'
/var/www/discourse/vendor/bundle/ruby/2.0.0/gems/rack-1.4.5/lib/rack/conditionalget.rb:64:in `to_rfc2822'
/var/www/discourse/vendor/bundle/ruby/2.0.0/gems/rack-1.4.5/lib/rack/conditionalget.rb:48:in `fresh?'
/var/www/discourse/vendor/bundle/ruby/2.0.0/gems/rack-1.4.5/lib/rack/conditionalget.rb:27:in `call'
```
