### PR TITLE
avoid conflicting with rails stringify_keys

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -149,11 +149,11 @@ module Rack
 
         def load!
           @id, session = @store.send(:load_session, @env)
-          @data = stringify_keys(session)
+          @data = convert_keys_to_strings(session)
           @loaded = true
         end
 
-        def stringify_keys(other)
+        def convert_keys_to_strings(other)
           hash = {}
           other.each do |key, value|
             hash[key.to_s] = value


### PR DESCRIPTION
when iterating over nested hashes (request.env)
this blows up when trying to stringify everything that is_a? Hash

@jeremy @spastorino @raggi
