### PR TITLE
Ensure correct parsing for quoted multipart boundary

### DIFF
--- a/test/multipart/quoted
+++ b/test/multipart/quoted
@@ -1,0 +1,15 @@
+--AaB:03x
+Content-Disposition: form-data; name="submit-name"
+
+Larry
+--AaB:03x
+Content-Disposition: form-data; name="submit-name-with-content"
+Content-Type: text/plain
+
+Berry
+--AaB:03x
+Content-Disposition: form-data; name="files"; filename="file1.txt"
+Content-Type: text/plain
+
+contents
+--AaB:03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -6,7 +6,7 @@ describe Rack::Multipart do
     file = multipart_file(name)
     data = File.open(file, 'rb') { |io| io.read }
 
-    type = "multipart/form-data; boundary=#{boundary}"
+    type = %(multipart/form-data; boundary=#{boundary})
     length = data.respond_to?(:bytesize) ? data.bytesize : data.size
 
     { "CONTENT_TYPE" => type,
@@ -227,6 +227,20 @@ describe Rack::Multipart do
     params["files"][:filename].should.equal "fi;le1.txt"
     params["files"][:head].should.equal "Content-Disposition: form-data; " +
       "name=\"files\"; filename=\"fi;le1.txt\"\r\n" +
+      "Content-Type: text/plain\r\n"
+    params["files"][:name].should.equal "files"
+    params["files"][:tempfile].read.should.equal "contents"
+  end
+
+  should "parse multipart upload with quoted boundary" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:quoted, %("AaB:03x")))
+    params = Rack::Multipart.parse_multipart(env)
+    params["submit-name"].should.equal "Larry"
+    params["submit-name-with-content"].should.equal "Berry"
+    params["files"][:type].should.equal "text/plain"
+    params["files"][:filename].should.equal "file1.txt"
+    params["files"][:head].should.equal "Content-Disposition: form-data; " +
+      "name=\"files\"; filename=\"file1.txt\"\r\n" +
       "Content-Type: text/plain\r\n"
     params["files"][:name].should.equal "files"
     params["files"][:tempfile].read.should.equal "contents"


### PR DESCRIPTION
This PR adds a test to exercise a problem reported with #858.
It supposed to fail, but it doesn't. That's why production code hasn't been touched.

Merging this PR is optional, but it increases test suite robustness: there isn't a test to cover this case. It may help to prevent regressions.