### PR TITLE
ShowException serves HTML only when accepted

### DIFF
--- a/lib/rack/showexceptions.rb
+++ b/lib/rack/showexceptions.rb
@@ -43,8 +43,16 @@ module Rack
     end
 
     def prefers_plain_text?(env)
-      env["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest" && (!env["HTTP_ACCEPT"] || !env["HTTP_ACCEPT"].include?("text/html"))
+      !prefers_html?(env)
     end
+
+    def prefers_html?(env)
+      Rack::Utils.best_q_match(
+        env.fetch("HTTP_ACCEPT", ""),
+        %w(text/plain text/html)
+      ) == "text/html"
+    end
+    private :prefers_html?
 
     def dump_exception(exception)
       string = "#{exception.class}: #{exception.message}\n"


### PR DESCRIPTION
Rather than be concerned with whether a request is an asynchronous browser
request or not it is better to simply consider the Accept header and only serve
HTML to clients that specifically ask for it.

This way you will not find your pure JSON API application splitting out HTML
error messages to your console when using curl :)
