### PR TITLE
Rack::Utils.add_cookie_to_header fails on headers it doesn't recognize

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -251,6 +251,8 @@ module Rack
         [header, cookie].join("\n")
       when Array
         (header + [cookie]).join("\n")
+      else
+        raise ArgumentError, "Unrecognized cookie header value. Expected String, Array, or nil, got #{header.inspect}"
       end
     end
     module_function :add_cookie_to_header


### PR DESCRIPTION
`#add_cookie_to_header` expects to add the cookie to an existing header.

If we get a header we don't know how to add on to, raise an `ArgumentError` rather than silently returning `nil`.