### PR TITLE
Simplify `Rack::Request#update_param`

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -238,20 +238,12 @@ module Rack
     #
     # env['rack.input'] is not touched.
     def update_param(k, v)
-      found = false
-      if self.GET.has_key?(k)
-        found = true
-        self.GET[k] = v
-      end
       if self.POST.has_key?(k)
-        found = true
         self.POST[k] = v
-      end
-      unless found
+      else
         self.GET[k] = v
       end
       @params = nil
-      nil
     end
 
     # Destructively delete a parameter, whether it's in GET or POST. Returns the value of the deleted parameter.


### PR DESCRIPTION
Previously, `Rack::Request#update_param` would do an unnecessary `has_key?` check on `Rack::Request::GET`.

It used to:
1. Check if k was is self.GET and insert into self.GET if true
2. Check if k was in self.POST and insert into self.POST if true
3. If it wasn't found in either, it would be inserted into the GET params.

Why would one need to check to see if a default works? (and if it doesn't default to that default)