### PR TITLE
Ignore param parsing errors in MethodOverride

### DIFF
--- a/lib/rack/methodoverride.rb
+++ b/lib/rack/methodoverride.rb
@@ -37,6 +37,7 @@ module Rack
 
     def method_override_param(req)
       req.POST[METHOD_OVERRIDE_PARAM_KEY]
+    rescue Utils::InvalidParameterError, Utils::ParameterTypeError
     end
   end
 end

--- a/test/spec_methodoverride.rb
+++ b/test/spec_methodoverride.rb
@@ -72,4 +72,11 @@ EOF
 
     env["REQUEST_METHOD"].should.equal "POST"
   end
+
+  should "not modify REQUEST_METHOD for POST requests when the params are unparseable" do
+    env = Rack::MockRequest.env_for("/", :method => "POST", :input => "(%bad-params%)")
+    app.call env
+
+    env["REQUEST_METHOD"].should.equal "POST"
+  end
 end


### PR DESCRIPTION
If unparseable parameters are passed through `Rack::MethodOverride` it will bomb whilst looking for the `_method` parameter. Because `Rack::MethodOverride` is usually included low down in the stack this exception often goes uncaught, causing a 500.

This PR silently ignores parameter parsing errors that occur in `Rack::MethodOverride`. If the params are used later the same exception will be raised, but this will typically be much higher up the stack, and after any exception handling middleware.

See https://github.com/rails/rails/pull/19632 for a discussion of this in Rails.