### PR TITLE
Prevent IP spoofing via X-Forwarded-For and Client-IP headers

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -353,12 +353,6 @@ module Rack
 
       forwarded_ips = split_ip_addresses(@env['HTTP_X_FORWARDED_FOR'])
 
-      if client_ip = @env['HTTP_CLIENT_IP']
-        # If forwarded_ips doesn't include the client_ip, it might be an
-        # ip spoofing attempt, so we ignore HTTP_CLIENT_IP
-        return client_ip if forwarded_ips.include?(client_ip)
-      end
-
       return reject_trusted_ip_addresses(forwarded_ips).last || @env["REMOTE_ADDR"]
     end
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1037,12 +1037,6 @@ EOF
       'HTTP_CLIENT_IP' => '1.1.1.1'
     res.body.should.equal '1.1.1.1'
 
-    # Spoofing attempt
-    res = mock.get '/',
-      'HTTP_X_FORWARDED_FOR' => '1.1.1.1',
-      'HTTP_CLIENT_IP' => '2.2.2.2'
-    res.body.should.equal '1.1.1.1'
-
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '8.8.8.8, 9.9.9.9'
     res.body.should.equal '9.9.9.9'
 
@@ -1059,6 +1053,24 @@ EOF
       'REMOTE_ADDR' => 'unix:/tmp/foo',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
     res.body.should.equal '3.4.5.6'
+  end
+
+  should "not allow IP spoofing via Client-IP and X-Forwarded-For headers" do
+    mock = Rack::MockRequest.new(Rack::Lint.new(ip_app))
+
+    # IP Spoofing attempt:
+    # Client sends          X-Forwarded-For: 6.6.6.6
+    #                       Client-IP: 6.6.6.6
+    # Load balancer adds    X-Forwarded-For: 2.2.2.3, 192.168.0.7
+    # App receives:         X-Forwarded-For: 6.6.6.6
+    #                       X-Forwarded-For: 2.2.2.3, 192.168.0.7
+    #                       Client-IP: 6.6.6.6
+    # Rack env:             HTTP_X_FORWARDED_FOR: '6.6.6.6, 2.2.2.3, 192.168.0.7'
+    #                       HTTP_CLIENT_IP: '6.6.6.6'
+    res = mock.get '/',
+      'HTTP_X_FORWARDED_FOR' => '6.6.6.6, 2.2.2.3, 192.168.0.7',
+      'HTTP_CLIENT_IP' => '6.6.6.6'
+    res.body.should.equal '2.2.2.3'
   end
 
   should "regard local addresses as proxies" do


### PR DESCRIPTION
By specifying the same IP address in `X-Forwarded-For` and `Client-IP` an attacker is able to easily spoof the value of `request.ip`. This affects deployments where a proxy is involved (where `REMOTE_ADDR` is recognised as a trusted proxy) and that proxy isn't configured to remove any `Client-IP` headers.

To reproduce `curl -IH 'X-Forwarded-For: 6.6.6.6' -H 'Client-IP: 6.6.6.6' http://site` and observe that the log entry includes 6.6.6.6 as the request IP.

In setups where a proxy is involved, the value of `request.ip` should be the IP address after the last trusted proxy IP address in `X-Forwarded-For` (from right to left). I don't see any specs covering when Client-IP should be returned from `request.ip`, only a spec covering the ip spoofing protection logic, which is trivial to work around. Does anyone know why Client-IP is involved here?

This change to rack was introduced in https://github.com/rack/rack/pull/192. The logic appears to have originally come from this commit in Rails back in 2008 https://github.com/rails/rails/commit/edfa195e2ace7b4fb.

If there is a need to support forwarding headers other than `X-Forwarded-For`, I think that should be something that can be configured or overridden (defaulting to `X-Forwarded-For`), not something we should have to guess based on headers present in each request.
