### PR TITLE
allow configuration of multipart cutoff

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -2,6 +2,8 @@ require 'rack/utils'
 
 module Rack
   module Multipart
+    class MultipartPartLiimitError < Errno::EMFILE; end
+
     class Parser
       BUFSIZE = 16384
 
@@ -44,7 +46,13 @@ module Rack
       def parse
         fast_forward_to_first_boundary
 
+        opened_files = 0
         loop do
+          if Utils.multipart_part_limit > 0
+            raise MultipartPartLiimitError, 'Maximum file multiparts in content reached' if opened_files >= Utils.multipart_part_limit
+            opened_files += 1
+          end
+
           head, filename, content_type, name, body =
             get_current_head_and_filename_and_content_type_and_name_and_body
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -61,11 +61,17 @@ module Rack
 
     class << self
       attr_accessor :key_space_limit
+      attr_accessor :multipart_part_limit
     end
 
     # The default number of bytes to allow parameter keys to take up.
     # This helps prevent a rogue client from flooding a Request.
     self.key_space_limit = 65536
+
+    # The maximum number of parts a request can contain. Accepting to many part
+    # can lead to the server running out of file handles.
+    # Set to `0` for no limit.
+    self.multipart_part_limit = (ENV['RACK_MULTIPART_PART_LIMIT'] || 128).to_i
 
     # Stolen from Mongrel, with some small modifications:
     # Parses a query string by breaking it up at the '&'

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -436,22 +436,29 @@ Content-Type: image/jpeg\r
   end
 
   it "builds complete params with the chunk size of 16384 slicing exactly on boundary" do
-    data = File.open(multipart_file("fail_16384_nofile"), 'rb') { |f| f.read }.gsub(/\n/, "\r\n")
-    options = {
-      "CONTENT_TYPE" => "multipart/form-data; boundary=----WebKitFormBoundaryWsY0GnpbI5U7ztzo",
-      "CONTENT_LENGTH" => data.length.to_s,
-      :input => StringIO.new(data)
-    }
-    env = Rack::MockRequest.env_for("/", options)
-    params = Rack::Multipart.parse_multipart(env)
+    begin
+      previous_limit = Rack::Utils.multipart_part_limit
+      Rack::Utils.multipart_part_limit = 256
 
-    params.should.not.equal nil
-    params.keys.should.include "AAAAAAAAAAAAAAAAAAA"
-    params["AAAAAAAAAAAAAAAAAAA"].keys.should.include "PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"
-    params["AAAAAAAAAAAAAAAAAAA"]["PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"].keys.should.include "new"
-    params["AAAAAAAAAAAAAAAAAAA"]["PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"]["new"].keys.should.include "-2"
-    params["AAAAAAAAAAAAAAAAAAA"]["PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"]["new"]["-2"].keys.should.include "ba_unit_id"
-    params["AAAAAAAAAAAAAAAAAAA"]["PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"]["new"]["-2"]["ba_unit_id"].should.equal "1017"
+      data = File.open(multipart_file("fail_16384_nofile"), 'rb') { |f| f.read }.gsub(/\n/, "\r\n")
+      options = {
+        "CONTENT_TYPE" => "multipart/form-data; boundary=----WebKitFormBoundaryWsY0GnpbI5U7ztzo",
+        "CONTENT_LENGTH" => data.length.to_s,
+        :input => StringIO.new(data)
+      }
+      env = Rack::MockRequest.env_for("/", options)
+      params = Rack::Multipart.parse_multipart(env)
+
+      params.should.not.equal nil
+      params.keys.should.include "AAAAAAAAAAAAAAAAAAA"
+      params["AAAAAAAAAAAAAAAAAAA"].keys.should.include "PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"
+      params["AAAAAAAAAAAAAAAAAAA"]["PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"].keys.should.include "new"
+      params["AAAAAAAAAAAAAAAAAAA"]["PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"]["new"].keys.should.include "-2"
+      params["AAAAAAAAAAAAAAAAAAA"]["PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"]["new"]["-2"].keys.should.include "ba_unit_id"
+      params["AAAAAAAAAAAAAAAAAAA"]["PLAPLAPLA_MEMMEMMEMM_ATTRATTRER"]["new"]["-2"]["ba_unit_id"].should.equal "1017"
+    ensure
+      Rack::Utils.multipart_part_limit = previous_limit
+    end
   end
 
   should "return nil if no UploadedFiles were used" do

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -2,6 +2,7 @@ require 'stringio'
 require 'cgi'
 require 'rack/request'
 require 'rack/mock'
+require 'securerandom'
 
 describe Rack::Request do
   should "wrap the rack variables" do
@@ -742,6 +743,22 @@ EOF
     f[:filename].should.equal "dj.jpg"
     f.should.include :tempfile
     f[:tempfile].size.should.equal 76
+  end
+
+  should "MultipartPartLiimitError when request has too many multipart parts if limit set" do
+    begin
+      data = 10000.times.map { "--AaB03x\r\nContent-Type: text/plain\r\nContent-Disposition: attachment; name=#{SecureRandom.hex(10)}; filename=#{SecureRandom.hex(10)}\r\n\r\ncontents\r\n" }.join("\r\n")
+      data += "--AaB03x--\r"
+
+      options = {
+        "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+        "CONTENT_LENGTH" => data.length.to_s,
+        :input => StringIO.new(data)
+      }
+
+      request = Rack::Request.new Rack::MockRequest.env_for("/", options)
+      lambda { request.POST }.should.raise(Rack::Multipart::MultipartPartLiimitError)
+    end
   end
 
   should "parse big multipart form data" do


### PR DESCRIPTION
Currently it's possible that a very large multi-file upload can run a server out of available file handles. 

I realize that setting a specific cut off for everybody is too restricting, but I think it'd be very useful to set a configurable point after which rack will stop handling new parts (and thus creating new tempfiles).

/cc @camilo, @arthurnn, @bslobodin
