### PR TITLE
 Run lighttpd tests if it's present on the system

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 
 module Rack
   class TestCase < Minitest::Test
-    if `which lighttpd` && !$?.success?
+    if `which lighttpd` && $?.success?
       begin
         # Keep this first.
         LIGHTTPD_PID = fork {


### PR DESCRIPTION
 - Because of using !$?, the lighttpd tests were getting skipped no
   matter what.