### PR TITLE
Fix missing space in list of paramaters

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -50,7 +50,7 @@ module Rack
         TOPLEVEL_BINDING, file, 0
     end
 
-    def initialize(default_app = nil,&block)
+    def initialize(default_app = nil, &block)
       @use, @map, @run, @warmup = [], nil, default_app, nil
       instance_eval(&block) if block_given?
     end


### PR DESCRIPTION
There is a space missing after a comma in the params to `initialize`. Added the single space to reflect the style used globally in the code.