### PR TITLE
Ensure Rack::Utils.best_q_match to respect requested content type

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -185,7 +185,7 @@ module Rack
       values = q_values(q_value_header)
 
       values.map do |req_mime, quality|
-        match = available_mimes.first { |am| Rack::Mime.match?(am, req_mime) }
+        match = available_mimes.find { |am| Rack::Mime.match?(am, req_mime) }
         next unless match
         [match, quality]
       end.compact.sort_by do |match, quality|

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -300,6 +300,9 @@ describe Rack::Utils do
     # Higher quality matches are preferred
     Rack::Utils.best_q_match("text/*;q=0.5,text/plain;q=1.0", %w[text/plain text/html]).should.equal "text/plain"
 
+    # Respect requested content type
+    Rack::Utils.best_q_match("application/json", %w[application/vnd.lotus-1-2-3 application/json]).should.equal "application/json"
+
     # All else equal, the available mimes are preferred in order
     Rack::Utils.best_q_match("text/*", %w[text/html text/plain]).should.equal "text/html"
     Rack::Utils.best_q_match("text/plain,text/html", %w[text/html text/plain]).should.equal "text/html"


### PR DESCRIPTION
I've tried to use this method like this:

``` ruby
Rack::Utils.best_q_match "application/json", Rack::Mime::MIME_TYPES.values
```

It was returning `"application/vnd.lotus-1-2-3"` instead of `"application/json"`.

Hint:

``` ruby
puts Rack::Mime::MIME_TYPES.values.first # => "application/vnd.lotus-1-2-3"
```
