### PR TITLE
Do not reference HTTP_VERSION internally

### DIFF
--- a/lib/rack/chunked.rb
+++ b/lib/rack/chunked.rb
@@ -43,7 +43,7 @@ module Rack
     # a version (nor response headers)
     def chunkable_version?(ver)
       case ver
-      when "HTTP/1.0", nil, "HTTP/0.9"
+      when 'HTTP/1.0', nil, 'HTTP/0.9'
         false
       else
         true
@@ -54,7 +54,7 @@ module Rack
       status, headers, body = @app.call(env)
       headers = HeaderHash.new(headers)
 
-      if ! chunkable_version?(env[HTTP_VERSION]) ||
+      if ! chunkable_version?(env[SERVER_PROTOCOL]) ||
          STATUS_WITH_NO_ENTITY_BODY.include?(status) ||
          headers[CONTENT_LENGTH] ||
          headers[TRANSFER_ENCODING]

--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -49,7 +49,7 @@ module Rack
         env[REQUEST_METHOD],
         env[PATH_INFO],
         env[QUERY_STRING].empty? ? "" : "?"+env[QUERY_STRING],
-        env[HTTP_VERSION],
+        env[SERVER_PROTOCOL],
         status.to_s[0..3],
         length,
         now - began_at ]

--- a/test/spec_chunked.rb
+++ b/test/spec_chunked.rb
@@ -16,7 +16,7 @@ describe Rack::Chunked do
 
   before do
     @env = Rack::MockRequest.
-      env_for('/', 'HTTP_VERSION' => '1.1', 'REQUEST_METHOD' => 'GET')
+      env_for('/', 'SERVER_PROTOCOL' => 'HTTP/1.1', 'REQUEST_METHOD' => 'GET')
   end
 
   it 'chunk responses with no Content-Length' do
@@ -59,7 +59,7 @@ describe Rack::Chunked do
 
   it 'not modify response when client is HTTP/1.0' do
     app = lambda { |env| [200, {"Content-Type" => "text/plain"}, ['Hello', ' ', 'World!']] }
-    @env['HTTP_VERSION'] = 'HTTP/1.0'
+    @env['SERVER_PROTOCOL'] = 'HTTP/1.0'
     status, headers, body = chunked(app).call(@env)
     status.must_equal 200
     headers.wont_include 'Transfer-Encoding'
@@ -75,10 +75,10 @@ describe Rack::Chunked do
       body.join.must_equal 'Hello World!'
     end
 
-    @env.delete('HTTP_VERSION') # unicorn will do this on pre-HTTP/1.0 requests
+    @env.delete('SERVER_PROTOCOL') # unicorn will do this on pre-HTTP/1.0 requests
     check.call
 
-    @env['HTTP_VERSION'] = 'HTTP/0.9' # not sure if this happens in practice
+    @env['SERVER_PROTOCOL'] = 'HTTP/0.9' # not sure if this happens in practice
     check.call
   end
 


### PR DESCRIPTION
HTTP_VERSION is supposed to be a client supplied header. This usage
inside Rack is conflating it with SERVER_PROTOCOL, which imo is instead
also conflating it with the client's HTTP version from the request line.

In any of these cases, HTTP_VERSION is set when an existing Version
header doesn't already exist. So it's possible to send a Version header
to conflict with the expected behaviors.

According to the CGI spec
(https://tools.ietf.org/html/draft-robinson-www-interface-00)

>  Environment variables with names beginning with "HTTP_" contain
>    header data read from the client, if the protocol used was HTTP.

This is an anscillary issue with Rack, but will leave that open for
discussion since this behavior already exists.
## Notes

It's worth noting that this incorrect behavior is happening as a result of https://github.com/rack/rack/blob/028438f/lib/rack/handler/cgi.rb#L29 (and in all other handlers). I believe this behavior should be changed and not set to HTTP_VERSION in the first place. See my follow up: #970

Lastly, I'm not super familiar with Rack, but this seems problematic to rely on `SERVER_PROTOCOL` for `Transfer-Encoding` behaviors since what you really want is the client's HTTP version. I've looked into WEBrick only, but their `SERVER_PROTOCOL` does NOT mean the protocol of the request. WEBrick has a separate `request.http_version` as opposed to `request.env_meta['SERVER_PROTOCOL']`. Not sure about the others.
