### PR TITLE
Update documentation of Rack::Response defaults

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -8,7 +8,7 @@ module Rack
   # response.
   #
   # It allows setting of headers and cookies, and provides useful
-  # defaults (a OK response containing HTML).
+  # defaults (an OK response with empty headers and body).
   #
   # You can use Response#write to iteratively generate your response,
   # but note that this is buffered by Rack::Response until you call


### PR DESCRIPTION
The “containing HTML” remark stopped being true in 3623d04526b953a63bfb3e72de2d6920a042563f, as reflected by https://github.com/rack/rack/blob/master/test/spec_response.rb#L5-L21.