### PR TITLE
Allow users to disable the secure cookie warning for custom coders

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -105,7 +105,7 @@ module Rack
 
       def initialize(app, options={})
         @secrets = options.values_at(:secret, :old_secret).compact
-        warn <<-MSG unless @secrets.size >= 1
+        warn <<-MSG unless secure?(options)
         SECURITY WARNING: No secret option provided to Rack::Session::Cookie.
         This poses a security threat. It is strongly recommended that you
         provide a secret to prevent exploits that may be possible from crafted
@@ -182,6 +182,11 @@ module Rack
 
       def generate_hmac(data, secret)
         OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA1.new, secret, data)
+      end
+
+      def secure?(options)
+        @secrets.size >= 1 ||
+        (options[:coder] && options[:let_coder_handle_secure_encoding])
       end
 
     end

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -152,6 +152,21 @@ describe Rack::Session::Cookie do
     @warnings.must_be :empty?
   end
 
+  it "doesn't warn if coder is configured to handle encoding" do
+    Rack::Session::Cookie.new(
+      incrementor,
+      :coder => Object.new,
+      :let_coder_handle_secure_encoding => true)
+    @warnings.must_be :empty?
+  end
+
+  it "still warns if coder is not set" do
+    Rack::Session::Cookie.new(
+      incrementor,
+      :let_coder_handle_secure_encoding => true)
+    @warnings.first.must_match(/no secret/i)
+  end
+
   it 'uses a coder' do
     identity = Class.new {
       attr_reader :calls


### PR DESCRIPTION
Hello,

Since we've recently updated Rack we've been getting the "No secret option provided to Rack::Session::Cookie" warning in our logs. However we are providing a custom coder to `Rack::Session::Cookie` that handles all of the encryption:
https://github.com/heroku/identity/blob/master/lib/identity/main.rb#L12-L19

This pull request adds an option to `Rack::Session::Cookie` to disable this warning, but only if a coder is supplied in the cases were the user wants to manage the cookie encryption themselves:

```ruby
use Rack::Session::Cookie,
  coder: MyFancyEncryptionCoder.new,
  let_coder_handle_secure_encoding: true
```

Does this approach make sense? If not I'm happy to hear alternatives.

Thanks!