### PR TITLE
1.6 backport of: Remove parse_query from request.rb…

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -188,7 +188,7 @@ module Rack
       if @env["rack.request.query_string"] == query_string
         @env["rack.request.query_hash"]
       else
-        p = parse_query(query_string, '&;')
+        p = Utils.parse_nested_query(query_string, '&;')
         @env["rack.request.query_string"] = query_string
         @env["rack.request.query_hash"]   = p
       end
@@ -212,7 +212,7 @@ module Rack
           form_vars.slice!(-1) if form_vars[-1] == ?\0
 
           @env["rack.request.form_vars"] = form_vars
-          @env["rack.request.form_hash"] = parse_query(form_vars, '&')
+          @env["rack.request.form_hash"] = Utils.parse_nested_query(form_vars, '&')
 
           @env["rack.input"].rewind
         end
@@ -363,10 +363,6 @@ module Rack
 
       def reject_trusted_ip_addresses(ip_addresses)
         ip_addresses.reject { |ip| trusted_proxy?(ip) }
-      end
-
-      def parse_query(qs, d)
-        Utils.parse_nested_query(qs, d)
       end
 
       def parse_multipart(env)


### PR DESCRIPTION
Remove parse_query from request.rb to provide actiondispatch compatibility.

See https://github.com/rack/rack/issues/896 and https://github.com/rack/rack/pull/897