### PR TITLE
Add Rack::Builder#warmup method for app preloading.

### DIFF
--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -130,6 +130,17 @@ describe Rack::Builder do
     Rack::MockRequest.new(app).get("/foo").should.be.server_error
   end
 
+  it "yields the generated app to a block for warmup" do
+    warmed_up_app = nil
+
+    app = Rack::Builder.new do
+      warmup { |a| warmed_up_app = a }
+      run lambda { |env| [200, {}, []] }
+    end.to_app
+
+    warmed_up_app.should.equal app
+  end
+
   should "initialize apps once" do
     app = builder do
       class AppClass


### PR DESCRIPTION
This new `warmup` method takes a block which is invoked after the app
is built. The block can be used to make mock requests that ensure
all application dependencies are loaded before the app starts
serving traffic.

With complex frameworks like Rails, many dependencies are auto-loaded
and data like mime-type and i18n is not loaded into memory by default. This
often means the first few requests handled by an application are quite
slow.

With this patch, config.ru can simply make requests via warmup to
exercise the app before it is used:

```
$ tail -4 config.ru
warmup do |app|
  client = Rack::MockRequest.new(app)
  client.get('/')
end
```
