### PR TITLE
chmod binaries to 755 instead of 775

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,8 +41,8 @@ end
 
 desc "Make binaries executable"
 task :chmod do
-  Dir["bin/*"].each { |binary| File.chmod(0775, binary) }
-  Dir["test/cgi/test*"].each { |binary| File.chmod(0775, binary) }
+  Dir["bin/*"].each { |binary| File.chmod(0755, binary) }
+  Dir["test/cgi/test*"].each { |binary| File.chmod(0755, binary) }
 end
 
 desc "Generate a ChangeLog"


### PR DESCRIPTION
I was looking at the Rakefile and noticed the chmod to 775. Unless there's some reason to give the group write permissions that I'm not aware of, 755 seems more appropriate to me.

\- Felix
