### PR TITLE
avoid ; to separate statements or expressions

### DIFF
--- a/lib/rack/cascade.rb
+++ b/lib/rack/cascade.rb
@@ -9,7 +9,7 @@ module Rack
     attr_reader :apps
 
     def initialize(apps, catch=[404, 405])
-      @apps = []; @has_app = {}
+      @apps, @has_app = [], {}
       apps.each { |app| add app }
 
       @catch = {}


### PR DESCRIPTION
I think that this is a little more clear and it follows the ruby style guide.