### PR TITLE
Fix bug when `qs` is `nil`

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -109,7 +109,7 @@ module Rack
     # ParameterTypeError is raised. Users are encouraged to return a 400 in this
     # case.
     def parse_nested_query(qs, d = nil)
-      return {} if qs.empty?
+      return {} if qs.nil? || qs.empty?
       params = KeySpaceConstrainedParams.new
 
       (qs || '').split(d ? /[#{d}] */n : DEFAULT_SEP).each do |p|


### PR DESCRIPTION
In c4596b3 I failed to test Rails tests :cry: and in working on other issues discovered some Rails ActionPack tests were erroring. I found that sometimes `qs` is nil so I changed this to check for `qs.nil? || qs.empty?`.

I'm going to investigate as to why we're calling this method when `qs` is nil but this will fix it for now until I figure out if we can skip this call. :grin: