### PR TITLE
Support BodyProxy objects in ContentLength middleware

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -4,9 +4,8 @@ module Rack
       @body, @block, @closed = body, block, false
     end
 
-    def respond_to?(*args)
-      return false if args.first.to_s =~ /^to_ary$/
-      super or @body.respond_to?(*args)
+    def respond_to?(method_name, include_all=false)
+      super or @body.respond_to?(method_name, include_all)
     end
 
     def close
@@ -27,13 +26,12 @@ module Rack
     # We are applying this special case for #each only. Future bugs of this
     # class will be handled by requesting users to patch their ruby
     # implementation, to save adding too many methods in this class.
-    def each(*args, &block)
-      @body.each(*args, &block)
+    def each
+      @body.each { |body| yield body }
     end
 
-    def method_missing(*args, &block)
-      super if args.first.to_s =~ /^to_ary$/
-      @body.__send__(*args, &block)
+    def method_missing(method_name, *args, &block)
+      @body.__send__(method_name, *args, &block)
     end
   end
 end

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -56,13 +56,13 @@ describe Rack::BodyProxy do
     proc { proxy.respond_to?(:foo, false) }.should.not.raise
   end
 
-  should 'not respond to :to_ary' do
+  should 'respond to :to_ary' do
     body = OpenStruct.new(:to_ary => true)
     body.respond_to?(:to_ary).should.equal true
 
     proxy = Rack::BodyProxy.new(body) { }
-    proxy.respond_to?(:to_ary).should.equal false
-    proxy.respond_to?("to_ary").should.equal false
+    proxy.respond_to?(:to_ary).should.equal true
+    proxy.respond_to?("to_ary").should.equal true
   end
 
   should 'not close more than one time' do

--- a/test/spec_content_length.rb
+++ b/test/spec_content_length.rb
@@ -82,4 +82,13 @@ describe Rack::ContentLength do
     response[1]['Content-Length'].should.equal expected.join.size.to_s
     response[2].to_enum.to_a.should.equal expected
   end
+
+  should "support Array bodies wrapped by BodyProxy" do
+    require 'rack/body_proxy'
+    str = ['foo']
+    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, Rack::BodyProxy.new(str)] }
+    response = content_length(app).call(request)
+    response[1]['Content-Length'].should.equal '3'
+    response[2].to_enum.to_a.should.equal str
+  end
 end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -337,7 +337,15 @@ describe Rack::Response do
 
   it "wraps the body from #to_ary to prevent infinite loops" do
     res = Rack::Response.new
-    res.finish.last.should.not.respond_to?(:to_ary)
-    lambda { res.finish.last.to_ary }.should.raise(NoMethodError)
+    res.to_ary.last.should.not.respond_to?(:to_ary)
+    lambda { res.to_ary.last.to_ary }.should.raise(NoMethodError)
+  end
+
+  it "supports [response].flatten" do
+    res = Rack::Response.new ['foo']
+    _, _, b = [res].flatten
+    output = ''
+    b.each {|part| output << part}
+    output.should.equal 'foo'
   end
 end


### PR DESCRIPTION
Fixes #734 by localizing the workaround added to `BodyProxy` from #419 to the specific API issue within `Response#to_ary`.

This patch is compatible with 1.6-stable. For 2.x, I would suggest deprecating/removing `Response#to_ary` entirely as [suggested](https://github.com/rack/rack/issues/419#issuecomment-55509509) by @jeremy, then all of the `NoAryBody` code can just be removed entirely.
