### PR TITLE
Make WEBrick ipv6 friendly

### DIFF
--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -24,7 +24,7 @@ module Rack
     class WEBrick < ::WEBrick::HTTPServlet::AbstractServlet
       def self.run(app, options={})
         environment  = ENV['RACK_ENV'] || 'development'
-        default_host = environment == 'development' ? 'localhost' : '0.0.0.0'
+        default_host = environment == 'development' ? 'localhost' : nil
 
         options[:BindAddress] = options.delete(:Host) || default_host
         options[:Port] ||= 8080


### PR DESCRIPTION
WEBrick uses for creating listeners Socket.tcp_server_sockets. If tcp_server_sockets is given host: nil, it opens socket on [::] address (IPv6 if available) and while on 0.0.0.0 (if IPv4 if available). See documentation: http://docs.ruby-lang.org/en/2.2.0/Socket.html#method-c-tcp_server_sockets

Closes #833