### PR TITLE
Fix spec_request on ruby-trunk (2.2.0dev)

### DIFF
--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -143,7 +143,7 @@ describe Rack::Request do
   end
 
   should "limit the key size per nested params hash" do
-    nested_query = Rack::MockRequest.env_for("/?foo[bar][baz][qux]=1")
+    nested_query = Rack::MockRequest.env_for("/?foo%5Bbar%5D%5Bbaz%5D%5Bqux%5D=1")
     plain_query  = Rack::MockRequest.env_for("/?foo_bar__baz__qux_=1")
 
     old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 3
@@ -1116,7 +1116,7 @@ EOF
   end
 
   should "raise TypeError every time if request parameters are broken" do
-    broken_query = Rack::MockRequest.env_for("/?foo[]=0&foo[bar]=1")
+    broken_query = Rack::MockRequest.env_for("/?foo%5B%5D=0&foo%5Bbar%5D=1")
     req = Rack::Request.new(broken_query)
     lambda{req.GET}.should.raise(TypeError)
     lambda{req.params}.should.raise(TypeError)


### PR DESCRIPTION
Manually percent-encode square brackets in query string. This fixes
current travis build issues.

2.2.0dev has recently changed URI parsing from RFC2396 to RFC3986.
Square brackets in RFC3986 are required to be percent-encoded when
present in the query string of a URI. URI.encode on 2.2.0dev isn't
currently updated to support this encoding (see:
    https://bugs.ruby-lang.org/issues/9990)
