### PR TITLE
request.referer checks HTTP_REFERRER as well.

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -289,7 +289,7 @@ module Rack
 
     # the referer of the client
     def referer
-      @env['HTTP_REFERER']
+      @env['HTTP_REFERER'] || @env['HTTP_REFERRER']
     end
     alias referrer referer
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -172,7 +172,7 @@ describe Rack::Request do
     req.POST.should.be.empty
     req.params.should.equal "foo" => "bar", "quux" => "b", "la" => nil, "wun" => "duh"
   end
-  
+
   should "limit the keys from the GET query string" do
     env = Rack::MockRequest.env_for("/?foo=bar")
 
@@ -387,6 +387,10 @@ describe Rack::Request do
   should "extract referrer correctly" do
     req = Rack::Request.new \
       Rack::MockRequest.env_for("/", "HTTP_REFERER" => "/some/path")
+    req.referer.should.equal "/some/path"
+
+    req = Rack::Request.new \
+      Rack::MockRequest.env_for("/", "HTTP_REFERRER" => "/some/path")
     req.referer.should.equal "/some/path"
 
     req = Rack::Request.new \


### PR DESCRIPTION
I had a request come in that had HTTP_REFERRER set (HTTP_REFERER was blank).

```
  "HTTP_REFERRER": "https://www.lolshirts.com/",
  "HTTP_USER_AGENT": "Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/549.36 (KHTML, like Gecko) Chrome/41.0.2382.89 Safari/549.16",
```

`request.referer` was `nil`. This fixes that.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rack/rack/874)

<!-- Reviewable:end -->
