### PR TITLE
request.port supports multiple x-http-forwarded-proto values

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -97,7 +97,7 @@ module Rack
       elsif @env.has_key?("HTTP_X_FORWARDED_HOST")
         DEFAULT_PORTS[scheme]
       elsif @env.has_key?("HTTP_X_FORWARDED_PROTO")
-        DEFAULT_PORTS[@env['HTTP_X_FORWARDED_PROTO']]
+        DEFAULT_PORTS[@env['HTTP_X_FORWARDED_PROTO'].split(',')[0]]
       else
         @env["SERVER_PORT"].to_i
       end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -96,7 +96,10 @@ describe Rack::Request do
 
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost", "HTTP_X_FORWARDED_PROTO" => "https", "SERVER_PORT" => "80")
+    req.port.should.equal 443
 
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost", "HTTP_X_FORWARDED_PROTO" => "https,https", "SERVER_PORT" => "80")
     req.port.should.equal 443
   end
 


### PR DESCRIPTION
Adds similar logic from `Rack::Request#scheme` to the `Rack::Request#port`
method. `X-HTTP-FORWARDED-PROTO` may have multiple comma-separated values if
the request passed through multiple reverse proxies.
