### PR TITLE
Make static.rb standalone

### DIFF
--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -1,3 +1,6 @@
+require "rack/file"
+require "rack/utils"
+
 module Rack
 
   # The Rack::Static middleware intercepts requests for static files


### PR DESCRIPTION
People sometimes require `rack/static` without `rack`, resulting in constant errors. This fixes that error.