### PR TITLE
Expand initialize ivars instead of using 1 line

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -1,7 +1,9 @@
 module Rack
   class BodyProxy
     def initialize(body, &block)
-      @body, @block, @closed = body, block, false
+      @body = body
+      @block = block
+      @closed = false
     end
 
     def respond_to?(method_name, include_all=false)


### PR DESCRIPTION
Flattening the ivars here causes them to be allocated as an array.
This commit expands them to avoid these extra allocations.

Total allocations before: 2913000
Total allocations after:  2892000

(I promise this one didn't break rails :grin:)