### PR TITLE
Allow file names with underscores inside Rack::Builder.parse_file

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -40,7 +40,7 @@ module Rack
         app = new_from_string cfgfile, config
       else
         require config
-        app = Object.const_get(::File.basename(config, '.rb').capitalize)
+        app = Object.const_get(::File.basename(config, '.rb').split('_').map(&:capitalize).join(''))
       end
       return app, options
     end

--- a/test/builder/an_underscore_app.rb
+++ b/test/builder/an_underscore_app.rb
@@ -1,0 +1,5 @@
+class AnUnderscoreApp
+  def self.call(env)
+    [200, {'Content-Type' => 'text/plain'}, ['OK']]
+  end
+end

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -210,6 +210,13 @@ describe Rack::Builder do
       $:.pop
     end
 
+    it 'requires an_underscore_app not ending in .ru' do
+      $: << File.dirname(__FILE__)
+      app, * = Rack::Builder.parse_file 'builder/an_underscore_app'
+      Rack::MockRequest.new(app).get('/').body.to_s.should.equal 'OK'
+      $:.pop
+    end
+
     it "sets __LINE__ correctly" do
       app, _ = Rack::Builder.parse_file config_file('line.ru')
       Rack::MockRequest.new(app).get("/").body.to_s.should.equal '1'


### PR DESCRIPTION
Currently, files with underscores are not loaded using
standard ruby/rails conventions b/c of the way Object.const_get
is called inside Rack::Builder.parse_file.

For example, a filename 'my_example_app', will be required and then
an Object.const_get('My_example_app') call will throw a NameError unless
you have named your class accordingly inside the my_example_app file.

This commit changes the behavior so that 'my_example_app' is required
and then Object.const_get('MyExampleApp') is called. I think this is
the behavior most developers would expect.