### PR TITLE
Revert-replace characters rather than removing them

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -136,7 +136,7 @@ module Rack
           filename = Utils.unescape(filename)
         end
         if filename.respond_to?(:valid_encoding?) && !filename.valid_encoding?
-          filename.encode!(:invalid => :replace)
+          filename = filename.chars.select { |char| char.valid_encoding? }.join
         end
         if filename && filename !~ /\\[^\\"]/
           filename = filename.gsub(/\\(.)/, '\1')


### PR DESCRIPTION
Revert- replace characters rather than removing them

Reason - It breaks with `ArgumentError: invalid byte sequence in UTF-8`

@tenderlove  - this PR is just for reference.
