### PR TITLE
Preserves extension in the created tempfile

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -117,7 +117,8 @@ module Rack
             end
 
             if filename
-              (@env['rack.tempfiles'] ||= []) << body = Tempfile.new("RackMultipart")
+              extname = ::File.extname(filename)
+              (@env['rack.tempfiles'] ||= []) << body = Tempfile.new(["RackMultipart", extname])
               body.binmode  if body.respond_to?(:binmode)
             end
 

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -153,6 +153,12 @@ describe Rack::Multipart do
     params["files"][:tempfile].read.should.equal "contents"
   end
 
+  should "preserve extension in the created tempfile" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:text))
+    params = Rack::Multipart.parse_multipart(env)
+    File.extname(params["files"][:tempfile].path).should.equal ".txt"
+  end
+
   should "parse multipart upload with text file with no name field" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:filename_and_no_name))
     params = Rack::Multipart.parse_multipart(env)


### PR DESCRIPTION
This is handy when you have to pass the generated tempfile to gems that relies on the detection of filename extension ([simple-spreadsheet](https://github.com/zenkay/simple-spreadsheet), [roo](https://github.com/Empact/roo) to name my use case).
