### PR TITLE
Convenient cache and content type for response generation

### DIFF
--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -38,6 +38,7 @@ module Rack
   SERVER_ADDR       = 'SERVER_ADDR'.freeze
   SERVER_PORT       = 'SERVER_PORT'.freeze
   CACHE_CONTROL     = 'Cache-Control'.freeze
+  EXPIRES           = 'Expires'.freeze
   CONTENT_LENGTH    = 'Content-Length'.freeze
   CONTENT_TYPE      = 'Content-Type'.freeze
   SET_COOKIE        = 'Set-Cookie'.freeze

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -211,6 +211,25 @@ module Rack
       def etag= v
         set_header ETAG, v
       end
+
+      # Specifies that the content shouldn't be cached. Overrides `cache!` if already called.
+      def do_not_cache!
+        set_header CACHE_CONTROL, "no-cache, must-revalidate"
+        set_header EXPIRES, Time.now.httpdate
+      end
+
+      # Specify that the content should be cached.
+      def cache!(duration = 3600, access = "public")
+        unless headers[CACHE_CONTROL] =~ /no-cache/
+          set_header CACHE_CONTROL, "#{access}, max-age=#{duration}"
+          set_header EXPIRES, (Time.now + duration).httpdate
+        end
+      end
+
+      # Specify the content type of the response data.
+      def content_type!(value)
+        set_header CONTENT_TYPE, value.to_s
+      end
     end
 
     include Helpers

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -212,6 +212,14 @@ module Rack
         set_header ETAG, v
       end
 
+      def content_type
+        get_header CONTENT_TYPE
+      end
+
+      def content_type= v
+        set_header CONTENT_TYPE, v
+      end
+
       # Specifies that the content shouldn't be cached. Overrides `cache!` if already called.
       def do_not_cache!
         set_header CACHE_CONTROL, "no-cache, must-revalidate"

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -225,11 +225,6 @@ module Rack
           set_header EXPIRES, (Time.now + duration).httpdate
         end
       end
-
-      # Specify the content type of the response data.
-      def content_type!(value)
-        set_header CONTENT_TYPE, value.to_s
-      end
     end
 
     include Helpers

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -414,14 +414,6 @@ describe Rack::Response do
     expires_header = Time.parse(response['Expires'])
     expect(expires_header).must_be :>=, expires
   end
-
-  it "should set content type" do
-    response = Rack::Response.new
-    
-    response.content_type! "text/html"
-    
-    expect(response['Content-Type']).must_be_equal "text/html"
-  end
 end
 
 describe Rack::Response, 'headers' do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -389,6 +389,39 @@ describe Rack::Response do
     res.finish.last.wont_respond_to(:to_ary)
     lambda { res.finish.last.to_ary }.must_raise NoMethodError
   end
+  
+  it "should specify not to cache content" do
+    response = Rack::Response.new
+    
+    response.cache!(1000)
+    response.do_not_cache!
+    
+    expect(response['Cache-Control']).must_be_equal "no-cache, must-revalidate"
+    
+    expires_header = Time.parse(response['Expires'])
+    expect(expires_header).must_be :<=, Time.now
+  end
+
+  it "should specify to cache content" do
+    response = Rack::Response.new
+    
+    duration = 120
+    expires = Time.now + 100 # At least this far into the future
+    response.cache!(duration)
+    
+    expect(response['Cache-Control']).must_be_equal "public, max-age=120"
+    
+    expires_header = Time.parse(response['Expires'])
+    expect(expires_header).must_be :>=, expires
+  end
+
+  it "should set content type" do
+    response = Rack::Response.new
+    
+    response.content_type! "text/html"
+    
+    expect(response['Content-Type']).must_be_equal "text/html"
+  end
 end
 
 describe Rack::Response, 'headers' do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -20,6 +20,14 @@ describe Rack::Response do
     assert_equal etag, response.to_a[2]['ETag']
   end
 
+  it 'has a content-type method' do
+    response = Rack::Response.new
+    content_type = 'foo'
+    response.content_type = content_type
+    assert_equal content_type, response.content_type
+    assert_equal content_type, response.to_a[2]['Content-Type']
+  end
+
   it "have sensible default values" do
     response = Rack::Response.new
     status, header, body = response.finish


### PR DESCRIPTION
These three convenient methods make it easy to declaratively specify how a response should be structured. For example:

```
response.do_not_cache!

response.cache!

response.content_type = 'text/html'
```

Open to discussion w.r.t. naming, and behaviour. I monkey patch these in which might be fine for my usage, but I thought it could be useful to a wider audience.
