### PR TITLE
Reduce object allocations in Rack::Utils

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -109,6 +109,7 @@ module Rack
     # ParameterTypeError is raised. Users are encouraged to return a 400 in this
     # case.
     def parse_nested_query(qs, d = nil)
+      return {} if qs.empty?
       params = KeySpaceConstrainedParams.new
 
       (qs || '').split(d ? /[#{d}] */n : DEFAULT_SEP).each do |p|
@@ -495,7 +496,7 @@ module Rack
       end
 
       def []=(k, v)
-        canonical = k.downcase
+        canonical = k.downcase.freeze
         delete k if @names[canonical] && @names[canonical] != k # .delete is expensive, don't invoke it unless necessary
         @names[k] = @names[canonical] = k
         super k, v


### PR DESCRIPTION
@tenderlove when we were working on this yesterday we were using the version compiled with Rails which meant we didn't have the most up to date. The change we made to body_proxy.rb was already made in October so that's why it's not here.

Using AllocationTracer we were able to find unnecessary allocations of
objects.

1) `[]=` is duping the hash key object on assignment. Frezing
`k.downcase` will prevent this.

2) `parse_nested_query` was taking unnecessary steps when the string was
empty. We can just return a `{}` instead if `qs` is empty.

AllocationTracer object allocation before these changes:
```
[["/rack/lib/rack/utils.rb", 500, :T_STRING], [56981, 4303, 78980, 0, 13, 2032240]]
[["/rack/lib/rack/utils.rb", 498, :T_STRING], [51000, 0, 45775, 0, 2, 1904680]]
[["/rack/lib/rack/utils.rb", 114, :T_STRING], [39123, 0, 35116, 0, 1, 4711600]]
[["/rack/lib/rack/utils.rb", 661, :T_STRING], [32993, 0, 29621, 0, 1, 1232289]]
[["/rack/lib/rack/body_proxy.rb", 34, :T_ARRAY], [30000, 0, 26930, 0, 1, 1120400]]
```
AllocationTracer object allocation after these changes:
```
[["/rack/lib/rack/utils.rb", 499, :T_STRING], [46665, 969, 54210, 0, 13, 1702720]]
[["/rack/lib/rack/utils.rb", 662, :T_STRING], [31375, 0, 30647, 0, 2, 1175369]]
[["/rack/lib/rack/body_proxy.rb", 34, :T_ARRAY], [28550, 0, 27880, 0, 2, 1068800]]
[["/rails/activesupport/lib/active_support/subscriber.rb", 99, :T_STRING], [28534, 0, 27869, 0, 2, 1068560]]
[["/rails/activesupport/lib/active_support/notifications/fanout.rb", 55, :T_DATA], [28528, 0, 27864, 0, 2, 3098592]]
```