### PR TITLE
Fix: `respond_to?` takes 2 arguments

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -4,14 +4,9 @@ module Rack
       @body, @block, @closed = body, block, false
     end
 
-    def respond_to?(method_name)
-      case method_name
-      when :to_ary
-        return false
-      when String
-        return false if /^to_ary$/ =~ method_name
-      end
-      super or @body.respond_to?(method_name)
+    def respond_to?(*args)
+      return false if args.first.to_s =~ /^to_ary$/
+      super or @body.respond_to?(*args)
     end
 
     def close

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -1,5 +1,6 @@
 require 'rack/body_proxy'
 require 'stringio'
+require 'ostruct'
 
 describe Rack::BodyProxy do
   should 'call each on the wrapped body' do
@@ -47,6 +48,21 @@ describe Rack::BodyProxy do
 
     raise "Expected exception to have been raised" unless e
     called.should.equal true
+  end
+
+  should 'allow multiple arguments in respond_to?' do
+    body  = []
+    proxy = Rack::BodyProxy.new(body) { }
+    proc { proxy.respond_to?(:foo, false) }.should.not.raise
+  end
+
+  should 'not respond to :to_ary' do
+    body = OpenStruct.new(:to_ary => true)
+    body.respond_to?(:to_ary).should.equal true
+
+    proxy = Rack::BodyProxy.new(body) { }
+    proxy.respond_to?(:to_ary).should.equal false
+    proxy.respond_to?("to_ary").should.equal false
   end
 
   should 'not close more than one time' do


### PR DESCRIPTION
The `respond_to?` method was optimized for less object creation, unfortunately I also mangled the method signature. This commit reverts the changes introduced in #737 to `BodyProxy#respond_to?` and adds tests.

See: https://github.com/rack/rack/pull/737/files#r18359323

cc/ @raggi
