### PR TITLE
Fix bug in parsing of Content-Disposition header where an unquoted name at end-of-line sucked in the trailing newline

### DIFF
--- a/lib/rack/multipart.rb
+++ b/lib/rack/multipart.rb
@@ -17,7 +17,7 @@ module Rack
     BROKEN_QUOTED = /^#{CONDISP}.*;\sfilename="(.*?)"(?:\s*$|\s*;\s*#{TOKEN}=)/i
     BROKEN_UNQUOTED = /^#{CONDISP}.*;\sfilename=(#{TOKEN})/i
     MULTIPART_CONTENT_TYPE = /Content-Type: (.*)#{EOL}/ni
-    MULTIPART_CONTENT_DISPOSITION = /Content-Disposition:.*\s+name="?([^\";]*)"?/ni
+    MULTIPART_CONTENT_DISPOSITION = /Content-Disposition:.*\s+name=(#{TOKEN}|"[^\";]*")/ni
     MULTIPART_CONTENT_ID = /Content-ID:\s*([^#{EOL}]*)/ni
     # Updated definitions from RFC 2231
     ATTRIBUTE_CHAR = %r{[^ \t\v\n\r)(><@,;:\\"/\[\]?='*%]}

--- a/lib/rack/multipart.rb
+++ b/lib/rack/multipart.rb
@@ -17,7 +17,7 @@ module Rack
     BROKEN_QUOTED = /^#{CONDISP}.*;\sfilename="(.*?)"(?:\s*$|\s*;\s*#{TOKEN}=)/i
     BROKEN_UNQUOTED = /^#{CONDISP}.*;\sfilename=(#{TOKEN})/i
     MULTIPART_CONTENT_TYPE = /Content-Type: (.*)#{EOL}/ni
-    MULTIPART_CONTENT_DISPOSITION = /Content-Disposition:.*\s+name=(#{TOKEN}|"[^\";]*")/ni
+    MULTIPART_CONTENT_DISPOSITION = /Content-Disposition:.*\s+name=(#{VALUE})/ni
     MULTIPART_CONTENT_ID = /Content-ID:\s*([^#{EOL}]*)/ni
     # Updated definitions from RFC 2231
     ATTRIBUTE_CHAR = %r{[^ \t\v\n\r)(><@,;:\\"/\[\]?='*%]}

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -245,8 +245,11 @@ module Rack
           @buf.slice!(0, 2)          # Second \r\n
 
           content_type = head[MULTIPART_CONTENT_TYPE, 1]
-          name = head[MULTIPART_CONTENT_DISPOSITION, 1] || head[MULTIPART_CONTENT_ID, 1]
-          name.gsub!(/\A"|"\Z/, '') if name
+          if name = head[MULTIPART_CONTENT_DISPOSITION, 1]
+            name = Rack::Auth::Digest::Params::dequote(name)
+          else
+            name = head[MULTIPART_CONTENT_ID, 1]
+          end
 
           filename = get_filename(head)
 

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -246,6 +246,7 @@ module Rack
 
           content_type = head[MULTIPART_CONTENT_TYPE, 1]
           name = head[MULTIPART_CONTENT_DISPOSITION, 1] || head[MULTIPART_CONTENT_ID, 1]
+          name.gsub!(/\A"|"\Z/, '') if name
 
           filename = get_filename(head)
 

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -606,6 +606,26 @@ contents\r
     params["file"][:filename].must_equal 'long' * 100
   end
 
+  it "parse unquoted parameter values at end of line" do
+    data = <<-EOF
+--AaB03x\r
+Content-Type: text/plain\r
+Content-Disposition: attachment; name=inline\r
+\r
+true\r
+--AaB03x--\r
+    EOF
+
+    options = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+      "CONTENT_LENGTH" => data.length.to_s,
+      :input => StringIO.new(data)
+    }
+    env = Rack::MockRequest.env_for("/", options)
+    params = Rack::Multipart.parse_multipart(env)
+    params["inline"].must_equal 'true'
+  end
+
   it "support mixed case metadata" do
     file = multipart_file(:text)
     data = File.open(file, 'rb') { |io| io.read }

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -626,6 +626,26 @@ true\r
     params["inline"].must_equal 'true'
   end
 
+  it "parse quoted chars in name parameter" do
+    data = <<-EOF
+--AaB03x\r
+Content-Type: text/plain\r
+Content-Disposition: attachment; name="quoted\\\\chars\\"in\rname"\r
+\r
+true\r
+--AaB03x--\r
+    EOF
+
+    options = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+      "CONTENT_LENGTH" => data.length.to_s,
+      :input => StringIO.new(data)
+    }
+    env = Rack::MockRequest.env_for("/", options)
+    params = Rack::Multipart.parse_multipart(env)
+    params["quoted\\chars\"in\rname"].must_equal 'true'
+  end
+
   it "support mixed case metadata" do
     file = multipart_file(:text)
     data = File.open(file, 'rb') { |io| io.read }


### PR DESCRIPTION
Hi,

I've encountered an edge case in the parsing of the multipart `Content-Disposition` header. [RFC2183](https://tools.ietf.org/html/rfc2183) specifies that the parameter value can be either a token or a quoted string, and Rack [supports this](https://github.com/rack/rack/blob/b2d73960e9ea6b8b15321ef190f13a290d1aedf0/lib/rack/multipart.rb#L20). However, the way the `MULTIPART_CONTENT_DISPOSITION` regex is written, if the quotes are left off and the parameter happens to be at the end of the line, the newline character gets sucked in.

Example: Given this input
```
--AaB03x
Content-Type: text/plain
Content-Disposition: attachment; name=inline

true
--AaB03x--
```
The resulting `params` contains `{"inline\r\n" => "true"}`

With this patch, you get the desired result `params = {"inline" => "true"}`

This PR

* Changes the `MULTIPART_CONTENT_DISPOSITION` regex to more exactly represent what is described in RFC2183: either a token (no tspecial chars), or a quoted string.
* Adds a test for this case
