### PR TITLE
Remove any reference to 418 status code

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -127,7 +127,6 @@ module Rack
       def not_found?;           status == 404;                        end
       def method_not_allowed?;  status == 405;                        end
       def precondition_failed?; status == 412;                        end
-      def i_m_a_teapot?;        status == 418;                        end
       def unprocessable?;       status == 422;                        end
 
       def redirect?;            [301, 302, 303, 307].include? status; end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -266,11 +266,6 @@ describe Rack::Response do
     res.must_be :client_error?
     res.must_be :precondition_failed?
 
-    res.status = 418
-    res.wont_be :successful?
-    res.must_be :client_error?
-    res.must_be :i_m_a_teapot?
-
     res.status = 422
     res.wont_be :successful?
     res.must_be :client_error?


### PR DESCRIPTION
It was removed in Rack 1.6 from HTTP status codes. See https://github.com/rack/rack/pull/754