### PR TITLE
Response#redirect? micro-optimization

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -24,6 +24,7 @@ module Rack
     alias headers header
 
     CHUNKED = 'chunked'.freeze
+    REDIRECT_CODES = Set.new([301, 302, 303, 307, 308]).freeze
 
     def initialize(body=[], status=200, header={})
       @status = status.to_i
@@ -129,7 +130,7 @@ module Rack
       def precondition_failed?; status == 412;                        end
       def unprocessable?;       status == 422;                        end
 
-      def redirect?;            [301, 302, 303, 307, 308].include? status; end
+      def redirect?;            REDIRECT_CODES.include? status; end
 
       def include?(header)
         has_header? header


### PR DESCRIPTION
This improves the performance of `Response#redirect?` by ~55% using a set instead of an
array.

See [this gist for benchmarks](https://gist.github.com/ktheory/e62bc43900745d54eb4f).

tl;dr: The new method can run a million redirect checks in 151ms, vs. 338ms for the original method (with a `301` status, the fastest case).
