### PR TITLE
handle authorization header without auth scheme

### DIFF
--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -21,7 +21,7 @@ module Rack
       end
 
       def scheme
-        @scheme ||= parts.first.downcase
+        @scheme ||= parts.first && parts.first.downcase
       end
 
       def params

--- a/lib/rack/auth/basic.rb
+++ b/lib/rack/auth/basic.rb
@@ -41,7 +41,7 @@ module Rack
 
       class Request < Auth::AbstractRequest
         def basic?
-          !parts.first.nil? && "basic" == scheme
+          "basic" == scheme
         end
 
         def credentials


### PR DESCRIPTION
Only `Rack::Auth::Basic` was handling this case, but it should be handled globally.
So that `Rack::Auth::Digest` and my rack-oauth2 gem will be fixed against this kind of request.
ref: https://github.com/nov/rack-oauth2/pull/38
