### PR TITLE
Use the default HTTP output buffer, instead of 5

### DIFF
--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -28,7 +28,6 @@ module Rack
 
         options[:BindAddress] = options.delete(:Host) || default_host
         options[:Port] ||= 8080
-        options[:OutputBufferSize] = 5
         @server = ::WEBrick::HTTPServer.new(options)
         @server.mount "/", Rack::Handler::WEBrick, app
         yield @server  if block_given?


### PR DESCRIPTION
Setting the output buffer size to 5 means that we will do thousands of
small writes when serving a large file, which is inefficient. This fix
improves performance of the HTTP server.

This resolves the slow-down referenced at https://github.com/rails/rails/issues/18828