### PR TITLE
Prefer attr_reader over self-written getters.

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -86,9 +86,8 @@ module Rack
       end
 
       private
-      def full_boundary; @full_boundary; end
 
-      def rx; @rx; end
+      attr_reader :full_boundary, :rx
 
       def fast_forward_to_first_boundary
         loop do


### PR DESCRIPTION
attr_reader is somewhat faster than writing plain getters, but this also increases readability.