### PR TITLE
Rack::ContentLength needs to support Rack::BodyProxy

### DIFF
--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -18,9 +18,14 @@ module Rack
       if !STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i) &&
          !headers['Content-Length'] &&
          !headers['Transfer-Encoding'] &&
-         body.respond_to?(:to_ary)
+         (body.respond_to?(:to_ary) || body.respond_to?(:body))
 
-        obody = body
+        if body.respond_to?(:to_ary)
+          obody = body
+        else
+          obody = body.body
+        end
+
         body, length = [], 0
         obody.each { |part| body << part; length += bytesize(part) }
 


### PR DESCRIPTION
Hi there.  I work for a client that continues to maintain a SOAP interface via XMLBuilder templates.  They have an issue whereby Rack::ContentLength is not setting the 'Content-Length' header for responses built in such a manner (causing all manner of downstream hangs and slowdowns).  

I noticed this back on a version of rack for use on their Rails 3.0.x app but thought this may disappear with the rewrite performed for 3.2.x.  Doesn't appear to have gone away and in fact it looks as though Rack::BodyProxy expressly avoids defining 'to_ary' so I thought I'd provide a patch.  I've also included a spec that exercises this patch successfully.  Here's a sample XMLBuilder template:

```
xml.instruct! :xml, :version => "1.0", :encoding => "UTF-8"
@XMLNS_SOAP = "http://schemas.xmlsoap.org/wsdl/soap/"
xml.soap :Envelope, {"xmlns:soap" => @XMLNS_SOAP} do
  xml.soap :Body do
    # small hack to create tag by the name of these variables -- better way to do this?
    xml.method_missing(@response_element) do
      xml.method_missing(@result_element, @result_value.to_s)
    end
  end
end
```

Any thoughts would be appreciated.  Cheers.
