### PR TITLE
HeaderHash must clear names on clear/replace.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -414,6 +414,12 @@ module Rack
         @names = other.names.dup
       end
 
+      # on clear, we need to clear @names hash
+      def clear
+        super
+        @names = {}
+      end
+
       def each
         super do |k, v|
           yield(k, v.respond_to?(:to_ary) ? v.to_ary.join("\n") : v)


### PR DESCRIPTION
Without this fix, `@names` contains old names after clear/replace call, causing include?/key?/etc. return true even if the key is not there anymore.
