### PR TITLE
Fix webrick handling of Transfer-encoding: chunked

### DIFF
--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -74,6 +74,10 @@ module Rack
           headers.each { |k, vs|
             next if k.downcase == "rack.hijack"
 
+            if k.downcase == "transfer-encoding" && vs == "chunked"
+              res.chunked = true
+            end
+
             if k.downcase == "set-cookie"
               res.cookies.concat vs.split("\n")
             else

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -162,5 +162,22 @@ describe Rack::Handler::WEBrick do
     }
   end
 
+  should "set transfer-encoding chunked via #chunked=" do
+    @server.mount "/chunked", Rack::Handler::WEBrick,
+    Rack::Lint.new(lambda{ |req|
+      [
+        200,
+        {"Transfer-Encoding" => "chunked"},
+        ["7\r\nchunked\r\n0\r\n\r\n"]
+      ]
+    })
+
+    Net::HTTP.start(@host, @port){ |http|
+      res = http.get("/chunked")
+      res["transfer-encoding"].should.equal "chunked"
+      res["content-length"].should.equal nil
+    }
+  end
+
   @server.shutdown
 end


### PR DESCRIPTION
WEBrick assumes that chunked will be set on the response using
the `#chunked=` method and doesn't respect setting the header
manually. Patch the webrick handler to set chunked on the response
in addition to setting the header. This prevents WEBrick from
calculating the content-length itself causing issues with Safari.

Fixes #618

I think this is probably a WEBrick issue which I have raised.
See: https://bugs.ruby-lang.org/issues/9986

However this patch to rack will also fix this issue for older and current
versions of Ruby (and in the future if my issue on ruby-lang continues
    to be rejected)

As I commented in #616 this issue can be replicated with the following rackup file:

``` ruby
require 'rack'

class HelloWorld
  def self.call(env)
    [200, {'Content-Type' => 'text/plain'}, ['Hello World']]
  end
end

class Rack::Server
  def middleware
    Hash.new([])
  end
end

use Rack::Chunked # removing this makes it work in Safari
run HelloWorld
```

And the response headers from this are:

```
ᐅ curl -I http://localhost:9292
HTTP/1.1 200 OK
Content-Type: text/plain
Transfer-Encoding: chunked
Server: WEBrick/1.3.1 (Ruby/2.1.2/2014-05-08)
Date: Fri, 27 Jun 2014 14:51:04 GMT
Content-Length: 21
Connection: Keep-Alive
```
