### PR TITLE
Remove check for `nil` on `qs`

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -109,7 +109,7 @@ module Rack
     # ParameterTypeError is raised. Users are encouraged to return a 400 in this
     # case.
     def parse_nested_query(qs, d = nil)
-      return {} if qs.nil? || qs.empty?
+      return {} if qs.empty?
       params = KeySpaceConstrainedParams.new
 
       (qs || '').split(d ? /[#{d}] */n : DEFAULT_SEP).each do |p|


### PR DESCRIPTION
Fixed by brynary/rack-test@4a4b2c1. rack-test was turning the query
string to nil if there was no argument passed in the params. This extra
`nil` check is no longer necessary after the changes made to the
rack-test gem. Fixes issue brought up in #800.

I found Rails wasn't doing anything wrong as we had originally thought. Since rack-test update has been released should I update rack-test to use 0.6.3 instead of 0.6.2 in Rails master as well? 

cc/ @tenderlove @spastorino