### PR TITLE
Only count files (not all form elements) against the Multipart File Limit

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -54,13 +54,14 @@ module Rack
 
         opened_files = 0
         loop do
-          if Utils.multipart_part_limit > 0
-            raise MultipartPartLimitError, 'Maximum file multiparts in content reached' if opened_files >= Utils.multipart_part_limit
-            opened_files += 1
-          end
 
           head, filename, content_type, name, body =
             get_current_head_and_filename_and_content_type_and_name_and_body
+
+          if Utils.multipart_part_limit > 0
+            opened_files += 1 if filename
+            raise MultipartPartLimitError, 'Maximum file multiparts in content reached' if opened_files >= Utils.multipart_part_limit
+          end
 
           # Save the rest.
           if i = @buf.index(rx)

--- a/test/multipart/three_files_three_fields
+++ b/test/multipart/three_files_three_fields
@@ -1,0 +1,31 @@
+--AaB03x
+content-disposition: form-data; name="reply"
+
+yes
+--AaB03x
+content-disposition: form-data; name="to"
+
+people
+--AaB03x
+content-disposition: form-data; name="from"
+
+others
+--AaB03x
+content-disposition: form-data; name="fileupload1"; filename="file1.jpg"
+Content-Type: image/jpeg
+Content-Transfer-Encoding: base64
+
+/9j/4AAQSkZJRgABAQAAAQABAAD//gA+Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcg
+--AaB03x
+content-disposition: form-data; name="fileupload2"; filename="file2.jpg"
+Content-Type: image/jpeg
+Content-Transfer-Encoding: base64
+
+/9j/4AAQSkZJRgABAQAAAQABAAD//gA+Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcg
+--AaB03x
+content-disposition: form-data; name="fileupload3"; filename="file3.jpg"
+Content-Type: image/jpeg
+Content-Transfer-Encoding: base64
+
+/9j/4AAQSkZJRgABAQAAAQABAAD//gA+Q1JFQVRPUjogZ2QtanBlZyB2MS4wICh1c2luZyBJSkcg
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -476,6 +476,33 @@ Content-Type: image/jpeg\r
     end
   end
 
+ should "not reach a multi-part limit" do
+    begin
+      previous_limit = Rack::Utils.multipart_part_limit
+      Rack::Utils.multipart_part_limit = 4
+
+      env = Rack::MockRequest.env_for '/', multipart_fixture(:three_files_three_fields)
+      params = Rack::Multipart.parse_multipart(env)
+      params['reply'].should.equal 'yes'
+      params['to'].should.equal 'people'
+      params['from'].should.equal 'others'
+    ensure
+      Rack::Utils.multipart_part_limit = previous_limit
+    end
+  end
+
+  should "reach a multipart limit" do
+    begin
+      previous_limit = Rack::Utils.multipart_part_limit
+      Rack::Utils.multipart_part_limit = 3
+
+      env = Rack::MockRequest.env_for '/', multipart_fixture(:three_files_three_fields)
+      lambda { Rack::Multipart.parse_multipart(env) }.should.raise(Rack::Multipart::MultipartPartLimitError)
+    ensure
+      Rack::Utils.multipart_part_limit = previous_limit
+    end
+  end
+
   should "return nil if no UploadedFiles were used" do
     data = Rack::Multipart.build_multipart("people" => [{"submit-name" => "Larry", "files" => "contents"}])
     data.should.equal nil


### PR DESCRIPTION
We were getting "Too many open files - Maximum file multiparts in content reached".  However, our form only had one file input.  It had several hundred other form elements.  Each was counted as a file. 

Only increment the opened_files counter for file inputs.  If you have a large form, you can quickly hit the MultipartPartLimitError, even though you aren't actually opening files