### PR TITLE
Use a monotonic time for Rack::Runtime, if available

### DIFF
--- a/lib/rack/runtime.rb
+++ b/lib/rack/runtime.rb
@@ -14,15 +14,27 @@ module Rack
 
     FORMAT_STRING = "%0.6f"
     def call(env)
-      start_time = Time.now
+      start_time = clock_time
       status, headers, body = @app.call(env)
-      request_time = Time.now - start_time
+      request_time = clock_time - start_time
 
       if !headers.has_key?(@header_name)
         headers[@header_name] = FORMAT_STRING % request_time
       end
 
       [status, headers, body]
+    end
+
+    private
+
+    if defined?(Process::CLOCK_MONOTONIC)
+      def clock_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    else
+      def clock_time
+        Time.now.to_f
+      end
     end
   end
 end


### PR DESCRIPTION
`Time.now` is prone to inaccuracies if the system time changes during the request. This could be due to DST, NTP, etc. Using a monotonic clock (available in Ruby 2.1+ on certain platforms) avoids this problem.

See [`Process.clock_gettime`’s docs](http://ruby-doc.org/core-2.1.5/Process.html#method-c-clock_gettime) for more information.
