### PR TITLE
[travis] fix apt package installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-before_install: sudo apt-get install lighttpd libfcgi-dev libmemcache-dev memcached
+before_install:
+  - sudo apt-get update > /dev/null
+  - sudo apt-get -y install lighttpd libfcgi-dev libmemcache-dev memcached
 install:
   - gem env version | grep '^\(2\|1.\(8\|9\|[0-9][0-9]\)\)' || gem update --system
   - bundle install --jobs=3 --retry=3


### PR DESCRIPTION
Travis CI builds (on Ubuntu 12.04 Precise) were failing at the
`before_install` step with the error:

    E: Unable to locate package lighttpd
    E: Unable to locate package libmemcache-dev

Updating the apt cache fixes it. :tada: 