### PR TITLE
Add backported bug fix.

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -197,7 +197,6 @@ module Rack
       elsif @env["rack.request.form_input"].eql? @env["rack.input"]
         @env["rack.request.form_hash"]
       elsif form_data? || parseable_data?
-        @env["rack.request.form_input"] = @env["rack.input"]
         unless @env["rack.request.form_hash"] = parse_multipart(env)
           form_vars = @env["rack.input"].read
 
@@ -210,6 +209,7 @@ module Rack
 
           @env["rack.input"].rewind
         end
+        @env["rack.request.form_input"] = @env["rack.input"]
         @env["rack.request.form_hash"]
       else
         {}

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -674,6 +674,20 @@ EOF
     lambda { req.POST }.should.raise(EOFError)
   end
 
+  should "consistently raise EOFError on bad multipart form data" do
+    input = <<EOF
+--AaB03x\r
+content-disposition: form-data; name="huge"; filename="huge"\r
+EOF
+    req = Rack::Request.new Rack::MockRequest.env_for("/",
+                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_LENGTH" => input.size,
+                      :input => input)
+
+    lambda { req.POST }.should.raise(EOFError)
+    lambda { req.POST }.should.raise(EOFError)
+  end
+
   should "correctly parse the part name from Content-Id header" do
     input = <<EOF
 --AaB03x\r


### PR DESCRIPTION
This bug is causing confusing errors such as:

{"error" => "Failed to access params -- no implicit conversion of nil into Hash"}

This code is provided in this PR: https://github.com/rack/rack/pull/561 and is never officially released to the 1.4.x branch.
