### PR TITLE
Fixes an issue where `Rack::Static` can raise a TypeError

### DIFF
--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -95,8 +95,12 @@ module Rack
       @file_server = Rack::File.new(root)
     end
 
+    def add_index_root?(path)
+      @index && path =~ /\/$/
+    end
+
     def overwrite_file_path(path)
-      @urls.kind_of?(Hash) && @urls.key?(path) || @index && path =~ /\/$/
+      @urls.kind_of?(Hash) && @urls.key?(path) || add_index_root?(path)
     end
 
     def route_file(path)
@@ -112,7 +116,7 @@ module Rack
 
       if can_serve(path)
         if overwrite_file_path(path)
-          env[PATH_INFO] = (path =~ /\/$/ ? path + @index : @urls[path])
+          env[PATH_INFO] = (add_index_root?(path) ? path + @index : @urls[path])
         elsif @gzip && env['HTTP_ACCEPT_ENCODING'] =~ /\bgzip\b/
           path = env[PATH_INFO]
           env[PATH_INFO] += '.gz'

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -21,12 +21,14 @@ describe Rack::Static do
   OPTIONS = {:urls => ["/cgi"], :root => root}
   STATIC_OPTIONS = {:urls => [""], :root => "#{root}/static", :index => 'index.html'}
   HASH_OPTIONS = {:urls => {"/cgi/sekret" => 'cgi/test'}, :root => root}
+  HASH_ROOT_OPTIONS = {:urls => {"/" => "static/foo.html"}, :root => root}
   GZIP_OPTIONS = {:urls => ["/cgi"], :root => root, :gzip=>true}
 
   before do
   @request = Rack::MockRequest.new(static(DummyApp.new, OPTIONS))
   @static_request = Rack::MockRequest.new(static(DummyApp.new, STATIC_OPTIONS))
   @hash_request = Rack::MockRequest.new(static(DummyApp.new, HASH_OPTIONS))
+  @hash_root_request = Rack::MockRequest.new(static(DummyApp.new, HASH_ROOT_OPTIONS))
   @gzip_request = Rack::MockRequest.new(static(DummyApp.new, GZIP_OPTIONS))
   @header_request = Rack::MockRequest.new(static(DummyApp.new, HEADER_OPTIONS))
   end
@@ -76,6 +78,12 @@ describe Rack::Static do
     res = @hash_request.get("/something/else")
     res.must_be :ok?
     res.body.must_equal "Hello World"
+  end
+
+  it "allows the root URI to be configured via hash options" do
+    res = @hash_root_request.get("/")
+    res.must_be :ok?
+    res.body.must_match(/foo.html!/)
   end
 
   it "serves gzipped files if client accepts gzip encoding and gzip files are present" do

--- a/test/static/foo.html
+++ b/test/static/foo.html
@@ -1,0 +1,1 @@
+foo.html!


### PR DESCRIPTION
Fixes an issue where `Rack::Static` can raise "TypeError: no implicit conversion of nil into String"

This is due a bug that always incorrectly tries to append `@index` to a root path.
This happens even when the "index option" is not given, thus `@index == nil`.