### PR TITLE
Remove legacy code in Rack::Server.daemonize_app method

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -354,17 +354,7 @@ module Rack
       end
 
       def daemonize_app
-        if RUBY_VERSION < "1.9"
-          exit if fork
-          Process.setsid
-          exit if fork
-          Dir.chdir "/"
-          STDIN.reopen "/dev/null"
-          STDOUT.reopen "/dev/null", "a"
-          STDERR.reopen "/dev/null", "a"
-        else
-          Process.daemon
-        end
+        Process.daemon
       end
 
       def write_pid


### PR DESCRIPTION
This code is not needed anymore on Ruby 2.2+.

Please, before merging this PR is needed to merge PR #862.