### PR TITLE
Remove unused require rbconfig

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ task :default => [:test]
 desc "Install gem dependencies"
 task :deps do
   require 'rubygems'
-  require 'rbconfig'
   spec = Gem::Specification.load('rack.gemspec')
   spec.dependencies.each do |dep|
     reqs = dep.requirements_list


### PR DESCRIPTION
Rbconfig is no longer used in the :deps task, so no longer required
