### PR TITLE
Load session for read before accessing keys or values

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -124,10 +124,12 @@ module Rack
         end
 
         def keys
+          load_for_read!
           @data.keys
         end
 
         def values
+          load_for_read!
           @data.values
         end
 

--- a/test/spec_session_abstract_session_hash.rb
+++ b/test/spec_session_abstract_session_hash.rb
@@ -1,0 +1,28 @@
+require 'minitest/autorun'
+require 'rack/session/abstract/id'
+
+describe Rack::Session::Abstract::SessionHash do
+  attr_reader :hash
+
+  def setup
+    super
+    store = Class.new do
+      def load_session(req)
+        ["id", {foo: :bar, baz: :qux}]
+      end
+      def session_exists?(req)
+        true
+      end
+    end
+    @hash = Rack::Session::Abstract::SessionHash.new(store.new, nil)
+  end
+
+  it "returns keys" do
+    assert_equal ["foo", "baz"], hash.keys
+  end
+
+  it "returns values" do
+    assert_equal [:bar, :qux], hash.values
+  end
+
+end


### PR DESCRIPTION
Is there a specific reason why the session is not loaded for `#keys` or `#values`? Looks like it should ...