### PR TITLE
Add woff2 mime type

### DIFF
--- a/lib/rack/mime.rb
+++ b/lib/rack/mime.rb
@@ -614,6 +614,7 @@ module Rack
       ".wmx"       => "video/x-ms-wmx",
       ".wmz"       => "application/x-ms-wmz",
       ".woff"      => "application/font-woff",
+      ".woff2"     => "application/font-woff2",
       ".wpd"       => "application/vnd.wordperfect",
       ".wpl"       => "application/vnd.ms-wpl",
       ".wps"       => "application/vnd.ms-works",

--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -53,8 +53,8 @@ module Rack
   #  4) Regular Expressions / Regexp
   #     Provide a regular expression
   #     %r{\.(?:css|js)\z} => Matches files ending in .css or .js
-  #     /\.(?:eot|ttf|otf|woff|svg)\z/ => Matches files ending in
-  #       the most common web font formats (.eot, .ttf, .otf, .woff, .svg)
+  #     /\.(?:eot|ttf|otf|woff2|woff|svg)\z/ => Matches files ending in
+  #       the most common web font formats (.eot, .ttf, .otf, .woff2, .woff, .svg)
   #       Note: This Regexp is available as a shortcut, using the :fonts rule
   #
   #  5) Font Shortcut
@@ -132,7 +132,7 @@ module Rack
         when :all
           true
         when :fonts
-          path =~ /\.(?:ttf|otf|eot|woff|svg)\z/
+          path =~ /\.(?:ttf|otf|eot|woff2|woff|svg)\z/
         when String
           path = ::Rack::Utils.unescape(path)
           path.start_with?(rule) || path.start_with?('/' + rule)


### PR DESCRIPTION
Reference:
http://dev.w3.org/webfonts/WOFF2/spec/#IMT (still a draft)

Browser support:
* Google Chrome 36
* Opera 23
* Firefox 35 ([disabled by default on stable and beta channels, enabled in aurora and nightly](https://developer.mozilla.org/en-US/docs/Web/Guide/WOFF))

I'm temporary using

```rb
Rack::Mime::MIME_TYPES['.woff2'] = 'application/font-woff2'
```
