### PR TITLE
Duplicate the @names hash on dup/clone to avoid shared references.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -480,6 +480,12 @@ module Rack
         hash.each { |k, v| self[k] = v }
       end
 
+      # on dup/clone, we need to duplicate @names hash
+      def initialize_copy(other)
+        super
+        @names = other.names.dup
+      end
+
       def each
         super do |k, v|
           yield(k, v.respond_to?(:to_ary) ? v.to_ary.join("\n") : v)
@@ -532,6 +538,11 @@ module Rack
         other.each { |k, v| self[k] = v }
         self
       end
+
+      protected
+        def names
+          @names
+        end
     end
 
     class KeySpaceConstrainedParams

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -506,6 +506,19 @@ describe Rack::Utils::HeaderHash do
     h.should.not.include 'ETag'
   end
 
+  should "create deep HeaderHash copy on dup" do
+    h1 = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+    h2 = h1.dup
+
+    h1.should.include 'content-md5'
+    h2.should.include 'content-md5'
+
+    h2.delete("Content-MD5")
+
+    h2.should.not.include 'content-md5'
+    h1.should.include 'content-md5'
+  end
+
   should "merge case-insensitively" do
     h = Rack::Utils::HeaderHash.new("ETag" => 'HELLO', "content-length" => '123')
     merged = h.merge("Etag" => 'WORLD', 'Content-Length' => '321', "Foo" => 'BAR')


### PR DESCRIPTION
We need to manually dup the `@names` hash since a HeaderHash.dup is
shallow, leading to multiple HeaderHash objects sharing the same
`@names` hash.

Very similar to https://github.com/lostisland/faraday/pull/478