### PR TITLE
Don't pass arguments to `#each`

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -30,8 +30,8 @@ module Rack
     # We are applying this special case for #each only. Future bugs of this
     # class will be handled by requesting users to patch their ruby
     # implementation, to save adding too many methods in this class.
-    def each(*args, &block)
-      @body.each(*args, &block)
+    def each
+      @body.each { |body| yield body }
     end
 
     def method_missing(method_name, *args, &block)


### PR DESCRIPTION
Nothing is actually passed to `#each` so we shouldn't be passing `*args`.
This change eliminates proc and array allocations here.

Before this change `#each` on rack/lib/rack/body_proxy.rb:34 was number
3 in highest allocations for Rails integration tests. After this change it's
no longer in the top 5.

cc/ @tenderlove 