### PR TITLE
Introduce a second argument for Request#parse_query

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -188,7 +188,7 @@ module Rack
       if @env["rack.request.query_string"] == query_string
         @env["rack.request.query_hash"]
       else
-        p = parse_query({ :query => query_string, :separator => '&;' })
+        p = parse_query(query_string, '&;')
         @env["rack.request.query_string"] = query_string
         @env["rack.request.query_hash"]   = p
       end
@@ -212,7 +212,7 @@ module Rack
           form_vars.slice!(-1) if form_vars[-1] == ?\0
 
           @env["rack.request.form_vars"] = form_vars
-          @env["rack.request.form_hash"] = parse_query({ :query => form_vars, :separator => '&' })
+          @env["rack.request.form_hash"] = parse_query(form_vars)
 
           @env["rack.input"].rewind
         end
@@ -365,9 +365,7 @@ module Rack
         ip_addresses.reject { |ip| trusted_proxy?(ip) }
       end
 
-      def parse_query(qs)
-        d = '&'
-        qs, d = qs[:query], qs[:separator] if Hash === qs
+      def parse_query(qs, d = '&')
         Utils.parse_nested_query(qs, d)
       end
 


### PR DESCRIPTION
I think it's a bad idea to mix types (i.e. String and Hash here),
and Utils.parse_query already accepts a second argument for
passing the delimiter, so why not do the same?

Ref: https://github.com/rack/rack/pull/899

My motivation for patching this is because we have overridden
Request#parse_query as follows, and it broke due to the above
pull request:

    class Request < Rack::Request
      def parse_query(qs)
        Rack::Utils.parse_query(qs, '&')
      end
    end

Given my patch, our application would still break, but at least
we just need to accept the delimiter and pass it to Utils.parse_query,
rather than doing String/Hash handling again.

I know accepting this patch means our application would break again,
but I'll just adopt the change again when a new Rack version is
released.

By the way, the intention for overriding Request#parse_query was
trying to avoid Utils.parse_nested_query because I hate that
behaviour. If this could be an option for Rack::Request, that
would be awesome.

If we're willing to make this change, then I'll try to think about
how to make it an option.