### PR TITLE
Avoid multipart dos

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -44,6 +44,8 @@ module Rack
       def parse
         fast_forward_to_first_boundary
 
+        limit_multiparts = ENV["multipart.limit"]
+        available_open_file_handles = limit_multiparts.to_i if limit_multiparts 
         loop do
           if limit_multiparts
             raise EOFError, "Maximum file multiparts in content reached" if available_open_file_handles == 0

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -756,9 +756,8 @@ EOF
       :input => StringIO.new(data)
     }
 
-    request = Rack::Request.new Rack::MockRequest.env_for("/", options)
-    lambda { request.POST }.should.raise(EOFError)
-
+    lambda { Rack::Request.new Rack::MockRequest.env_for("/", options) }.should.not.raise
+    
     ENV.delete("multipart.limit")
   end
 


### PR DESCRIPTION
We encountered issues with users uploading thousands of small files which resulted in exhausted file descriptors on the server triggering weird issues everywhere.

We believe this could be a nasty DOS vector.

Regards.

cc @orenmazor.
