### PR TITLE
Lazily instantiate ERB template object

### DIFF
--- a/lib/rack/showexceptions.rb
+++ b/lib/rack/showexceptions.rb
@@ -14,10 +14,19 @@ module Rack
 
   class ShowExceptions
     CONTEXT = 7
+    
+    class << self
+      def template
+        @template ||= ERB.new(TEMPLATE)
+      end
+    end
+    
+    def template
+      self.class.template
+    end
 
     def initialize(app)
       @app = app
-      @template = ERB.new(TEMPLATE)
     end
 
     def call(env)
@@ -94,7 +103,7 @@ module Rack
         end
       }.compact
 
-      @template.result(binding)
+      template.result(binding)
     end
 
     def h(obj)                  # :nodoc:


### PR DESCRIPTION
ShowExceptions currently parses it's ERB template on instantiation. This can add significant overhead, especially for frameworks and applications that may add middleware dynamically on each request, such as Scorched, where caching an application instance is non-trivial.