### PR TITLE
Rack::Response::Helpers#redirect? would accept 308 status code

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -129,7 +129,7 @@ module Rack
       def precondition_failed?; status == 412;                        end
       def unprocessable?;       status == 422;                        end
 
-      def redirect?;            [301, 302, 303, 307].include? status; end
+      def redirect?;            [301, 302, 303, 307, 308].include? status; end
 
       def include?(header)
         have_header? header

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -241,6 +241,18 @@ describe Rack::Response do
     res.must_be :redirect?
     res.must_be :moved_permanently?
 
+    res.status = 302
+    res.must_be :redirect?
+
+    res.status = 303
+    res.must_be :redirect?
+
+    res.status = 307
+    res.must_be :redirect?
+
+    res.status = 308
+    res.must_be :redirect?
+
     res.status = 400
     res.wont_be :successful?
     res.must_be :client_error?
@@ -274,9 +286,6 @@ describe Rack::Response do
     res.status = 501
     res.wont_be :successful?
     res.must_be :server_error?
-
-    res.status = 307
-    res.must_be :redirect?
   end
 
   it "provide access to the HTTP headers" do


### PR DESCRIPTION
308 status code is ‘Permanent Redirect’ (see http://greenbytes.de/tech/webdav/draft-reschke-http-status-308-07.html) and `Rack::Response::Helpers#redirect?` would accept it as a redirection when 308 status is supported by Rack.