### PR TITLE
Monkey patch to fix WEBrick chunking semantics.

### DIFF
--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -162,5 +162,23 @@ describe Rack::Handler::WEBrick do
     }
   end
 
+  should "produce correct HTTP semantics with and without app chunking" do
+    @server.mount "/chunked", Rack::Handler::WEBrick,
+    Rack::Lint.new(lambda{ |req|
+      [
+        200,
+        {"Transfer-Encoding" => "chunked"},
+        ["7\r\nchunked\r\n0\r\n\r\n"]
+      ]
+    })
+
+    Net::HTTP.start(@host, @port){ |http|
+      res = http.get("/chunked")
+      res["Transfer-Encoding"].should.equal "chunked"
+      res["Content-Length"].should.equal nil
+      res.body.should.equal "chunked"
+    }
+  end
+
   @server.shutdown
 end


### PR DESCRIPTION
- Previously proposed in #707, unfortunately that patch caused double encoding
- Fixes #707, #618
- The longevity of this patch is dubious. If WEBrick makes identical semantics
  modifications as I think should be done, this patch will have no effect. If
  WEBrick introduces changes to internal header handling, class structure, etc,
  we'll break.
