### PR TITLE
Use yield instead of block.call

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -15,7 +15,7 @@ module Rack
 
     class LintError < RuntimeError; end
     module Assertion
-      def assert(message, &block)
+      def assert(message)
         unless yield
           raise LintError, message
         end

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -16,7 +16,7 @@ module Rack
     class LintError < RuntimeError; end
     module Assertion
       def assert(message, &block)
-        unless block.call
+        unless yield
           raise LintError, message
         end
       end


### PR DESCRIPTION
yielding is faster than performing block.call 

[Reference](https://www.omniref.com/ruby/2.2.0/symbols/Proc/yield?#annotation=4087638&line=711)