### PR TITLE
Fix typo in comment

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -418,7 +418,7 @@ module Rack
     # Constant time string comparison.
     #
     # NOTE: the values compared should be of fixed length, such as strings
-    # that have aready been processed by HMAC.  This should not be used
+    # that have already been processed by HMAC. This should not be used
     # on variable length plaintext strings because it could leak length info
     # via timing attacks.
     def secure_compare(a, b)


### PR DESCRIPTION
Looking through the documentation I noticed a small typo on `Rack::Utils.secure_compare`, so I fixed it (and removed a double space.
