### PR TITLE
Add created? and accepted? response helper methods

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -122,6 +122,8 @@ module Rack
       def server_error?;       status >= 500 && status < 600;        end
 
       def ok?;                 status == 200;                        end
+      def created?;            status == 201;                        end
+      def accepted?;           status == 202;                        end
       def bad_request?;        status == 400;                        end
       def unauthorized?;       status == 401;                        end
       def forbidden?;          status == 403;                        end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -223,6 +223,14 @@ describe Rack::Response do
     res.should.be.successful
     res.should.be.ok
 
+    res.status = 201
+    res.should.be.successful
+    res.should.be.created
+
+    res.status = 202
+    res.should.be.successful
+    res.should.be.accepted
+
     res.status = 400
     res.should.not.be.successful
     res.should.be.client_error


### PR DESCRIPTION
Two helper methods for `Rack::Response`: `created?` and `accepted?` for 201 and 202 response codes respectively.

Hope this looks like a reasonable addition!
