### PR TITLE
Update cookie parser to only accept `;` as delimiter

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -205,12 +205,11 @@ module Rack
     module_function :parse_cookies
 
     def parse_cookies_header(header)
-      # According to RFC 2109:
-      #   If multiple cookies satisfy the criteria above, they are ordered in
-      #   the Cookie header such that those with more specific Path attributes
-      #   precede those with less specific.  Ordering with respect to other
-      #   attributes (e.g., Domain) is unspecified.
-      cookies = parse_query(header, ';,') { |s| unescape(s) rescue s }
+      # According to RFC 6265:
+      # The syntax for cookie headers only supports semicolons
+      # User Agent -> Server ==
+      # Cookie: SID=31d4d96e407aad42; lang=en-US
+      cookies = parse_query(header, ';') { |s| unescape(s) rescue s }
       cookies.each_with_object({}) { |(k,v), hash| hash[k] = Array === v ? v.first : v }
     end
     module_function :parse_cookies_header


### PR DESCRIPTION
The cookie parse used to accept both `;` and `,` as delimiters. This follows the original specifications in RFC 2109 and RFC 2965, but both of these have been deprecated by RFC 6265 which does not include the possibility of `,` as a delimiter in Cookie: headers. Note that `,` is still not allowed in cookie values (it is explicitly excluded from cookie-octets in RFC 6265).

From now on the cookie parser will only accept `;` as a delimiter to adhere to RFC 6265.

https://github.com/rack/rack/issues/849
