### PR TITLE
unescape path on commonlogger

### DIFF
--- a/lib/rack/commonlogger.rb
+++ b/lib/rack/commonlogger.rb
@@ -47,7 +47,7 @@ module Rack
         env["REMOTE_USER"] || "-",
         now.strftime("%d/%b/%Y:%H:%M:%S %z"),
         env["REQUEST_METHOD"],
-        env["PATH_INFO"],
+        Utils.unescape(env["PATH_INFO"]),
         env["QUERY_STRING"].empty? ? "" : "?"+env["QUERY_STRING"],
         env["HTTP_VERSION"],
         status.to_s[0..3],

--- a/test/spec_commonlogger.rb
+++ b/test/spec_commonlogger.rb
@@ -35,6 +35,19 @@ describe Rack::CommonLogger do
     log.string.should =~ /"GET \/ " 200 #{length} /
   end
 
+  should "unescape the path" do
+
+    app1 = Rack::Lint.new lambda { |env|
+      env["PATH_INFO"] = ::Rack::Utils.escape(env["PATH_INFO"])
+      [200,
+        {"Content-Type" => "text/html", "Content-Length" => length.to_s},
+        [obj]]}
+
+    log = StringIO.new
+    Rack::MockRequest.new(Rack::CommonLogger.new(app1, log)).get("/favicon.ico")
+    log.string.should =~ /"GET \/favicon.ico " 200 #{length} /
+  end
+
   should "work with standartd library logger" do
     logdev = StringIO.new
     log = Logger.new(logdev)


### PR DESCRIPTION
### Problem

`Rack::File` unescape the file path, https://github.com/rack/rack/blob/master/lib/rack/file.rb#L41 , So the middleware that is setting that up is suppose to escape it, for instance on rails https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/static.rb#L24 .

The problem is, that the logger, doesn't unescape, and end up showing this log:

```
"GET %2Ffavicon.ico HTTP/1.1"
```
### Solution

call unescape before logging it.

[ref rails/rails#11816]
