### PR TITLE
Fix Rack::Lock mutex usage

### DIFF
--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -12,18 +12,15 @@ module Rack
     end
 
     def call(env)
-      old, env[FLAG] = env[FLAG], false
       @mutex.lock
       begin
-        response = @app.call(env)
+        response = @app.call(env.merge(FLAG => false))
         body = BodyProxy.new(response[2]) { @mutex.unlock }
         response[2] = body
         response
       ensure
         @mutex.unlock unless body
       end
-    ensure
-      env[FLAG] = old
     end
   end
 end

--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -15,11 +15,9 @@ module Rack
       @mutex.lock
       begin
         response = @app.call(env.merge(FLAG => false))
-        body = BodyProxy.new(response[2]) { @mutex.unlock }
-        response[2] = body
-        response
+        returned = response << BodyProxy.new(response.pop) { @mutex.unlock }
       ensure
-        @mutex.unlock unless body
+        @mutex.unlock unless returned
       end
     end
   end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -187,4 +187,12 @@ describe Rack::Lock do
     response = app.call(Rack::MockRequest.env_for("/"))[2]
     response.env['rack.multithread'].should.equal false
   end
+
+  should "unlock if an exception occurs before returning" do
+    lock = Lock.new
+    env  = Rack::MockRequest.env_for("/")
+    app  = lock_app(proc { [].freeze }, lock)
+    lambda { app.call(env) }.should.raise(Exception)
+    lock.synchronized.should.equal false
+  end
 end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -9,11 +9,6 @@ class Lock
     @synchronized = false
   end
 
-  def synchronize
-    @synchronized = true
-    yield
-  end
-
   def lock
     @synchronized = true
   end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -161,4 +161,17 @@ describe Rack::Lock do
     }.new(lambda { |env| [200, {"Content-Type" => "text/plain"}, %w{ a b c }] })
     Rack::Lint.new(app).call(Rack::MockRequest.env_for("/"))
   end
+
+  should 'not unlock if an error is raised before the mutex is locked' do
+    lock = Class.new do
+      def initialize() @unlocked = false end
+      def unlocked?() @unlocked end
+      def lock() raise Exception end
+      def unlock() @unlocked = true end
+    end.new
+    env = Rack::MockRequest.env_for("/")
+    app = lock_app(proc { [200, {"Content-Type" => "text/plain"}, []] }, lock)
+    lambda { app.call(env) }.should.raise(Exception)
+    lock.unlocked?.should.equal false
+  end
 end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -149,7 +149,10 @@ describe Rack::Lock do
       env['rack.multithread'].should.equal false
       [200, {"Content-Type" => "text/plain"}, %w{ a b c }]
     }, false)
-    app.call(Rack::MockRequest.env_for("/"))
+    env = Rack::MockRequest.env_for("/")
+    env['rack.multithread'].should.equal true
+    app.call(env)
+    env['rack.multithread'].should.equal true
   end
 
   should "reset original multithread flag when exiting lock" do
@@ -173,5 +176,15 @@ describe Rack::Lock do
     app = lock_app(proc { [200, {"Content-Type" => "text/plain"}, []] }, lock)
     lambda { app.call(env) }.should.raise(Exception)
     lock.unlocked?.should.equal false
+  end
+
+  should "not reset the environment while the body is proxied" do
+    proxy = Class.new do
+      attr_reader :env
+      def initialize(env) @env = env end
+    end
+    app = Rack::Lock.new lambda { |env| [200, {"Content-Type" => "text/plain"}, proxy.new(env)] }
+    response = app.call(Rack::MockRequest.env_for("/"))[2]
+    response.env['rack.multithread'].should.equal false
   end
 end


### PR DESCRIPTION
This branch fixes the mutex usage within Rack::Lock.

If an exception happened while waiting for the `@mutex.lock` the ensure block would execute, which would run `@mutex.unlock`. This would raise a `ThreadError` exception because the thread did not own the mutex. This was most commonly seen in rack-timeout, specifically in https://github.com/heroku/rack-timeout/issues/55 and https://github.com/heroku/rack-timeout/issues/65.

Another potential, but less likely, problem could occur with a timeout error being raised after the app call was executed, and after `body` was set to a `BodyProxy` instance but before the method had returned. This would not trigger the `ensure` block because it assumed once `body` was set that everything else would proceed.

A third problem I found when auditing the code, is that the `env['rack.multithread']` option was being reset when the method exited, but (potentially) before a streaming body had executed code that tests this option. I changed the code to a simpler but less memory efficient approach using `Hash#merge`. I suppose it could be optimized to  be cleaned up in the BodyProxy block and ensure block the same way the mutex is conditionally unlocked; but I wanted to go with the simplest thing that could work and send it upstream for comment first. My guess was that the most common use case for `Rack::Proxy` may not necessarily value performance higher than correctness.

I'd love it if this could be merged into 1-6-stable and rack-1.5 branches. If necessary I would be happy to provide PRs for both of those branches.