### PR TITLE
cache result of to_app to avoid re-traversal of maps

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -150,7 +150,8 @@ module Rack
     end
 
     def call(env)
-      to_app.call(env)
+      @to_app ||= to_app
+      @to_app.call(env)
     end
 
     private


### PR DESCRIPTION
This prevents re-traversing the whole middleware tree and re-instantiating
Rack::Builder instances on each request.

I guess that this commit was in the same direction, except it does not solve the
problem as far as I can see:

https://github.com/rack/rack/commit/b51f3036fbdb911eac6b5cf97ebf9388fb1f14a9

This passes tests. Of course it assumes that it's fine to reuse the same
Rack::Builder instance for more than one request (I don't see why that should
not be the case).

I already use this change in a production app with a large number of mappings,
where we experienced massive improvements on routing time and object allocation.

Here is a quick benchmark (to be run on the current Rack::Builder, before
applying this change): https://gist.github.com/lucaong/ec70d8059adb48e4ca8a
