### PR TITLE
Prioritise CLI options over comment options

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -46,10 +46,6 @@ module Rack
     def self.default(options = {})
       # Guess.
       if ENV.include?("PHP_FCGI_CHILDREN")
-        # We already speak FastCGI
-        options.delete :File
-        options.delete :Port
-
         Rack::Handler::FastCGI
       elsif ENV.include?(REQUEST_METHOD)
         Rack::Handler::CGI

--- a/test/builder/options.ru
+++ b/test/builder/options.ru
@@ -1,2 +1,2 @@
-#\ -d
+#\ -d -p 2929 --env test
 run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -187,6 +187,8 @@ describe Rack::Builder do
     it "parses commented options" do
       app, options = Rack::Builder.parse_file config_file('options.ru')
       options[:debug].should.be.true
+      options[:environment].should.equal 'test'
+      options[:Port].should.equal '2929'
       Rack::MockRequest.new(app).get("/").body.to_s.should.equal 'OK'
     end
 


### PR DESCRIPTION
I'll start with my use case: I want to provide a default port for an app, but still be able to override it when launching from the command-line.

I found four sources of options for `Rack::Server`:

1. In the constructor, as a hash: `Rack::Server.new(server: 'thin')` (if this is provided, 4 and 2 won't be used.)
2. On the command line: `bundle exec rackup --server thin`
3. In a magic comment on the first line of config.ru (or whichever config file was used): `#\ --server thin`
4. `Rack::Server#default_options`

Previously, the order of precedence - earlier 'wins' - was 3, 2, 4. This changes it to 2, 3, 4. That way you can have default options in the magic comment, but still let them be overridden by passing options on the command line. This way makes far more sense to me, but I appreciate it's a breaking change.