### PR TITLE
correct Request#port for lighttpd2 proxy case

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -100,6 +100,8 @@ module Rack
         port.to_i
       elsif @env.has_key?("HTTP_X_FORWARDED_HOST")
         DEFAULT_PORTS[scheme]
+      elsif @env.has_key?("HTTP_X_FORWARDED_PROTO")
+        DEFAULT_PORTS[@env['HTTP_X_FORWARDED_PROTO']]
       else
         @env["SERVER_PORT"].to_i
       end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -93,6 +93,11 @@ describe Rack::Request do
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "SERVER_PORT" => "9393")
     req.port.should.equal 80
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost", "HTTP_X_FORWARDED_PROTO" => "https", "SERVER_PORT" => "80")
+
+    req.port.should.equal 443
   end
 
   should "figure out the correct host with port" do


### PR DESCRIPTION
Apply fix to the 1.5 series for Rails 4 compatibility https://rubygems.org/gems/actionpack/versions/4.1.4

The [breaking commit was in the 1.5 series](https://github.com/rack/rack/commit/fe431e753224)
