### PR TITLE
Missed optimizations

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -4,9 +4,12 @@ module Rack
       @body, @block, @closed = body, block, false
     end
 
-    def respond_to?(*args)
-      return false if args.first.to_s =~ /^to_ary$/
-      super or @body.respond_to?(*args)
+    def respond_to?(method_name, include_all=false)
+      case method_name
+      when :to_ary, 'to_ary'
+        return false
+      end
+      super or @body.respond_to?(method_name, include_all)
     end
 
     def close
@@ -31,9 +34,9 @@ module Rack
       @body.each(*args, &block)
     end
 
-    def method_missing(*args, &block)
-      super if args.first.to_s =~ /^to_ary$/
-      @body.__send__(*args, &block)
+    def method_missing(method_name, *args, &block)
+      super if :to_ary == method_name
+      @body.__send__(method_name, *args, &block)
     end
   end
 end

--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -71,7 +71,7 @@ table { width:100%%; }
 
       body = "Forbidden\n"
       size = Rack::Utils.bytesize(body)
-      return [403, {"Content-Type" => "text/plain",
+      return [403, {CONTENT_TYPE => "text/plain",
         CONTENT_LENGTH => size.to_s,
         "X-Cascade" => "pass"}, [body]]
     end
@@ -129,7 +129,7 @@ table { width:100%%; }
     def entity_not_found
       body = "Entity not found: #{@path_info}\n"
       size = Rack::Utils.bytesize(body)
-      return [404, {"Content-Type" => "text/plain",
+      return [404, {CONTENT_TYPE => "text/plain",
         CONTENT_LENGTH => size.to_s,
         "X-Cascade" => "pass"}, [body]]
     end

--- a/lib/rack/runtime.rb
+++ b/lib/rack/runtime.rb
@@ -12,7 +12,7 @@ module Rack
       @header_name << "-#{name}" if name
     end
 
-    FORMAT_STRING = "%0.6f"
+    FORMAT_STRING = "%0.6f".freeze
     def call(env)
       start_time = Time.now
       status, headers, body = @app.call(env)


### PR DESCRIPTION
- freezing constant string to ensure it's not mutated
- use constant where available
- optimize `respond_to?` to not allocate array.

Discussed in #737 and #739

`respond_to?` takes two arguments all recent rubies:

- http://ruby-doc.org/core-2.1.3/Object.html#method-i-respond_to-3F
- http://ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to-3F
- http://ruby-doc.org/core-1.8.7/Object.html#method-i-respond_to-3F

Also `method_missing` will return a symbol from the first argument, we don't need to allocate a string:

- http://ruby-doc.org/core-2.1.3/BasicObject.html#method-i-method_missing
- http://ruby-doc.org/core-1.9.3/BasicObject.html#method-i-method_missing
- http://ruby-doc.org/core-1.8.7/Kernel.html#method-i-method_missing

cc/ @raggi 