### PR TITLE
Fix media_type_params when Content-Type parameters contains quoted-strings

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -52,7 +52,7 @@ module Rack
       return {} if content_type.nil?
       Hash[*content_type.split(/\s*[;,]\s*/)[1..-1].
         collect { |s| s.split('=', 2) }.
-        map { |k,v| [k.downcase, v] }.flatten]
+        map { |k,v| [k.downcase, v.gsub(/\A"|"\z/, "")] }.flatten]
     end
 
     # The character set of the request body if a "charset" media type

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -611,7 +611,7 @@ describe Rack::Request do
   should "handle multiple media type parameters" do
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/",
-        "CONTENT_TYPE" => 'text/plain; foo=BAR,baz=bizzle dizzle;BLING=bam')
+        "CONTENT_TYPE" => 'text/plain; foo=BAR,baz=bizzle dizzle;BLING=bam;blong="boo";zump="zoo\"o"')
       req.should.not.be.form_data
       req.media_type_params.should.include 'foo'
       req.media_type_params['foo'].should.equal 'BAR'
@@ -620,6 +620,8 @@ describe Rack::Request do
       req.media_type_params.should.not.include 'BLING'
       req.media_type_params.should.include 'bling'
       req.media_type_params['bling'].should.equal 'bam'
+      req.media_type_params['blong'].should.equal 'boo'
+      req.media_type_params['zump'].should.equal 'zoo\"o'
   end
 
   should "parse with junk before boundry" do


### PR DESCRIPTION
According RFC 2616, Content-Type parameters value can be even a token or a quoted-string:

```
    media-type     = type "/" subtype *( ";" parameter )
    type           = token
    subtype        = token
    parameter      = attribute "=" value
    attribute      = token
    value          = token | quoted-string
    quoted-string  = ( <"> *(qdtext | quoted-pair ) <"> )
    qdtext         = <any TEXT except <">>"
    quoted-pair    = "\" CHAR
```
