### PR TITLE
Rack 1.5: Use equal? to compare form_input to rack.input

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -198,7 +198,7 @@ module Rack
     def POST
       if @env["rack.input"].nil?
         raise "Missing rack.input"
-      elsif @env["rack.request.form_input"].eql? @env["rack.input"]
+      elsif @env["rack.request.form_input"].equal? @env["rack.input"]
         @env["rack.request.form_hash"]
       elsif form_data? || parseable_data?
         @env["rack.request.form_input"] = @env["rack.input"]

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -864,6 +864,21 @@ EOF
     lambda{ req.POST }.should.not.raise("input re-processed!")
   end
 
+  should "use form_hash when form_input is a Tempfile" do
+    input = "{foo: 'bar'}"
+
+    rack_input = Tempfile.new("rackspec")
+    rack_input.write(input)
+    rack_input.rewind
+
+    req = Rack::Request.new Rack::MockRequest.env_for("/",
+                      "rack.request.form_hash" => {'foo' => 'bar'},
+                      "rack.request.form_input" => rack_input,
+                      :input => rack_input)
+
+    req.POST.should.equal(req.env['rack.request.form_hash'])
+  end
+
   should "conform to the Rack spec" do
     app = lambda { |env|
       content = Rack::Request.new(env).POST["file"].inspect


### PR DESCRIPTION
Backport to rack 1.5 of https://github.com/rack/rack/pull/588 by @statianzo

It's really just a cherry-pick without changes. But that's all I can do to make this be merged faster on rack 1.5.
