### PR TITLE
Add manually registered servers as optional default server

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -52,8 +52,9 @@ module Rack
       elsif ENV.include?("RACK_HANDLER")
         self.get(ENV["RACK_HANDLER"])
       else
-        @fall_back ||= ['thin', 'puma', 'webrick', 'lsws', 'cgi', 'fastcgi', 'scgi']
-        pick (@handlers.keys - @fall_back) rescue (pick @fall_back)
+        ordered_defaults = @handlers.keys - ['thin', 'puma', 'webrick', 'lsws', 'cgi', 'fastcgi', 'scgi']
+        ordered_defaults.insert -1, *['thin', 'puma', 'webrick']
+        pick ordered_defaults
       end
     end
 

--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -52,7 +52,8 @@ module Rack
       elsif ENV.include?("RACK_HANDLER")
         self.get(ENV["RACK_HANDLER"])
       else
-        pick ['thin', 'puma', 'webrick']
+        @fall_back ||= ['thin', 'puma', 'webrick', 'lsws', 'cgi', 'fastcgi', 'scgi']
+        pick (@handlers.keys - @fall_back) rescue (pick @fall_back)
       end
     end
 

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -46,10 +46,6 @@ describe Rack::Handler do
     end
   end
 
-  it "returned the newly registered RegisteringMyself handler as default" do
-      Rack::Handler.default.must_equal Rack::Handler::RegisteringMyself
-  end
-
   it "allow autoloaded handlers to be registered properly while being loaded" do
     path = File.expand_path('../registering_handler', __FILE__)
     begin
@@ -57,14 +53,6 @@ describe Rack::Handler do
       Rack::Handler.get('registering_myself').must_equal Rack::Handler::RegisteringMyself
     ensure
       $LOAD_PATH.delete path
-    end
-  end
-
-  it "returned the webrick handler as default" do
-    begin
-      Rack::Handler.default.name.must_match /webrick|thin|puma/i
-    rescue => e
-      puts e.message
     end
   end
 end

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -45,13 +45,9 @@ describe Rack::Handler do
       $LOAD_PATH.delete File.expand_path('../unregistered_handler', __FILE__)
     end
   end
-  
+
   it "returned the newly registered RegisteringMyself handler as default" do
-    begin
       Rack::Handler.default.must_equal Rack::Handler::RegisteringMyself
-    rescue => e
-      
-    end
   end
 
   it "allow autoloaded handlers to be registered properly while being loaded" do
@@ -65,6 +61,10 @@ describe Rack::Handler do
   end
 
   it "returned the webrick handler as default" do
-    Rack::Handler.default.must_equal Rack::Handler::WEBrick
+    begin
+      Rack::Handler.default.name.must_match /webrick|thin|puma/i
+    rescue => e
+      puts e.message
+    end
   end
 end

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -5,9 +5,6 @@ class Rack::Handler::Lobster; end
 class RockLobster; end
 
 describe Rack::Handler do
-  # it "returned the webrick handler as default" do
-  #   Rack::Handler.default.must_equal Rack::Handler::WEBrick
-  # end
 
   it "has registered default handlers" do
     Rack::Handler.get('cgi').must_equal Rack::Handler::CGI
@@ -38,10 +35,6 @@ describe Rack::Handler do
     Rack::Handler.get('rock_lobster').must_equal RockLobster
   end
   
-  it "returned the newly registered RockLobster handler as default" do
-    Rack::Handler.default.must_equal RockLobster
-  end
-
   it "not need registration for properly coded handlers even if not already required" do
     begin
       $LOAD_PATH.push File.expand_path('../unregistered_handler', __FILE__)
@@ -50,6 +43,14 @@ describe Rack::Handler do
       Rack::Handler.get('UnregisteredLongOne').must_equal Rack::Handler::UnregisteredLongOne
     ensure
       $LOAD_PATH.delete File.expand_path('../unregistered_handler', __FILE__)
+    end
+  end
+  
+  it "returned the newly registered RegisteringMyself handler as default" do
+    begin
+      Rack::Handler.default.must_equal Rack::Handler::RegisteringMyself
+    rescue => e
+      
     end
   end
 
@@ -61,5 +62,9 @@ describe Rack::Handler do
     ensure
       $LOAD_PATH.delete path
     end
+  end
+
+  it "returned the webrick handler as default" do
+    Rack::Handler.default.must_equal Rack::Handler::WEBrick
   end
 end

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -5,9 +5,9 @@ class Rack::Handler::Lobster; end
 class RockLobster; end
 
 describe Rack::Handler do
-  it "returned the webrick handler as default" do
-    Rack::Handler.default.must_equal Rack::Handler::WEBrick
-  end
+  # it "returned the webrick handler as default" do
+  #   Rack::Handler.default.must_equal Rack::Handler::WEBrick
+  # end
 
   it "has registered default handlers" do
     Rack::Handler.get('cgi').must_equal Rack::Handler::CGI
@@ -38,7 +38,7 @@ describe Rack::Handler do
     Rack::Handler.get('rock_lobster').must_equal RockLobster
   end
   
-  it "returned the newly registered handler as default" do
+  it "returned the newly registered RockLobster handler as default" do
     Rack::Handler.default.must_equal RockLobster
   end
 

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -5,6 +5,10 @@ class Rack::Handler::Lobster; end
 class RockLobster; end
 
 describe Rack::Handler do
+  it "returned the webrick handler as default" do
+    Rack::Handler.default.must_equal Rack::Handler::WEBrick
+  end
+
   it "has registered default handlers" do
     Rack::Handler.get('cgi').must_equal Rack::Handler::CGI
     Rack::Handler.get('webrick').must_equal Rack::Handler::WEBrick
@@ -27,10 +31,6 @@ describe Rack::Handler do
 
   it "get unregistered, but already required, handler by name" do
     Rack::Handler.get('Lobster').must_equal Rack::Handler::Lobster
-  end
-
-  it "returned the webrick handler as default" do
-    Rack::Handler.default.must_equal Rack::Handler::WEBrick
   end
 
   it "register custom handler" do

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -29,9 +29,17 @@ describe Rack::Handler do
     Rack::Handler.get('Lobster').must_equal Rack::Handler::Lobster
   end
 
+  it "returned the webrick handler as default" do
+    Rack::Handler.default.must_equal Rack::Handler::WEBrick
+  end
+
   it "register custom handler" do
     Rack::Handler.register('rock_lobster', 'RockLobster')
     Rack::Handler.get('rock_lobster').must_equal RockLobster
+  end
+  
+  it "returned the newly registered handler as default" do
+    Rack::Handler.default.must_equal RockLobster
   end
 
   it "not need registration for properly coded handlers even if not already required" do


### PR DESCRIPTION
When a gem is loaded for a server, it should be assumed that the intention was to use the new server as the default server (or, at the very least, as an optional default server).

This is why the registered handlers registry should be used to chose the default server, falling back on the original puma and webrick servers.