### PR TITLE
Secure request.referer

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -290,6 +290,7 @@ module Rack
 
     # the referer of the client
     def referer
+      return nil if !@env['HTTP_REFERER'].nil? && @env['HTTP_REFERER'].match(/\Ajavascript:/i)
       @env['HTTP_REFERER']
     end
     alias referrer referer

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -152,7 +152,7 @@ describe Rack::Request do
     req.POST.should.be.empty
     req.params.should.equal "foo" => "bar", "quux" => "b", "la" => nil, "wun" => "duh"
   end
-  
+
   should "limit the keys from the GET query string" do
     env = Rack::MockRequest.env_for("/?foo=bar")
 
@@ -329,6 +329,14 @@ describe Rack::Request do
 
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/")
+    req.referer.should.equal nil
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_REFERER" => "javascript:alert(1)")
+    req.referer.should.equal nil
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_REFERER" => "JAVASCRIPT:alert(1)")
     req.referer.should.equal nil
   end
 


### PR DESCRIPTION
Sanitize `request.referer` for preventing XSS