### PR TITLE
Simplified the URLMapping logic and added case insensitivity to domain matching

### DIFF
--- a/lib/rack/urlmap.rb
+++ b/lib/rack/urlmap.rb
@@ -48,11 +48,7 @@ module Rack
       sPort = env['SERVER_PORT']
 
       @mapping.each do |host, location, match, app|
-        unless hHost == host \
-            || sName == host \
-            || (!host && (hHost == sName || hHost == sName+':'+sPort))
-          next
-        end
+        next unless hHost && hHost.casecmp(host).zero? || sName.casecmp(host).zero? if host
 
         next unless m = match.match(path.to_s)
 
@@ -73,4 +69,3 @@ module Rack
     end
   end
 end
-

--- a/test/spec_urlmap.rb
+++ b/test/spec_urlmap.rb
@@ -100,7 +100,15 @@ describe Rack::URLMap do
     res.should.be.ok
     res["X-Position"].should.equal "bar.org"
 
+    res = Rack::MockRequest.new(map).get("/", "HTTP_HOST" => "Bar.org")
+    res.should.be.ok
+    res["X-Position"].should.equal "bar.org"
+
     res = Rack::MockRequest.new(map).get("/", "HTTP_HOST" => "foo.org")
+    res.should.be.ok
+    res["X-Position"].should.equal "foo.org"
+
+    res = Rack::MockRequest.new(map).get("/", "HTTP_HOST" => "Foo.org")
     res.should.be.ok
     res["X-Position"].should.equal "foo.org"
 
@@ -108,7 +116,15 @@ describe Rack::URLMap do
     res.should.be.ok
     res["X-Position"].should.equal "subdomain.foo.org"
 
+    res = Rack::MockRequest.new(map).get("/", "HTTP_HOST" => "Subdomain.foo.org", "SERVER_NAME" => "Foo.org")
+    res.should.be.ok
+    res["X-Position"].should.equal "subdomain.foo.org"
+
     res = Rack::MockRequest.new(map).get("http://foo.org/")
+    res.should.be.ok
+    res["X-Position"].should.equal "foo.org"
+
+    res = Rack::MockRequest.new(map).get("http://Foo.org/")
     res.should.be.ok
     res["X-Position"].should.equal "foo.org"
 
@@ -116,8 +132,18 @@ describe Rack::URLMap do
     res.should.be.ok
     res["X-Position"].should.equal "default.org"
 
+    res = Rack::MockRequest.new(map).get("/", "HTTP_HOST" => "Example.org")
+    res.should.be.ok
+    res["X-Position"].should.equal "default.org"
+
     res = Rack::MockRequest.new(map).get("/",
                                          "HTTP_HOST" => "example.org:9292",
+                                         "SERVER_PORT" => "9292")
+    res.should.be.ok
+    res["X-Position"].should.equal "default.org"
+
+    res = Rack::MockRequest.new(map).get("/",
+                                         "HTTP_HOST" => "Example.org:9292",
                                          "SERVER_PORT" => "9292")
     res.should.be.ok
     res["X-Position"].should.equal "default.org"


### PR DESCRIPTION
So we recently ran into a bug and realized that the domain matching in Rack::URLMap is case-sensitive, ahhhhh!!!! 

Anyway, I fixed it.

While exercising the tests I realized this bit <code>(!host && (hHost == sName || hHost == sName+':'+sPort))</code> was a case never hit; is there something that I'm missing/breaking by taking it out? All the tests are green.
