### PR TITLE
Rack 1.5: app error: deadlock; recursive locking (ThreadError) with Rack::Deflater

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -207,7 +207,7 @@ but only contain keys that consist of
 letters, digits, <tt>_</tt> or <tt>-</tt> and start with a letter.
 The values of the header must be Strings,
 consisting of lines (for multiple header values, e.g. multiple
-<tt>Set-Cookie</tt> values) seperated by "\n".
+<tt>Set-Cookie</tt> values) separated by "\n".
 The lines must not contain characters below 037.
 === The Content-Type
 There must not be a <tt>Content-Type</tt>, when the +Status+ is 1xx,

--- a/lib/rack/backports/uri/common_18.rb
+++ b/lib/rack/backports/uri/common_18.rb
@@ -46,7 +46,7 @@ module URI
 
   # Decode given +str+ of URL-encoded form data.
   #
-  # This decods + to SP.
+  # This decodes + to SP.
   #
   # See URI.encode_www_form_component, URI.decode_www_form
   def self.decode_www_form_component(str, enc=nil)

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -79,13 +79,19 @@ module Rack
           gzip.flush
         }
       ensure
-        @body.close if @body.respond_to?(:close)
+        close
         gzip.close
         @writer = nil
       end
 
       def write(data)
         @writer.call(data)
+      end
+
+      def close
+        return if @closed
+        @closed = true
+        @body.close if @body.respond_to?(:close)
       end
     end
 
@@ -100,6 +106,7 @@ module Rack
 
       def initialize(body)
         @body = body
+        @closed = false
       end
 
       def each
@@ -108,8 +115,14 @@ module Rack
         yield deflater.finish
         nil
       ensure
+        close
+        deflator.close
+      end
+
+      def close
+        return if @closed
+        @closed = true
         @body.close if @body.respond_to?(:close)
-        deflater.close
       end
     end
   end

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -79,7 +79,6 @@ module Rack
           gzip.flush
         }
       ensure
-        close
         gzip.close
         @writer = nil
       end
@@ -115,7 +114,6 @@ module Rack
         yield deflater.finish
         nil
       ensure
-        close
         deflator.close
       end
 

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -109,9 +109,9 @@ module Rack
       end
 
       def each
-        deflater = ::Zlib::Deflate.new(*DEFLATE_ARGS)
-        @body.each { |part| yield deflater.deflate(part, Zlib::SYNC_FLUSH) }
-        yield deflater.finish
+        deflator = ::Zlib::Deflate.new(*DEFLATE_ARGS)
+        @body.each { |part| yield deflator.deflate(part, Zlib::SYNC_FLUSH) }
+        yield deflator.finish
         nil
       ensure
         deflator.close

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -584,7 +584,7 @@ module Rack
         assert("a header value must be a String, but the value of " +
           "'#{key}' is a #{value.class}") { value.kind_of? String }
         ## consisting of lines (for multiple header values, e.g. multiple
-        ## <tt>Set-Cookie</tt> values) seperated by "\n".
+        ## <tt>Set-Cookie</tt> values) separated by "\n".
         value.split("\n").each { |item|
           ## The lines must not contain characters below 037.
           assert("invalid header value #{key}: #{item.inspect}") {

--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -22,7 +22,7 @@ module Rack
   #
   # Nginx supports the X-Accel-Redirect header. This is similar to X-Sendfile
   # but requires parts of the filesystem to be mapped into a private URL
-  # hierarachy.
+  # hierarchy.
   #
   # The following example shows the Nginx configuration required to create
   # a private "/files/" area, enable X-Accel-Redirect, and pass the special

--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -289,7 +289,7 @@ module Rack
           value && !value.empty?
         end
 
-        # Session should be commited if it was loaded, any of specific options like :renew, :drop
+        # Session should be committed if it was loaded, any of specific options like :renew, :drop
         # or :expire_after was given and the security permissions match. Skips if skip is given.
 
         def commit_session?(env, session, options)
@@ -386,7 +386,7 @@ module Rack
           raise '#set_session not implemented.'
         end
 
-        # All thread safety and session destroy proceedures should occur here.
+        # All thread safety and session destroy procedures should occur here.
         # Should return a new session id or nil if options[:drop]
 
         def destroy_session(env, sid, options)

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -9,7 +9,7 @@ major, minor, patch = RUBY_VERSION.split('.').map { |v| v.to_i }
 
 if major == 1 && minor < 9
   require 'rack/backports/uri/common_18'
-elsif major == 1 && minor == 9 && patch == 2 && RUBY_PATCHLEVEL <= 320 && RUBY_ENGINE != 'jruby'
+elsif major == 1 && minor == 9 && patch == 2 && RUBY_PATCHLEVEL <= 326 && RUBY_ENGINE != 'jruby'
   require 'rack/backports/uri/common_192'
 elsif major == 1 && minor == 9 && patch == 3 && RUBY_PATCHLEVEL < 125
   require 'rack/backports/uri/common_193'

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -203,7 +203,7 @@ module Rack
     if //.respond_to?(:encoding)
       ESCAPE_HTML_PATTERN = Regexp.union(*ESCAPE_HTML.keys)
     else
-      # On 1.8, there is a kcode = 'u' bug that allows for XSS otherwhise
+      # On 1.8, there is a kcode = 'u' bug that allows for XSS otherwise
       # TODO doesn't apply to jruby, so a better condition above might be preferable?
       ESCAPE_HTML_PATTERN = /#{Regexp.union(*ESCAPE_HTML.keys)}/n
     end
@@ -350,7 +350,7 @@ module Rack
     # of '% %b %Y'.
     # It assumes that the time is in GMT to comply to the RFC 2109.
     #
-    # NOTE: I'm not sure the RFC says it requires GMT, but is ambigous enough
+    # NOTE: I'm not sure the RFC says it requires GMT, but is ambiguous enough
     # that I'm certain someone implemented only that option.
     # Do not use %a and %b from Time.strptime, it would use localized names for
     # weekday and month.

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -9,7 +9,7 @@ major, minor, patch = RUBY_VERSION.split('.').map { |v| v.to_i }
 
 if major == 1 && minor < 9
   require 'rack/backports/uri/common_18'
-elsif major == 1 && minor == 9 && patch == 2 && RUBY_PATCHLEVEL <= 326 && RUBY_ENGINE != 'jruby'
+elsif major == 1 && minor == 9 && patch == 2 && RUBY_PATCHLEVEL <= 328 && RUBY_ENGINE != 'jruby'
   require 'rack/backports/uri/common_192'
 elsif major == 1 && minor == 9 && patch == 3 && RUBY_PATCHLEVEL < 125
   require 'rack/backports/uri/common_193'


### PR DESCRIPTION
Based on the comments at https://github.com/rack/rack/issues/658 the fix already on master seems to work. This backports the relevant commits to the 1.5 branch.

Note, I only ran `rake test` on `ruby 1.9.3p392`. I didn't run the tests on other ruby versions. I didn't run the "full" test suite with `rake fulltest`.