### PR TITLE
Fix semicolons as separators for GET

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -188,7 +188,7 @@ module Rack
       if @env["rack.request.query_string"] == query_string
         @env["rack.request.query_hash"]
       else
-        p = parse_query(query_string)
+        p = parse_query(query_string, '&;')
         @env["rack.request.query_string"] = query_string
         @env["rack.request.query_hash"]   = p
       end
@@ -212,7 +212,7 @@ module Rack
           form_vars.slice!(-1) if form_vars[-1] == ?\0
 
           @env["rack.request.form_vars"] = form_vars
-          @env["rack.request.form_hash"] = parse_query(form_vars)
+          @env["rack.request.form_hash"] = parse_query(form_vars, '&')
 
           @env["rack.input"].rewind
         end
@@ -365,8 +365,8 @@ module Rack
         ip_addresses.reject { |ip| trusted_proxy?(ip) }
       end
 
-      def parse_query(qs)
-        Utils.parse_nested_query(qs, '&')
+      def parse_query(qs, d)
+        Utils.parse_nested_query(qs, d)
       end
 
       def parse_multipart(env)


### PR DESCRIPTION
Fix to use semicolons as separators for GET not for POST.

(cf. issue: Truncation of POST data on semicolon during param processing (unencoding?)  https://github.com/rack/rack/issues/543)

A semicolon ';' should be used as a separator according to a W3.org recommendation
http://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2

The commit https://github.com/rack/rack/commit/71c69113f269f04207157bee6c197b5675f3df61 was the one for only POST not for GET, but the test was written for GET, which is kind of a discrepancy.