### PR TITLE
Update example use of Rack::Deflater

### DIFF
--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -22,7 +22,7 @@ module Rack
     # [app] rack app instance
     # [options] hash of deflater options, i.e.
     #           'if' - a lambda enabling / disabling deflation based on returned boolean value
-    #                  e.g use Rack::Deflater, :if => lambda { |env, status, headers, body| body.length > 512 }
+    #                  e.g use Rack::Deflater, :if => lambda { |*, body| body.map(&:bytesize).reduce(0, :+) > 512 }
     #           'include' - a list of content types that should be compressed
     def initialize(app, options = {})
       @app = app


### PR DESCRIPTION
The example if-lambda given in the documentation for Rack::Deflater is dysfunctional. `body` is an array in Rack responses and has been for a while, so checking to see if `body.length > 512` will likely never be true. Additionally, with different encodings taking multiple bytes per character, I think it's more appropriate to check the byte size of the body cf. the string length, so I've also updated the example to reflect that. I've been using this technique for a while and it works well. 
