### PR TITLE
Add a note to Rack::Utils.secure_compare doc

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -394,6 +394,11 @@ module Rack
     module_function :byte_ranges
 
     # Constant time string comparison.
+    #
+    # NOTE: the values compared should be of fixed length, such as strings
+    # that have aready been processed by HMAC.  This should not be used
+    # on variable length plaintext strings because it could leak length info
+    # via timing attacks.
     def secure_compare(a, b)
       return false unless bytesize(a) == bytesize(b)
 


### PR DESCRIPTION
I mistakenly used this to compare plaintext before.  Probably good
to warn others off.  The OpenSSL docs have a similar warning about
using 'fixed size'
