### PR TITLE
Refactor methodoverride to make it easier to inherit and extend

### DIFF
--- a/lib/rack/methodoverride.rb
+++ b/lib/rack/methodoverride.rb
@@ -10,7 +10,7 @@ module Rack
     end
 
     def call(env)
-      if env["REQUEST_METHOD"] == "POST"
+      if allowed_methods.include?(env["REQUEST_METHOD"])
         method = method_override(env)
         if HTTP_METHODS.include?(method)
           env["rack.methodoverride.original_method"] = env["REQUEST_METHOD"]
@@ -23,9 +23,19 @@ module Rack
 
     def method_override(env)
       req = Request.new(env)
-      method = req.POST[METHOD_OVERRIDE_PARAM_KEY] ||
+      method = method_override_param(req) ||
         env[HTTP_METHOD_OVERRIDE_HEADER]
       method.to_s.upcase
+    end
+
+    private
+
+    def allowed_methods
+      ["POST"]
+    end
+
+    def method_override_param(req)
+      req.POST[METHOD_OVERRIDE_PARAM_KEY]
     end
   end
 end


### PR DESCRIPTION
The purpose of this refactor is to make it simpler to inherit from Rack::MethodOverride and enable method override for methods other than POST.

For example consider an app which needs to respond to `jsonp` requests such as Stripe (See also https://stripe.com/blog/stripejs-and-jsonp)

With this change you can now do

``` ruby
# app/middleware/bongloy/methodoverride.rb
module Bongloy
  class MethodOverride < ::Rack::MethodOverride

  private

  def allowed_methods
    super + ["GET"]
  end

  def method_override_param(req)
    super || req.GET[METHOD_OVERRIDE_PARAM_KEY]
  end
end
```

``` ruby
# config/application.rb

config.middleware.swap(Rack::MethodOverride, "Bongloy::MethodOverride")
```
