### PR TITLE
avoid copying entire payload twice just to hash it

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -55,10 +55,14 @@ module Rack
 
       def digest_body(body)
         parts = []
-        body.each { |part| parts << part }
-        string_body = parts.join
-        digest = Digest::MD5.hexdigest(string_body) unless string_body.empty?
-        [digest, parts]
+        digest = nil
+
+        body.each do |part|
+          parts << part
+          (digest ||= Digest::MD5.new) << part unless part.empty?
+        end
+
+        [digest && digest.hexdigest, parts]
       end
   end
 end


### PR DESCRIPTION
noticed this while profiling using the memory_profiler gem.

```
allocated memory by location
-----------------------------------
...
/home/sam/.rbenv/versions/ruby-head/lib/ruby/gems/2.1.0/gems/rack-1.4.5/lib/rack/etag.rb:59 x 60334
...
```

That line was the `.join` line luckily hmacs allow us to generate a hexdigest without creating a massive string. 
