### PR TITLE
Implement full Logger interface on NullLogger

### DIFF
--- a/lib/rack/nulllogger.rb
+++ b/lib/rack/nulllogger.rb
@@ -9,10 +9,29 @@ module Rack
       @app.call(env)
     end
 
-    def info(progname = nil, &block);  end
+    def info(progname = nil, &block); end
     def debug(progname = nil, &block); end
-    def warn(progname = nil, &block);  end
+    def warn(progname = nil, &block); end
     def error(progname = nil, &block); end
     def fatal(progname = nil, &block); end
+    def unknown(progname = nil, &block); end
+    def info? ;  end
+    def debug? ; end
+    def warn? ;  end
+    def error? ; end
+    def fatal? ; end
+    def level ; end
+    def progname ; end
+    def datetime_format ; end
+    def formatter ; end
+    def sev_threshold ; end
+    def level=(level); end
+    def progname=(progname); end
+    def datetime_format=(datetime_format); end
+    def formatter=(formatter); end
+    def sev_threshold=(sev_threshold); end
+    def close ; end
+    def add(severity, message = nil, progname = nil, &block); end
+    def <<(msg); end
   end
 end


### PR DESCRIPTION
NullLogger implements only a small subset of the Logger public
interface. In case you need to hack with your loggers a bit more than
usual the NullLogger is useless since it will raise NoMethodError all
the time.
