### PR TITLE
Refactor Rack::Response to accept unbuffered body content

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -165,7 +165,7 @@ module Rack
       @errors           = errors.string if errors.respond_to?(:string)
       @body_string      = nil
 
-      super(body, status, headers)
+      super(body, status, headers, true)
     end
 
     def =~(other)
@@ -187,7 +187,7 @@ module Rack
       #     ...
       #     res.body.should == "foo!"
       #   end
-      super.join
+      @body_string ||= [].tap{|str|super.each{|part|str << part}}.join
     end
 
     def empty?


### PR DESCRIPTION
This refactor follows the discussion in issue #877, and is a further improvement upon PR #887 based on feedback from @tenderlove to allow buffered/unbuffered body contents to be explicitly configurable in the class constructor and to allow some breaking API changes for the 2.0 branch.

Summary:
- make the behavior among the available interfaces to update body contents consistent
  - v2 API change: the `body=` setter will become private
- allow configurable buffering of body contents (through `buffered` constructor parameter, or `Response.buffered`/`Response.unbuffered` factory methods)
  - v2 API change: `unbuffered` will become the default setting (on the fence about this one- while unbuffered will be more efficient, it also will not support updating the `Content-Length` header)
- v2 API change: raise error when `#write` or `#each` are called after `#close` has already been called
- update class documentation
