### PR TITLE
Add colon to match common logger spec

### DIFF
--- a/lib/rack/commonlogger.rb
+++ b/lib/rack/commonlogger.rb
@@ -46,7 +46,7 @@ module Rack
       logger.write FORMAT % [
         env['HTTP_X_FORWARDED_FOR'] || env["REMOTE_ADDR"] || "-",
         env["REMOTE_USER"] || "-",
-        now.strftime("%d/%b/%Y %H:%M:%S %z"),
+        now.strftime("%d/%b/%Y:%H:%M:%S %z"),
         env["REQUEST_METHOD"],
         env["PATH_INFO"],
         env["QUERY_STRING"].empty? ? "" : "?"+env["QUERY_STRING"],

--- a/test/spec_commonlogger.rb
+++ b/test/spec_commonlogger.rb
@@ -67,7 +67,7 @@ describe Rack::CommonLogger do
     md = /- - - \[([^\]]+)\] "(\w+) \/ " (\d{3}) \d+ ([\d\.]+)/.match(log.string)
     md.should.not.equal nil
     time, method, status, duration = *md.captures
-    time.should.equal Time.at(0).strftime("%d/%b/%Y %H:%M:%S %z")
+    time.should.equal Time.at(0).strftime("%d/%b/%Y:%H:%M:%S %z")
     method.should.equal "GET"
     status.should.equal "200"
     (0..1).should.include?(duration.to_f)


### PR DESCRIPTION
Apache Common Logger uses a colon between the date and time, see http://httpd.apache.org/docs/1.3/logs.html#common and http://en.wikipedia.org/wiki/Common_Log_Format for examples. The lack of common breaks parsers that expect it (awstats is an example of this).
