### PR TITLE
Handle params key encoding error.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -36,9 +36,9 @@ module Rack
     module_function :escape_path
 
     # Unescapes a URI escaped string with +encoding+. +encoding+ will be the
-    # target encoding of the string returned, and it defaults to UTF-8
+    # target encoding of the string returned, and it defaults to BINARY
     if defined?(::Encoding)
-      def unescape(s, encoding = Encoding::UTF_8)
+      def unescape(s, encoding = Encoding::BINARY)
         URI.decode_www_form_component(s, encoding)
       end
     else

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -143,6 +143,8 @@ describe Rack::Utils do
       should.equal "foo" => "bar"
     Rack::Utils.parse_nested_query("foo=\"bar\"").
       should.equal "foo" => "\"bar\""
+    lambda { Rack::Utils.parse_nested_query("nonsense%81Ekey=") }.
+      should.not.raise(ArgumentError)
 
     Rack::Utils.parse_nested_query("foo=bar&foo=quux").
       should.equal "foo" => "quux"


### PR DESCRIPTION
~~Explicitly raise error in case of encoding error.~~

Updated to default decode to binary. Fixes(?) #610.
