### PR TITLE
Update license with up-to-date year

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2007, 2008, 2009, 2010, 2011, 2012 Christian Neukirchen <purl.org/net/chneukirchen>
+Copyright (c) 2007-2015 Christian Neukirchen <purl.org/net/chneukirchen>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to


### PR DESCRIPTION
Only made 1 change in COPYING:
1) Modified copyright year to be a year-range, starting from 2007 through the current year 2015

No other changes were made.