### PR TITLE
MockRequest should include REQUEST_PATH as part of env

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -96,6 +96,7 @@ module Rack
       env[SERVER_PORT] = uri.port ? uri.port.to_s : "80"
       env[QUERY_STRING] = uri.query.to_s
       env[PATH_INFO] = (!uri.path || uri.path.empty?) ? "/" : uri.path
+      env[REQUEST_PATH] = env[PATH_INFO]
       env["rack.url_scheme"] = uri.scheme || "http"
       env[HTTPS] = env["rack.url_scheme"] == "https" ? "on" : "off"
 

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -34,6 +34,7 @@ describe Rack::MockRequest do
     env = Rack::MockRequest.env_for("http://www.example.com/parse?location[]=1&location[]=2&age_group[]=2")
     env["QUERY_STRING"].should.equal "location[]=1&location[]=2&age_group[]=2"
     env["PATH_INFO"].should.equal "/parse"
+    env["REQUEST_PATH"].should.equal "/parse"
     env.should.be.kind_of Hash
     env.should.include "rack.version"
   end
@@ -47,6 +48,7 @@ describe Rack::MockRequest do
     env["SERVER_PORT"].should.equal "80"
     env["QUERY_STRING"].should.equal ""
     env["PATH_INFO"].should.equal "/"
+    env["REQUEST_PATH"].should.equal "/"
     env["SCRIPT_NAME"].should.equal ""
     env["rack.url_scheme"].should.equal "http"
     env["mock.postdata"].should.be.empty
@@ -106,6 +108,7 @@ describe Rack::MockRequest do
     env["SERVER_PORT"].should.equal "9292"
     env["QUERY_STRING"].should.equal "bar"
     env["PATH_INFO"].should.equal "/meh/foo"
+    env["REQUEST_PATH"].should.equal "/meh/foo"
     env["rack.url_scheme"].should.equal "https"
   end
 
@@ -120,6 +123,7 @@ describe Rack::MockRequest do
     env["SERVER_PORT"].should.equal "443"
     env["QUERY_STRING"].should.equal ""
     env["PATH_INFO"].should.equal "/foo"
+    env["REQUEST_PATH"].should.equal "/foo"
     env["rack.url_scheme"].should.equal "https"
     env["HTTPS"].should.equal "on"
   end
@@ -135,6 +139,7 @@ describe Rack::MockRequest do
     env["SERVER_PORT"].should.equal "80"
     env["QUERY_STRING"].should.equal ""
     env["PATH_INFO"].should.equal "/foo"
+    env["REQUEST_PATH"].should.equal "/foo"
     env["rack.url_scheme"].should.equal "http"
   end
 
@@ -151,6 +156,7 @@ describe Rack::MockRequest do
     env["QUERY_STRING"].should.include "baz=2"
     env["QUERY_STRING"].should.include "foo[bar]=1"
     env["PATH_INFO"].should.equal "/foo"
+    env["REQUEST_PATH"].should.equal "/foo"
     env["mock.postdata"].should.equal ""
   end
 
@@ -161,6 +167,7 @@ describe Rack::MockRequest do
     env["QUERY_STRING"].should.include "baz=2"
     env["QUERY_STRING"].should.include "foo[bar]=1"
     env["PATH_INFO"].should.equal "/foo"
+    env["REQUEST_PATH"].should.equal "/foo"
     env["mock.postdata"].should.equal ""
   end
 
@@ -170,6 +177,7 @@ describe Rack::MockRequest do
     env["REQUEST_METHOD"].should.equal "POST"
     env["QUERY_STRING"].should.equal ""
     env["PATH_INFO"].should.equal "/foo"
+    env["REQUEST_PATH"].should.equal "/foo"
     env["CONTENT_TYPE"].should.equal "application/x-www-form-urlencoded"
     env["mock.postdata"].should.equal "foo[bar]=1"
   end
@@ -180,6 +188,7 @@ describe Rack::MockRequest do
     env["REQUEST_METHOD"].should.equal "POST"
     env["QUERY_STRING"].should.equal ""
     env["PATH_INFO"].should.equal "/foo"
+    env["REQUEST_PATH"].should.equal "/foo"
     env["CONTENT_TYPE"].should.equal "application/x-www-form-urlencoded"
     env["mock.postdata"].should.equal "foo[bar]=1"
   end
@@ -191,6 +200,7 @@ describe Rack::MockRequest do
     env["REQUEST_METHOD"].should.equal "POST"
     env["QUERY_STRING"].should.equal ""
     env["PATH_INFO"].should.equal "/foo"
+    env["REQUEST_PATH"].should.equal "/foo"
     env["CONTENT_TYPE"].should.equal "multipart/form-data; boundary=AaB03x"
     # The gsub accounts for differences in YAMLs affect on the data.
     env["mock.postdata"].gsub("\r", "").length.should.equal 206


### PR DESCRIPTION
The Rack handlers add in an additional key for REQUEST_PATH on each Request, but this key is not present in the MockRequest object. This pull request includes this additional key.