### PR TITLE
Don't get ancestors' constant as Handler that name is same

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -19,7 +19,7 @@ module Rack
       if klass = @handlers[server]
         klass.split("::").inject(Object) { |o, x| o.const_get(x) }
       else
-        const_get(server)
+        const_get(server, false)
       end
 
     rescue NameError => name_error

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -23,6 +23,10 @@ describe Rack::Handler do
     lambda {
       Rack::Handler.get('boom')
     }.should.raise(LoadError)
+
+    lambda {
+      Rack::Handler.get('Object')
+    }.should.raise(LoadError)
   end
 
   should "get unregistered, but already required, handler by name" do


### PR DESCRIPTION
On current implementation, `Rack::Handler.get` try to get module (constant) that is not defined  under `Rack::Handler`. Try this:

```ruby
require 'rack'

module Foo # not a rack handler
end

Rack::Handler.get('Foo') #=> Foo
```
Returning non-related module like `Foo` causes misunderstanding and unexpected error. I guess that `const_get` in `Rack::Handler.get` is for module that defined under  `Rack::Handler`.

This 1-liner PR fixes this with 2nd argument `false` of `const_get`. `false` stops looking up constant to the ancestors. It can be used since Ruby 1.9.1.
http://ruby-doc.org/core-1.9.1/Module.html#method-i-const_get

This also fixes an error of following simple command:

    $ ruby -rsinatra -rrestclient -e0
    /home/tadashi/rubies/2.2/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1505:in `start_server': undefined method `run' for HTTP:Module (NoMethodError)
    	from /home/tadashi/rubies/2.2/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1443:in `run!'
    	from /home/tadashi/rubies/2.2/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/main.rb:25:in `block in <module:Sinatra>'

It occurs because:

1. restclient 1.8.0 requires http-cookie https://github.com/sparklemotion/http-cookie
2. http-cookie defines empty module `::HTTP` https://github.com/sparklemotion/http-cookie/blob/master/lib/http/cookie.rb#L8
3. sinatra try to get `"HTTP"` as Rack::Handler https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1869 and https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1777

I hope this is picked for stable branch too. 