### PR TITLE
Fix #773: Rack.release must match value in gemspec.

### DIFF
--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -20,7 +20,7 @@ module Rack
 
   # Return the Rack release as a dotted string.
   def self.release
-    "1.5"
+    "1.6"
   end
   PATH_INFO      = 'PATH_INFO'.freeze
   REQUEST_METHOD = 'REQUEST_METHOD'.freeze

--- a/test/spec_version.rb
+++ b/test/spec_version.rb
@@ -1,0 +1,17 @@
+# -*- encoding: utf-8 -*-
+require 'rack'
+
+describe Rack do
+  describe 'version' do
+    it 'defaults to a hard-coded api version' do
+      Rack.version.should.equal("1.3")
+    end
+  end
+  describe 'release' do
+    it 'matches version in .gemspec' do
+      gemspec_path = File.join(File.dirname(File.expand_path(__FILE__)), '../rack.gemspec')
+      gemspec = Gem::Specification.load(gemspec_path)
+      Rack.release.split('.').take(2).should.equal gemspec.version.to_s.split('.').take(2)
+    end
+  end
+end


### PR DESCRIPTION
With a spec, I think the "release" is the major version, minus the build number increment. But I could be wrong. I think it would make sense to have both, so we can add a "build" if this is true or change the test to match the whole thing, in which case the `self.release` now should be "1.6.0" (and be bumped to "1.6.1" for next release).