### PR TITLE
Use standard header for method override.

### DIFF
--- a/lib/rack/method_override.rb
+++ b/lib/rack/method_override.rb
@@ -3,7 +3,8 @@ module Rack
     HTTP_METHODS = %w[GET HEAD PUT POST DELETE OPTIONS PATCH LINK UNLINK]
 
     METHOD_OVERRIDE_PARAM_KEY = "_method".freeze
-    HTTP_METHOD_OVERRIDE_HEADER = "HTTP_X_HTTP_METHOD_OVERRIDE".freeze
+    HTTP_METHOD_OVERRIDE_HEADER_DEPRECATED = "HTTP_X_HTTP_METHOD_OVERRIDE".freeze
+    HTTP_METHOD_OVERRIDE_HEADER = "X-HTTP-Method-Override".freeze
     ALLOWED_METHODS = %w[POST]
 
     def initialize(app)
@@ -25,7 +26,7 @@ module Rack
     def method_override(env)
       req = Request.new(env)
       method = method_override_param(req) ||
-        env[HTTP_METHOD_OVERRIDE_HEADER]
+        method_override_header(env)
       method.to_s.upcase
     end
 
@@ -33,6 +34,17 @@ module Rack
 
     def allowed_methods
       ALLOWED_METHODS
+    end
+
+    def method_override_header(env)
+      if env[HTTP_METHOD_OVERRIDE_HEADER_DEPRECATED]
+        if logger = env[RACK_LOGGER]
+          logger.warn "Deprecation notice: #{HTTP_METHOD_OVERRIDE_HEADER_DEPRECATED} header is deprecated and will be removed. Please use #{HTTP_METHOD_OVERRIDE_HEADER} for HTTP method override."
+        end
+        env[HTTP_METHOD_OVERRIDE_HEADER_DEPRECATED]
+      else
+        env[HTTP_METHOD_OVERRIDE_HEADER]
+      end
     end
 
     def method_override_param(req)

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -34,6 +34,16 @@ describe Rack::MethodOverride do
     env["REQUEST_METHOD"].must_equal "PATCH"
   end
 
+  it "modify REQUEST_METHOD for POST requests when X-HTTP-Method-Override is set with standard header name" do
+    env = Rack::MockRequest.env_for("/",
+            :method => "POST",
+            "X-HTTP-Method-Override" => "PATCH"
+          )
+    app.call env
+
+    env["REQUEST_METHOD"].must_equal "PATCH"
+  end
+
   it "not modify REQUEST_METHOD if the method is unknown" do
     env = Rack::MockRequest.env_for("/", :method => "POST", :input => "_method=foo")
     app.call env


### PR DESCRIPTION
The documentation and specs discuss a header called `X-HTTP-Method-Override` for use as the method override signifier, but in practice it's called `HTTP_X_HTTP_METHOD_OVERRIDE`.  This is not in keeping with standard HTTP header naming convention and it also differs from what others are [using](https://github.com/mgonto/restangular#setmethodoverriders).

This pull request adds the standard header `X-HTTP-Method-Override` into the mix and also adds a deprecation warning for those using `HTTP_X_HTTP_METHOD_OVERRIDE`.

I want to request that we move to the same header name that's used elsewhere in the industry.

If someone can tell me where to go to add information to the correct page in rails guides, I'll happily add this there, as the ability to use a header for Method Override is currently undocumented in rails guides.

thanks!