### PR TITLE
Fix rack abstract id key option

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -245,10 +245,10 @@ module Rack
         # metadata into 'rack.session.options'.
 
         def prepare_session(env)
-          session_was               = env[RACK_SESSION]
-          env[RACK_SESSION]         = session_class.new(self, env)
+          session_was               = env[@key]
+          env[@key]         = session_class.new(self, env)
           env[RACK_SESSION_OPTIONS] = @default_options.dup
-          env[RACK_SESSION].merge! session_was if session_was
+          env[@key].merge! session_was if session_was
         end
 
         # Extracts the session id from provided cookies and passes it and the
@@ -272,7 +272,7 @@ module Rack
         # Returns the current session id from the SessionHash.
 
         def current_session_id(env)
-          env[RACK_SESSION].id
+          env[@key].id
         end
 
         # Check if the session exists or not.
@@ -318,7 +318,7 @@ module Rack
         # response with the session's id.
 
         def commit_session(env, status, headers, body)
-          session = env[RACK_SESSION]
+          session = env[@key]
           options = session.options
 
           if options[:drop] || options[:renew]

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -408,4 +408,16 @@ describe Rack::Session::Cookie do
     response = response_for(:app => _app, :cookie => response)
     response.body.must_equal "1--2--"
   end
+
+  it "uses the cookie name set by the :key option" do
+    custom_session_key = 'rack.some.session.key'
+    app = lambda do |env|
+      env[custom_session_key]['cookie'] = "some_cookie_value"
+      Rack::Response.new("").to_a
+    end
+    app_with_cookie = Rack::Session::Cookie.new(app, key: custom_session_key)
+
+    response = Rack::MockRequest.new(app_with_cookie).get("/")
+    response["Set-Cookie"].must_include "rack.some.session.key="
+  end
 end


### PR DESCRIPTION
Hi there!

The `:key` option was documented (see https://github.com/rack/rack/blob/master/lib/rack/session/abstract/id.rb#L164) but ignored.

I split this into two commits to make it easier to check that the additional test is failing, but I can squash them into one if you want to keep the git log cleaner (which I assume you do).