### PR TITLE
Cleanup: Remove outdated comment in request.rb about instance-memoization

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -8,10 +8,6 @@ module Rack
   #   req = Rack::Request.new(env)
   #   req.post?
   #   req.params["data"]
-  #
-  # The environment hash passed will store a reference to the Request object
-  # instantiated so that it will only instantiate if an instance of the Request
-  # object doesn't already exist.
 
   class Request
     # The environment of the request.


### PR DESCRIPTION
Spotted an outdated doc-comment that was otherwise a bit confusing.
- Removed memoization in: 0bf8d8e840ae226d6efed8af345feb67a10f6aa6
- Added memoization + comment in: eefbed89c4ece749e889132012d0f67cd87926a8
