### PR TITLE
Restore Rack::Server#middleware backward compatibility

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -235,16 +235,14 @@ module Rack
         m
       end
 
-      # Aliased for backwards-compatibility
-      alias :middleware :default_middleware_by_environment
+      def middleware
+        default_middleware_by_environment
+      end
     end
 
-    def default_middleware_by_environment
-      self.class.default_middleware_by_environment
+    def middleware
+      self.class.middleware
     end
-
-    # Aliased for backwards-compatibility
-    alias :middleware :default_middleware_by_environment
 
     def start &blk
       if options[:warn]
@@ -325,8 +323,7 @@ module Rack
       end
 
       def build_app(app)
-        middlewares = default_middleware_by_environment[options[:environment]]
-        middlewares.reverse_each do |middleware|
+        middleware[options[:environment]].reverse_each do |middleware|
           middleware = middleware.call(self) if middleware.respond_to?(:call)
           next unless middleware
           klass, *args = middleware


### PR DESCRIPTION
Fixes regression in #706. It intends to retain backward compatibility with calls to `#middleware` by aliasing the method to the new `default_middleware_for_environment`, but since it doesn't call `#middleware` internally, subclasses that overrode it no longer work.

Restored compatibility by calling `#middleware` internally and delegating its implementation to the new `default_middleware_for_environment` methods.
