### PR TITLE
Backport lock mutex problem fix to Rack 1.4

### DIFF
--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -13,11 +13,9 @@ module Rack
       @mutex.lock
       begin
         response = @app.call(env.merge(FLAG => false))
-        body = BodyProxy.new(response[2]) { @mutex.unlock }
-        response[2] = body
-        response
+        returned = response << BodyProxy.new(response.pop) { @mutex.unlock }
       ensure
-        @mutex.unlock unless body
+        @mutex.unlock unless returned
       end
     end
   end

--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -10,18 +10,15 @@ module Rack
     end
 
     def call(env)
-      old, env[FLAG] = env[FLAG], false
       @mutex.lock
       begin
-        response = @app.call(env)
+        response = @app.call(env.merge(FLAG => false))
         body = BodyProxy.new(response[2]) { @mutex.unlock }
         response[2] = body
         response
       ensure
         @mutex.unlock unless body
       end
-    ensure
-      env[FLAG] = old
     end
   end
 end

--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -12,12 +12,15 @@ module Rack
     def call(env)
       old, env[FLAG] = env[FLAG], false
       @mutex.lock
-      response = @app.call(env)
-      body = BodyProxy.new(response[2]) { @mutex.unlock }
-      response[2] = body
-      response
+      begin
+        response = @app.call(env)
+        body = BodyProxy.new(response[2]) { @mutex.unlock }
+        response[2] = body
+        response
+      ensure
+        @mutex.unlock unless body
+      end
     ensure
-      @mutex.unlock unless body
       env[FLAG] = old
     end
   end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -190,4 +190,12 @@ describe Rack::Lock do
     response = app.call(Rack::MockRequest.env_for("/"))[2]
     response.env['rack.multithread'].should.equal false
   end
+
+  should "unlock if an exception occurs before returning" do
+    lock = Lock.new
+    env  = Rack::MockRequest.env_for("/")
+    app  = lock_app(proc { [].freeze }, lock)
+    lambda { app.call(env) }.should.raise(Exception)
+    lock.synchronized.should.equal false
+  end
 end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -10,11 +10,6 @@ class Lock
     @synchronized = false
   end
 
-  def synchronize
-    @synchronized = true
-    yield
-  end
-
   def lock
     @synchronized = true
   end


### PR DESCRIPTION
Hey,

I apologize if `1.4` isn't supported any more. But if it is, please accept this pull request. It's just a cherry-picked fix taken from https://github.com/dkubb/rack/tree/fix/1-6-stable/rack-lock-mutex-usage

Thanks,