### PR TITLE
Add failing spec for parsing invalid query bytes

### DIFF
--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -204,6 +204,10 @@ describe Rack::Utils do
       message.should.equal "expected Array (got String) for param `y'"
   end
 
+  should "parse nested queries with invalid bytes correctly" do
+    Rack::Utils.parse_nested_query("fo\255[]=1")
+  end
+
   should "build query strings correctly" do
     Rack::Utils.build_query("foo" => "bar").should.be equal_query_to("foo=bar")
     Rack::Utils.build_query("foo" => ["bar", "quux"]).


### PR DESCRIPTION
One of our mobile client's has an intermittent bug which causes it to send requests with binary uploads, but with the `Content-Type` header incorrectly set to `application/x-www-form-urlencoded`. As a result when `Rack::Utils` attempts to parse the query params it throws an `ArgumentError: invalid byte sequence in UTF-8` exception. Here is the relevant slice of the stack trace:

```
[GEM_ROOT]/gems/rack-1.4.5/lib/rack/utils.rb:104:in `normalize_params`
[GEM_ROOT]/gems/rack-1.4.5/lib/rack/utils.rb:96:in `block in parse_nested_query`
[GEM_ROOT]/gems/rack-1.4.5/lib/rack/utils.rb:93:in `each`
[GEM_ROOT]/gems/rack-1.4.5/lib/rack/utils.rb:93:in `parse_nested_query`
[GEM_ROOT]/gems/rack-1.4.5/lib/rack/request.rb:332:in `parse_query`
[GEM_ROOT]/gems/actionpack-3.2.15/lib/action_dispatch/http/request.rb:275:in `parse_query`
[GEM_ROOT]/gems/rack-1.4.5/lib/rack/request.rb:209:in `POST`
```

I've looked into forcing an alternate encoding or swallowing the error, but there are a lot of different approaches possible, all with different support and performance considerations. Considering Rack supports Ruby 1.8 through 2.1 I would like some feedback on how you would approach the matter.

Some possible solutions I see are:
1. Strip any characters that aren't UTF-8 using either `String.encode` or `Iconv`, depending on Ruby version.
2. Catch the exception and skip parsing the params entirely.

Unfortunately I've seen this error thousands of times, and there is no way for me to stop the exception from happening inside my application's stack.
