### PR TITLE
Freeze 'X-Runtime' string

### DIFF
--- a/lib/rack/runtime.rb
+++ b/lib/rack/runtime.rb
@@ -6,13 +6,15 @@ module Rack
   # time, or before all the other middlewares to include time for them,
   # too.
   class Runtime
+    FORMAT_STRING = "%0.6f".freeze # :nodoc:
+    HEADER_NAME = "X-Runtime".freeze # :nodoc:
+
     def initialize(app, name = nil)
       @app = app
-      @header_name = "X-Runtime"
-      @header_name << "-#{name}" if name
+      @header_name = HEADER_NAME
+      @header_name += "-#{name}" if name
     end
 
-    FORMAT_STRING = "%0.6f".freeze
     def call(env)
       start_time = clock_time
       status, headers, body = @app.call(env)


### PR DESCRIPTION
Move 'X-Runtime' to a constant and freeze. Combine with other
`FORMAT_STRING` constant used in the class.

We are freezing these strings to reduce the number of allocations in
Rails integration tests. The tests are spending a lot of time in GC and
this reduces the amount of time spent from 12% to 9% (in combination
with Rails PR that also freezes some strings).

Strings allocated before this change: 1030722
Strings allocated after this change: 1024722

Checked this time that Rails tests pass :grin:. With #800 merged in they do.

cc/ @tenderlove 