### PR TITLE
Remove Rack::Utils.bytesize method in favour of native method

### DIFF
--- a/lib/rack/chunked.rb
+++ b/lib/rack/chunked.rb
@@ -21,7 +21,7 @@ module Rack
       def each
         term = TERM
         @body.each do |chunk|
-          size = bytesize(chunk)
+          size = chunk.bytesize
           next if size == 0
 
           chunk = chunk.dup.force_encoding(Encoding::BINARY) if chunk.respond_to?(:force_encoding)

--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -22,7 +22,7 @@ module Rack
 
         obody = body
         body, length = [], 0
-        obody.each { |part| body << part; length += bytesize(part) }
+        obody.each { |part| body << part; length += part.bytesize }
 
         body = BodyProxy.new(body) do
           obody.close if obody.respond_to?(:close)

--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -70,7 +70,7 @@ table { width:100%%; }
       return unless @path_info.include? ".."
 
       body = "Forbidden\n"
-      size = Rack::Utils.bytesize(body)
+      size = body.bytesize
       return [403, {CONTENT_TYPE => "text/plain",
         CONTENT_LENGTH => size.to_s,
         "X-Cascade" => "pass"}, [body]]
@@ -128,7 +128,7 @@ table { width:100%%; }
 
     def entity_not_found
       body = "Entity not found: #{@path_info}\n"
-      size = Rack::Utils.bytesize(body)
+      size = body.bytesize
       return [404, {CONTENT_TYPE => "text/plain",
         CONTENT_LENGTH => size.to_s,
         "X-Cascade" => "pass"}, [body]]

--- a/lib/rack/file.rb
+++ b/lib/rack/file.rb
@@ -139,7 +139,7 @@ module Rack
       #   We check via File::size? whether this file provides size info
       #   via stat (e.g. /proc files often don't), otherwise we have to
       #   figure it out by reading the whole file into memory.
-      F.size?(@path) || Utils.bytesize(F.read(@path))
+      F.size?(@path) || F.read(@path).bytesize
     end
 
     # By default, the response body for file requests is nil.

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -710,7 +710,7 @@ module Rack
         assert("Body yielded non-string value #{part.inspect}") {
           part.kind_of? String
         }
-        bytes += Rack::Utils.bytesize(part)
+        bytes += part.bytesize
         yield part
       }
       verify_content_length(bytes)

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -37,7 +37,7 @@ module Rack
         @boundary       = "--#{boundary}"
         @io             = io
         @content_length = content_length
-        @boundary_size  = Utils.bytesize(@boundary) + EOL.size
+        @boundary_size  = @boundary.bytesize + EOL.size
         @env = env
         @tempfile       = tempfile
         @bufsize        = bufsize
@@ -103,7 +103,7 @@ module Rack
             return if read_buffer == full_boundary
           end
 
-          raise EOFError, "bad content body" if Utils.bytesize(@buf) >= @bufsize
+          raise EOFError, "bad content body" if @buf.bytesize >= @bufsize
         end
       end
 

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -97,7 +97,7 @@ module Rack
     #
     def write(str)
       s = str.to_s
-      @length += Rack::Utils.bytesize(s) unless @chunked
+      @length += s.bytesize unless @chunked
       @writer.call s
 
       header[CONTENT_LENGTH] = @length.to_s unless @chunked

--- a/lib/rack/rewindable_input.rb
+++ b/lib/rack/rewindable_input.rb
@@ -88,7 +88,7 @@ module Rack
         entire_buffer_written_out = false
         while !entire_buffer_written_out
           written = @rewindable_io.write(buffer)
-          entire_buffer_written_out = written == Rack::Utils.bytesize(buffer)
+          entire_buffer_written_out = written == buffer.bytesize
           if !entire_buffer_written_out
             buffer.slice!(0 .. written - 1)
           end

--- a/lib/rack/showexceptions.rb
+++ b/lib/rack/showexceptions.rb
@@ -40,7 +40,7 @@ module Rack
         500,
         {
           CONTENT_TYPE => content_type,
-          CONTENT_LENGTH => Rack::Utils.bytesize(body).to_s,
+          CONTENT_LENGTH => body.bytesize.to_s,
         },
         [body],
       ]

--- a/lib/rack/showstatus.rb
+++ b/lib/rack/showstatus.rb
@@ -34,7 +34,7 @@ module Rack
         detail = detail = env["rack.showstatus.detail"] || message
 
         body = @template.result(binding)
-        size = Rack::Utils.bytesize(body)
+        size = body.bytesize
         [status, headers.merge(CONTENT_TYPE => "text/html", CONTENT_LENGTH => size.to_s), [body]]
       else
         [status, headers, body]

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -370,19 +370,6 @@ module Rack
     end
     module_function :delete_cookie_header!
 
-    # Return the bytesize of String; uses String#size under Ruby 1.8 and
-    # String#bytesize under 1.9.
-    if ''.respond_to?(:bytesize)
-      def bytesize(string)
-        string.bytesize
-      end
-    else
-      def bytesize(string)
-        string.size
-      end
-    end
-    module_function :bytesize
-
     def rfc2822(time)
       time.rfc2822
     end
@@ -444,7 +431,7 @@ module Rack
     # on variable length plaintext strings because it could leak length info
     # via timing attacks.
     def secure_compare(a, b)
-      return false unless bytesize(a) == bytesize(b)
+      return false unless a.bytesize == b.bytesize
 
       l = a.unpack("C*")
 

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -6,7 +6,7 @@ require 'timeout'
 describe Rack::Utils do
 
   # A helper method which checks
-  # if certain query parameters 
+  # if certain query parameters
   # are equal.
   def equal_query_to(query)
     parts = query.split('&')
@@ -78,7 +78,7 @@ describe Rack::Utils do
       Rack::Utils.escape("ø".encode("ISO-8859-1")).should.equal "%F8"
     end
   end
-  
+
   should "not hang on escaping long strings that end in % (http://redmine.ruby-lang.org/issues/5149)" do
     lambda {
       timeout(1) do
@@ -412,10 +412,6 @@ describe Rack::Utils do
 
     helper.call(%w(foo bar identity), [["foo", 0], ["bar", 0]]).should.equal("identity")
     helper.call(%w(foo bar baz identity), [["*", 0], ["identity", 0.1]]).should.equal("identity")
-  end
-
-  should "return the bytesize of String" do
-    Rack::Utils.bytesize("FOO\xE2\x82\xAC").should.equal 6
   end
 
   should "should perform constant time string comparison" do


### PR DESCRIPTION
Since Rack 2.0 depends on Ruby 2.2+. This method can be freely removed in favour of native String’s method `bytesize`.

Please, before merging this PR is needed to merge PR #862.