### PR TITLE
Close body set via initializer, matching direct #body accessor

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -103,9 +103,6 @@ module Rack
     end
 
     # Append to body and update Content-Length.
-    #
-    # NOTE: Do not mix #write and direct #body access!
-    #
     def write(str)
       s = str.to_s
       @length += s.bytesize unless @chunked

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -113,7 +113,8 @@ module Rack
     end
 
     def close_input
-      @body_input.close if @body_input != nil && @body_input.respond_to?(:close)
+      @body_input.close if @body_input != nil && @body_input.respond_to?(:close) &&
+          !(@body_input.respond_to?(:closed?) && @body_input.closed?) # prevent double-close IOError on streams
       @body_input = nil # remove reference to old body after closing
     end
 

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -29,9 +29,18 @@ module Rack
       @chunked = CHUNKED == @header[TRANSFER_ENCODING]
       @writer  = lambda { |x| @body << x }
       @block   = nil
-      @length  = 0
 
-      @body = []
+      @body = nil
+
+      @body_input = nil
+      self.body = body
+      yield self  if block_given?
+    end
+
+    def body=(body)
+      @length = 0
+      # provide body#close and body#closed?
+      @body = BodyProxy.new([]){}
 
       if body.respond_to? :to_str
         write body.to_str
@@ -43,11 +52,12 @@ module Rack
         raise TypeError, "stringable or iterable required"
       end
 
-      yield self  if block_given?
+      # don't close input body until #finish, because body#close may be called first
+      @body_input = body if body.respond_to?(:close)
     end
 
-    attr_reader :header
-    attr_accessor :status, :body
+    attr_reader :header, :body
+    attr_accessor :status
 
     def [](key)
       header[key]
@@ -71,6 +81,7 @@ module Rack
     end
 
     def finish(&block)
+      close_input
       @block = block
 
       if [204, 205, 304].include?(status.to_i)
@@ -104,7 +115,13 @@ module Rack
       str
     end
 
+    def close_input
+      @body_input.close if @body_input != nil && @body_input.respond_to?(:close)
+      @body_input = nil # remove reference to old body after closing
+    end
+
     def close
+      close_input
       body.close if body.respond_to?(:close)
     end
 

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -353,4 +353,24 @@ describe Rack::Response do
     res.finish.last.should.not.respond_to?(:to_ary)
     lambda { res.finish.last.to_ary }.should.raise(NoMethodError)
   end
+
+  it "closes body set via initializer" do
+    body = StringIO.new
+    res = Rack::Response.new body
+    _,_,b = res.finish
+    body.should.be.closed
+    b.close if b.respond_to? :close
+  end
+
+  it "can set #body multiple times" do
+    # Only the last body set should be in the response
+    res = Rack::Response.new ['foo']
+    res.body = StringIO.new 'bar'
+    res.body = ['baz']
+    _,_,b = res.finish
+    output = ''
+    b.each {|part| output << part}
+    b.close if b.respond_to? :close
+    output.should.equal 'baz'
+  end
 end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -374,6 +374,20 @@ describe Rack::Response do
     output.should.equal 'baz'
   end
 
+  it "can close body from #finish after body#close is called" do
+    body = StringIO.new 'foo'
+
+    # rack-test uses this pattern
+    res = Rack::Response.new(body)
+    body.close
+
+    _, _, b = res.finish
+    output = ''
+    b.each {|part| output << part}
+    b.close if b.respond_to? :close
+    output.should.equal 'foo'
+  end
+
   it "can mix #write and direct #body access" do
     res = Rack::Response.new
     res.body = ['foo']

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -398,4 +398,15 @@ describe Rack::Response do
     b.close if b.respond_to? :close
     output.should.equal 'foobar'
   end
+
+  it "updates Content-Length when body is changed" do
+    res = Rack::Response.new 'foo'
+    res.content_length.should.equal 3
+    res = Rack::Response.new
+    res.write 'bar'
+    res.content_length.should.equal 3
+    res = Rack::Response.new
+    res.body = 'baz'
+    res.content_length.should.equal 3
+  end
 end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -373,4 +373,15 @@ describe Rack::Response do
     b.close if b.respond_to? :close
     output.should.equal 'baz'
   end
+
+  it "can mix #write and direct #body access" do
+    res = Rack::Response.new
+    res.body = ['foo']
+    res.write 'bar'
+    _,_,b = res.finish
+    output = ''
+    b.each {|part| output << part}
+    b.close if b.respond_to? :close
+    output.should.equal 'foobar'
+  end
 end


### PR DESCRIPTION
This PR makes `Request.new(body)` behave the same as `Request.new.body = body`, ensuring that a body object passed via the class initializer will be closed properly by `Response#finish`. Besides eliminating that strange difference in behavior, it has the additional benefit of making it possible to mix #write and direct #body access without problems, so I've removed that warning comment and added a test to verify it works.

Fixes #877.