### PR TITLE
add support for application/json content type requests

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -148,7 +148,8 @@ module Rack
     # for form-data / param parsing.
     FORM_DATA_MEDIA_TYPES = [
       'application/x-www-form-urlencoded',
-      'multipart/form-data'
+      'multipart/form-data',
+      'application/json'
     ]
 
     # The set of media-types. Requests that do not indicate
@@ -372,7 +373,12 @@ module Rack
       end
 
       def parse_query(qs)
-        Utils.parse_nested_query(qs)
+        case media_type
+        when 'application/json'
+          (qs && qs != '') ? ::Rack::Utils::OkJson.decode(qs) : {}
+        else
+          Utils.parse_nested_query(qs)
+        end
       end
 
       def parse_multipart(env)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -247,6 +247,16 @@ describe Rack::Request do
     input.read.should.equal "foo=bar&quux=bla"
   end
 
+  should "accept application/json content type" do
+    input = StringIO.new('{"foo":"bar","quxx":"bla"}')
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/",
+        "CONTENT_TYPE" => 'application/json',
+        :input => input)
+    req.params.should.equal "foo" => "bar", "quxx" => "bla"
+    input.read.should.equal '{"foo":"bar","quxx":"bla"}'
+  end
+
   should "clean up Safari's ajax POST body" do
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/",


### PR DESCRIPTION
Don't see any reason why Rack should not support application/json content types. This adds support for it, test included.
