### PR TITLE
Fixed link and rack.session's indentation in SPEC

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -60,8 +60,8 @@ below.
                            the presence or absence of the
                            appropriate HTTP header in the
                            request. See
-                           <a href="https://tools.ietf.org/html/rfc3875#section-4.1.18">
-                           RFC3875 section 4.1.18</a> for
+                           {https://tools.ietf.org/html/rfc3875#section-4.1.18
+                           RFC3875 section 4.1.18} for
                            specific behavior.
 In addition to this, the Rack environment must include these
 Rack-specific variables:
@@ -98,13 +98,12 @@ Rack-specific variables:
 Additional environment specifications have approved to
 standardized middleware APIs.  None of these are required to
 be implemented by the server.
-<tt>rack.session</tt>:: A hash like interface for storing
-                        request session data.
+<tt>rack.session</tt>:: A hash like interface for storing request session data.
                         The store must implement:
-                        store(key, value)         (aliased as []=);
-                        fetch(key, default = nil) (aliased as []);
-                        delete(key);
-                        clear;
+                         store(key, value)         (aliased as []=);
+                         fetch(key, default = nil) (aliased as []);
+                         delete(key);
+                         clear;
 <tt>rack.logger</tt>:: A common object interface for logging messages.
                        The object must implement:
                         info(message, &block)


### PR DESCRIPTION
`rack.session` was missing indentation.
![missing_indentation](https://cloud.githubusercontent.com/assets/1132451/9409149/e3125398-4835-11e5-9c2f-12a81cb0ffaa.png)

Also include link fix for `RFC3875 section 4.1.18`.