### PR TITLE
default_middleware_by_environment should always returns empty array for unknown keys

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -213,23 +213,23 @@ module Rack
       end
 
       def default_middleware_by_environment
-        {
-          "deployment" => [
-            [Rack::ContentLength],
-            [Rack::Chunked],
-            logging_middleware,
-            [Rack::TempfileReaper]
-          ],
-          "development" => [
-            [Rack::ContentLength],
-            [Rack::Chunked],
-            logging_middleware,
-            [Rack::ShowExceptions],
-            [Rack::Lint],
-            [Rack::TempfileReaper]
-          ],
-          "none" => []
-        }
+        m = Hash.new {|h,k| h[k] = []}
+        m["deployment"] = [
+          [Rack::ContentLength],
+          [Rack::Chunked],
+          logging_middleware,
+          [Rack::TempfileReaper]
+        ]
+        m["development"] = [
+          [Rack::ContentLength],
+          [Rack::Chunked],
+          logging_middleware,
+          [Rack::ShowExceptions],
+          [Rack::Lint],
+          [Rack::TempfileReaper]
+        ]
+
+        m
       end
 
       # Aliased for backwards-compatibility

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -40,6 +40,11 @@ describe Rack::Server do
     server.default_middleware_by_environment['none'].flatten.should.not.include(Rack::ShowExceptions)
   end
 
+  should "always return an empty array for unknown environments" do
+    server = Rack::Server.new(:app => 'foo')
+    server.default_middleware_by_environment['production'].should.equal []
+  end
+
   should "include Rack::TempfileReaper in deployment environment" do
     server = Rack::Server.new(:app => 'foo')
     server.middleware['deployment'].flatten.should.include(Rack::TempfileReaper)
@@ -72,7 +77,7 @@ describe Rack::Server do
     FileUtils.rm pidfile
     server = Rack::Server.new(
       :app         => app,
-      :environment => 'none',
+      :environment => 'production',
       :pid         => pidfile,
       :Port        => TCPServer.open('127.0.0.1', 0){|s| s.addr[1] },
       :Host        => '127.0.0.1',


### PR DESCRIPTION
The current behaviour break rails server for any environment different of development.

This behaviour was removed at 704be37e with a warning that if this behavior is supported tests need to be added. The tests are already
there and they were not failing because "none" environment were added to the hash. This environment is not a valid environment and it is on the
tests exactly to assert the behaviour that `default_middleware_by_environment always` return an empty array for unknown keys.
