### PR TITLE
Avoid re-calculation in Rack::Builder call method 

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -150,7 +150,7 @@ module Rack
     end
 
     def call(env)
-      to_app.call(env)
+      (@_app ||= to_app).call(env)
     end
 
     private

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -180,6 +180,19 @@ describe Rack::Builder do
     end.must_raise(RuntimeError)
   end
 
+  it "doesn't dupe #to_app when mapping" do
+    app = builder do
+      map '/' do |outer_env|
+        run lambda { |env|  [200, {"Content-Type" => "text/plain"}, [object_id.to_s]] }
+      end
+    end
+
+    builder_app1_id = Rack::MockRequest.new(app).get("/").body.to_s
+    builder_app2_id = Rack::MockRequest.new(app).get("/").body.to_s
+
+    assert_equal builder_app2_id, builder_app1_id
+  end
+
   describe "parse_file" do
     def config_file(name)
       File.join(File.dirname(__FILE__), 'builder', name)


### PR DESCRIPTION
in a simple `config.ru` like this one below, 

``` ruby
require 'rack'

class App
  def initialize(); puts "NEW APP INSTANCE CREATED"; end
  def call(env); [200, {}, [""]]; end
end

app = Rack::Builder.new do
  map '/' do
    run App.new
  end
end

run app
```

each time the builder app receives a new request, a new instance of the App class is created. 

```
[2015-09-25 13:14:06] INFO  WEBrick 1.3.1
[2015-09-25 13:14:06] INFO  ruby 2.2.2 (2015-04-13) [x86_64-darwin14]
[2015-09-25 13:14:06] INFO  WEBrick::HTTPServer#start: pid=93874 port=9292
NEW APP INSTANCE CREATED
127.0.0.1 - - [25/Sep/2015 13:14:08] "GET / HTTP/1.1" 200 - 0.0014
NEW APP INSTANCE CREATED
127.0.0.1 - - [25/Sep/2015 13:14:09] "GET / HTTP/1.1" 200 - 0.0003
```

This is not efficient, as the `#to_app` method is invoked to re-calculate the mapped stack for each request. 

This PR simply caches the `#to_app` value in the `call` method.

alternatively, use `Rack::Builder.app` method.
