### PR TITLE
Add support for HTTP 451 "Unavailable for Legal Reasons"

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -551,6 +551,7 @@ module Rack
       428 => 'Precondition Required',
       429 => 'Too Many Requests',
       431 => 'Request Header Fields Too Large',
+      451 => 'Unavailable for Legal Reasons',
       500 => 'Internal Server Error',
       501 => 'Not Implemented',
       502 => 'Bad Gateway',


### PR DESCRIPTION
Adds support for the newly approved HTTP 451 response code,
“Unavailable for Legal Reasons”.

Adds `Rack::Response#unavailable?` method.

See also:

- [IETF draft specification](https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-05)
- [Why 451?](https://www.mnot.net/blog/2015/12/18/451)
- [451unavailable.org](http://www.451unavailable.org)