### PR TITLE
Remove RACK_MULTIPART_LIMIT introduced by a mistake

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -53,8 +53,7 @@ module Rack
     # The maximum number of parts a request can contain. Accepting too many part
     # can lead to the server running out of file handles.
     # Set to `0` for no limit.
-    # FIXME: RACK_MULTIPART_LIMIT was introduced by mistake and it will be removed in 1.7.0
-    self.multipart_part_limit = (ENV['RACK_MULTIPART_PART_LIMIT'] || ENV['RACK_MULTIPART_LIMIT'] || 128).to_i
+    self.multipart_part_limit = (ENV['RACK_MULTIPART_PART_LIMIT'] || 128).to_i
 
     def self.param_depth_limit
       default_query_parser.param_depth_limit


### PR DESCRIPTION
It's deprecated stuff which can be removed for newer version of Rack.