### PR TITLE
Utils.build_nested_query to handle empty arrays and hashes

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -159,7 +159,7 @@ module Rack
       when Hash
         value.map { |k, v|
           build_nested_query(v, prefix ? "#{prefix}[#{escape(k)}]" : escape(k))
-        }.join("&")
+        }.reject(&:empty?).join('&')
       when String
         raise ArgumentError, "value must be a Hash" if prefix.nil?
         "#{prefix}=#{escape(value)}"

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -240,6 +240,14 @@ describe Rack::Utils do
       should.equal "foo[]="
     Rack::Utils.build_nested_query("foo" => ["bar"]).
       should.equal "foo[]=bar"
+    Rack::Utils.build_nested_query('foo' => []).
+      should.equal ''
+    Rack::Utils.build_nested_query('foo' => {}).
+      should.equal ''
+    Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => []).
+      should.equal 'foo=bar'
+    Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => {}).
+      should.equal 'foo=bar'
 
     # The ordering of the output query string is unpredictable with 1.8's
     # unordered hash. Test that build_nested_query performs the inverse


### PR DESCRIPTION
Hello,

In master we have the following:

``` ruby
Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => []) #=> "foo=bar&"
Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => {}) #=> "foo=bar&"
```

The pull request turns it into:

``` ruby
Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => []) #=> "foo=bar"
Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => {}) #=> "foo=bar"
```

Regards,
Ivan
