### PR TITLE
fix rdoc formatting (remove accidental links)

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,12 +16,12 @@ module Rack
       super(env)
     end
 
-    # shortcut for request.params[key]
+    # shortcut for <tt>request.params[key]</tt>
     def [](key)
       params[key.to_s]
     end
 
-    # shortcut for request.params[key] = value
+    # shortcut for <tt>request.params[key] = value</tt>
     #
     # Note that modifications will not be persisted in the env. Use update_param or delete_param if you want to destructively modify params.
     def []=(key, value)
@@ -358,7 +358,7 @@ module Rack
       #
       # The parameter is updated wherever it was previous defined, so GET, POST, or both. If it wasn't previously defined, it's inserted into GET.
       #
-      # env['rack.input'] is not touched.
+      # <tt>env['rack.input']</tt> is not touched.
       def update_param(k, v)
         found = false
         if self.GET.has_key?(k)
@@ -378,7 +378,7 @@ module Rack
       #
       # If the parameter is in both GET and POST, the POST value takes precedence since that's how #params works.
       #
-      # env['rack.input'] is not touched.
+      # <tt>env['rack.input']</tt> is not touched.
       def delete_param(k)
         [ self.POST.delete(k), self.GET.delete(k) ].compact.first
       end

--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -176,9 +176,9 @@ module Rack
       #   id will be.
       #
       # These options can be set on a per request basis, at the location of
-      # env['rack.session.options']. Additionally the id of the session can be
-      # found within the options hash at the key :id. It is highly not
-      # recommended to change its value.
+      # <tt>env['rack.session.options']</tt>. Additionally the id of the
+      # session can be found within the options hash at the key :id. It is
+      # highly not recommended to change its value.
       #
       # Is Rack::Utils::Context compatible.
       #


### PR DESCRIPTION
In several places, the rdoc comments attempt to indicate hash access, for
example `env['rack.input']`, but rdoc interprets this as a link with
text "env" and href="%27rack.input%27/". Wrapping these snippets of hash
access code in `<tt>` tags escapes the link syntax and also renders the
code snippets in monospace.