### PR TITLE
add quiet mode of rack server, rackup --quiet

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -30,6 +30,9 @@ module Rack
           opts.on("-w", "--warn", "turn warnings on for your script") {
             options[:warn] = true
           }
+          opts.on("-q", "--quiet", "turn off logging") {
+            options[:quiet] = true
+          }
 
           opts.on("-I", "--include PATH",
                   "specify $LOAD_PATH (may be used more than once)") { |path|
@@ -208,7 +211,7 @@ module Rack
     class << self
       def logging_middleware
         lambda { |server|
-          server.server.name =~ /CGI/ ? nil : [Rack::CommonLogger, $stderr]
+          server.server.name =~ /CGI/ || server.options[:quiet] ? nil : [Rack::CommonLogger, $stderr]
         }
       end
 

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -61,6 +61,11 @@ describe Rack::Server do
     end
   end
 
+  should "be quiet if said so" do
+    server = Rack::Server.new(:app => "FOO", :quiet => true)
+    Rack::Server.logging_middleware.call(server).should.eql(nil)
+  end
+
   should "not force any middleware under the none configuration" do
     server = Rack::Server.new(:app => 'foo')
     server.default_middleware_by_environment['none'].should.be.empty


### PR DESCRIPTION
Rack server should be able to not log every request if `rackup` is run with `-q` or `--quiet` switch. This mode would be useful with applications that provide own logging features.

Ref: https://www.google.ru/search?q=disable+rack+commonlogger
