### PR TITLE
Allow specifying a params hash class to use when parsing

### DIFF
--- a/lib/rack/multipart.rb
+++ b/lib/rack/multipart.rb
@@ -21,8 +21,8 @@ module Rack
     MULTIPART_CONTENT_ID = /Content-ID:\s*([^#{EOL}]*)/ni
 
     class << self
-      def parse_multipart(env)
-        Parser.create(env).parse
+      def parse_multipart(env, params = QueryParser::DEFAULT.params_class.new)
+        Parser.create(env, params).parse
       end
 
       def build_multipart(params, first = true)

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -10,7 +10,7 @@ module Rack
 
       DUMMY = Struct.new(:parse).new
 
-      def self.create(env)
+      def self.create(env, params = QueryParser::DEFAULT.params_class.new)
         return DUMMY unless env['CONTENT_TYPE'] =~ MULTIPART
 
         io = env['rack.input']
@@ -23,13 +23,13 @@ module Rack
           lambda { |filename, content_type| Tempfile.new(["RackMultipart", ::File.extname(filename)]) }
         bufsize = env['rack.multipart.buffer_size'] || BUFSIZE
 
-        new($1, io, content_length, env, tempfile, bufsize)
+        new($1, io, content_length, env, tempfile, bufsize, params)
       end
 
-      def initialize(boundary, io, content_length, env, tempfile, bufsize)
+      def initialize(boundary, io, content_length, env, tempfile, bufsize, params = QueryParser::DEFAULT.params_class.new)
         @buf            = "".force_encoding(Encoding::ASCII_8BIT)
 
-        @params         = Utils::KeySpaceConstrainedParams.new
+        @params         = params
         @boundary       = "--#{boundary}"
         @io             = io
         @content_length = content_length

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -1,0 +1,160 @@
+module Rack
+  class QueryParser
+    DEFAULT_SEP = /[&;] */n
+    COMMON_SEP = { ";" => /[;] */n, ";," => /[;,] */n, "&" => /[&] */n }
+
+    # ParameterTypeError is the error that is raised when incoming structural
+    # parameters (parsed by parse_nested_query) contain conflicting types.
+    class ParameterTypeError < TypeError; end
+
+    # InvalidParameterError is the error that is raised when incoming structural
+    # parameters (parsed by parse_nested_query) contain invalid format or byte
+    # sequence.
+    class InvalidParameterError < ArgumentError; end
+
+    attr_accessor :params_class
+
+    def initialize(opts={})
+      self.params_class = opts[:params_class] || Params
+    end
+
+    # Stolen from Mongrel, with some small modifications:
+    # Parses a query string by breaking it up at the '&'
+    # and ';' characters.  You can also use this to parse
+    # cookies by changing the characters used in the second
+    # parameter (which defaults to '&;').
+    def parse_query(qs, d = nil, &unescaper)
+      unescaper ||= method(:unescape)
+
+      params = params_class.new
+
+      (qs || '').split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
+        next if p.empty?
+        k, v = p.split('='.freeze, 2).map!(&unescaper)
+
+        if cur = params[k]
+          if cur.class == Array
+            params[k] << v
+          else
+            params[k] = [cur, v]
+          end
+        else
+          params[k] = v
+        end
+      end
+
+      return params.to_params_hash
+    end
+
+    # parse_nested_query expands a query string into structural types. Supported
+    # types are Arrays, Hashes and basic value types. It is possible to supply
+    # query strings with parameters of conflicting types, in this case a
+    # ParameterTypeError is raised. Users are encouraged to return a 400 in this
+    # case.
+    def parse_nested_query(qs, d = nil)
+      return {} if qs.nil? || qs.empty?
+      params = params_class.new
+
+      (qs || '').split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
+        k, v = p.split('='.freeze, 2).map! { |s| unescape(s) }
+
+        normalize_params(params, k, v)
+      end
+
+      return params.to_params_hash
+    rescue ArgumentError => e
+      raise InvalidParameterError, e.message
+    end
+
+    # normalize_params recursively expands parameters into structural types. If
+    # the structural types represented by two different parameter names are in
+    # conflict, a ParameterTypeError is raised.
+    def normalize_params(params, name, v = nil)
+      name =~ %r(\A[\[\]]*([^\[\]]+)\]*)
+      k = $1 || ''
+      after = $' || ''
+
+      return if k.empty?
+
+      if after == ""
+        params[k] = v
+      elsif after == "["
+        params[name] = v
+      elsif after == "[]"
+        params[k] ||= []
+        raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
+        params[k] << v
+      elsif after =~ %r(^\[\]\[([^\[\]]+)\]$) || after =~ %r(^\[\](.+)$)
+        child_key = $1
+        params[k] ||= []
+        raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
+        if params_hash_type?(params[k].last) && !params[k].last.key?(child_key)
+          normalize_params(params[k].last, child_key, v)
+        else
+          params[k] << normalize_params(params.class.new, child_key, v)
+        end
+      else
+        params[k] ||= params.class.new
+        raise ParameterTypeError, "expected Hash (got #{params[k].class.name}) for param `#{k}'" unless params_hash_type?(params[k])
+        params[k] = normalize_params(params[k], after, v)
+      end
+
+      return params
+    end
+
+    def params_hash_type?(obj)
+      obj.kind_of?(params_class) || obj.kind_of?(Hash)
+    end
+
+    def unescape(s)
+      Utils.unescape(s)
+    end
+
+    class Params
+      class << self
+        # The default number of bytes to allow parameter keys to take up.
+        # This helps prevent a rogue client from flooding a Request.
+        attr_accessor :limit
+      end
+
+      def initialize(limit = self.class.limit)
+        @limit  = limit || 65536
+        @size   = 0
+        @params = {}
+      end
+
+      def [](key)
+        @params[key]
+      end
+
+      def []=(key, value)
+        @size += key.size if key && !@params.key?(key)
+        raise RangeError, 'exceeded available parameter key space' if @size > @limit
+        @params[key] = value
+      end
+
+      def key?(key)
+        @params.key?(key)
+      end
+
+      def to_params_hash
+        hash = @params
+        hash.keys.each do |key|
+          value = hash[key]
+          if value.kind_of?(self.class)
+            if value.object_id == self.object_id
+              hash[key] = hash
+            else
+              hash[key] = value.to_params_hash
+            end
+          elsif value.kind_of?(Array)
+            value.map! {|x| x.kind_of?(self.class) ? x.to_params_hash : x}
+          end
+        end
+        hash
+      end
+    end
+
+    DEFAULT = new
+  end
+end

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -307,6 +307,10 @@ module Rack
       hash
     end
 
+    def query_parser
+      QueryParser::DEFAULT
+    end
+
     def xhr?
       @env["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest"
     end
@@ -363,11 +367,11 @@ module Rack
       end
 
       def parse_query(qs, d='&')
-        Utils.parse_nested_query(qs, d)
+        query_parser.parse_nested_query(qs, d)
       end
 
       def parse_multipart(env)
-        Rack::Multipart.parse_multipart(env)
+        Rack::Multipart.parse_multipart(env, query_parser.params_class.new)
       end
 
       def parse_http_accept_header(header)

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -3,6 +3,7 @@ require 'fileutils'
 require 'set'
 require 'tempfile'
 require 'rack/multipart'
+require 'rack/query_parser'
 require 'time'
 
 require 'uri/common'
@@ -12,14 +13,12 @@ module Rack
   # applications adopted from all kinds of Ruby libraries.
 
   module Utils
-    # ParameterTypeError is the error that is raised when incoming structural
-    # parameters (parsed by parse_nested_query) contain conflicting types.
-    class ParameterTypeError < TypeError; end
-
-    # InvalidParameterError is the error that is raised when incoming structural
-    # parameters (parsed by parse_nested_query) contain invalid format or byte
-    # sequence.
-    class InvalidParameterError < ArgumentError; end
+    ParameterTypeError = QueryParser::ParameterTypeError
+    InvalidParameterError = QueryParser::InvalidParameterError
+    DEFAULT_SEP = QueryParser::DEFAULT_SEP
+    COMMON_SEP = QueryParser::COMMON_SEP
+    KeySpaceConstrainedParams = QueryParser::Params
+    DEFAULT_QUERY_PARSER = QueryParser::DEFAULT
 
     # URI escapes. (CGI style space to +)
     def escape(s)
@@ -41,17 +40,9 @@ module Rack
     end
     module_function :unescape
 
-    DEFAULT_SEP = /[&;] */n
-    COMMON_SEP = { ";" => /[;] */n, ";," => /[;,] */n, "&" => /[&] */n }
-
     class << self
-      attr_accessor :key_space_limit
       attr_accessor :multipart_part_limit
     end
-
-    # The default number of bytes to allow parameter keys to take up.
-    # This helps prevent a rogue client from flooding a Request.
-    self.key_space_limit = 65536
 
     # The maximum number of parts a request can contain. Accepting too many part
     # can lead to the server running out of file handles.
@@ -59,95 +50,31 @@ module Rack
     # FIXME: RACK_MULTIPART_LIMIT was introduced by mistake and it will be removed in 1.7.0
     self.multipart_part_limit = (ENV['RACK_MULTIPART_PART_LIMIT'] || ENV['RACK_MULTIPART_LIMIT'] || 128).to_i
 
-    # Stolen from Mongrel, with some small modifications:
-    # Parses a query string by breaking it up at the '&'
-    # and ';' characters.  You can also use this to parse
-    # cookies by changing the characters used in the second
-    # parameter (which defaults to '&;').
+    def self.key_space_limit
+      DEFAULT_QUERY_PARSER.params_class.limit
+    end
+
+    def self.key_space_limit=(v)
+      DEFAULT_QUERY_PARSER.params_class.limit = v
+    end
+
     def parse_query(qs, d = nil, &unescaper)
-      unescaper ||= method(:unescape)
-
-      params = KeySpaceConstrainedParams.new
-
-      (qs || '').split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
-        next if p.empty?
-        k, v = p.split('='.freeze, 2).map!(&unescaper)
-
-        if cur = params[k]
-          if cur.class == Array
-            params[k] << v
-          else
-            params[k] = [cur, v]
-          end
-        else
-          params[k] = v
-        end
-      end
-
-      return params.to_params_hash
+      DEFAULT_QUERY_PARSER.parse_query(qs, d, &unescaper)
     end
     module_function :parse_query
 
-    # parse_nested_query expands a query string into structural types. Supported
-    # types are Arrays, Hashes and basic value types. It is possible to supply
-    # query strings with parameters of conflicting types, in this case a
-    # ParameterTypeError is raised. Users are encouraged to return a 400 in this
-    # case.
     def parse_nested_query(qs, d = nil)
-      return {} if qs.nil? || qs.empty?
-      params = KeySpaceConstrainedParams.new
-
-      (qs || '').split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
-        k, v = p.split('='.freeze, 2).map! { |s| unescape(s) }
-
-        normalize_params(params, k, v)
-      end
-
-      return params.to_params_hash
-    rescue ArgumentError => e
-      raise InvalidParameterError, e.message
+      DEFAULT_QUERY_PARSER.parse_nested_query(qs, d)
     end
     module_function :parse_nested_query
 
-    # normalize_params recursively expands parameters into structural types. If
-    # the structural types represented by two different parameter names are in
-    # conflict, a ParameterTypeError is raised.
     def normalize_params(params, name, v = nil)
-      name =~ %r(\A[\[\]]*([^\[\]]+)\]*)
-      k = $1 || ''
-      after = $' || ''
-
-      return if k.empty?
-
-      if after == ""
-        params[k] = v
-      elsif after == "["
-        params[name] = v
-      elsif after == "[]"
-        params[k] ||= []
-        raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
-        params[k] << v
-      elsif after =~ %r(^\[\]\[([^\[\]]+)\]$) || after =~ %r(^\[\](.+)$)
-        child_key = $1
-        params[k] ||= []
-        raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
-        if params_hash_type?(params[k].last) && !params[k].last.key?(child_key)
-          normalize_params(params[k].last, child_key, v)
-        else
-          params[k] << normalize_params(params.class.new, child_key, v)
-        end
-      else
-        params[k] ||= params.class.new
-        raise ParameterTypeError, "expected Hash (got #{params[k].class.name}) for param `#{k}'" unless params_hash_type?(params[k])
-        params[k] = normalize_params(params[k], after, v)
-      end
-
-      return params
+      DEFAULT_QUERY_PARSER.normalize_params(params, name, v)
     end
     module_function :normalize_params
 
     def params_hash_type?(obj)
-      obj.kind_of?(KeySpaceConstrainedParams) || obj.kind_of?(Hash)
+      DEFAULT_QUERY_PARSER.params_hash_type?(obj)
     end
     module_function :params_hash_type?
 
@@ -522,45 +449,6 @@ module Rack
         def names
           @names
         end
-    end
-
-    class KeySpaceConstrainedParams
-      def initialize(limit = Utils.key_space_limit)
-        @limit  = limit
-        @size   = 0
-        @params = {}
-      end
-
-      def [](key)
-        @params[key]
-      end
-
-      def []=(key, value)
-        @size += key.size if key && !@params.key?(key)
-        raise RangeError, 'exceeded available parameter key space' if @size > @limit
-        @params[key] = value
-      end
-
-      def key?(key)
-        @params.key?(key)
-      end
-
-      def to_params_hash
-        hash = @params
-        hash.keys.each do |key|
-          value = hash[key]
-          if value.kind_of?(self.class)
-            if value.object_id == self.object_id
-              hash[key] = hash
-            else
-              hash[key] = value.to_params_hash
-            end
-          elsif value.kind_of?(Array)
-            value.map! {|x| x.kind_of?(self.class) ? x.to_params_hash : x}
-          end
-        end
-        hash
-      end
     end
 
     # Every standard HTTP code mapped to the appropriate message.

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -153,6 +153,18 @@ describe Rack::Multipart do
     params["files"][:tempfile].read.should.equal "contents"
   end
 
+  should "accept the params hash class to use for multipart parsing" do
+    c = Class.new(Rack::QueryParser::Params) do
+      def initialize(*)
+        super
+        @params = Hash.new{|h,k| h[k.to_s] if k.is_a?(Symbol)}
+      end
+    end
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:text))
+    params = Rack::Multipart.parse_multipart(env, c.new)
+    params[:files][:type].should.equal "text/plain"
+  end
+
   should "preserve extension in the created tempfile" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:text))
     params = Rack::Multipart.parse_multipart(env)


### PR DESCRIPTION
Currently, Rack is hardcoded to use KeySpaceConstrainedParams
as the params hash class, and this commit doesn't change that
behavior.

Rails and Sinatra and other web frameworks that want to allow
indifferent access to the params generally end up making a deep
copy of the params.  This is inefficient.  If they could overide
the params hash class to use the type of indifferent hash they
want, they wouldn't need to make a deep copy, they could use the
hash Rack provides.  This commit makes this possible without
monkey patching.

Note that this isn't really a perfect solution, since changing
the params_hash_class for the Utils class is still a global
change.  Ideally, this code would be in a class separate from
Rack::Utils, which you could subclass and then inject that
dependency into whatever Request subclass you use for the
framework.

I'm certainly willing to do the work of making it possible for
local overrides of the params hash class, while keeping
backward compatibility.  But as that's a bit more involved,
I'd like to get your feedback on this first part before doing
more work.