### PR TITLE
Freeze static strings in QueryParser#normalize_params

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -79,16 +79,16 @@ module Rack
       raise RangeError if depth <= 0
 
       name =~ %r(\A[\[\]]*([^\[\]]+)\]*)
-      k = $1 || ''
-      after = $' || ''
+      k = $1 || ''.freeze
+      after = $' || ''.freeze
 
       return if k.empty?
 
-      if after == ""
+      if after == ''.freeze
         params[k] = v
-      elsif after == "["
+      elsif after == "[".freeze
         params[name] = v
-      elsif after == "[]"
+      elsif after == "[]".freeze
         params[k] ||= []
         raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
         params[k] << v
@@ -107,7 +107,7 @@ module Rack
         params[k] = normalize_params(params[k], after, v, depth - 1)
       end
 
-      return params
+      params
     end
 
     def make_params


### PR DESCRIPTION
I used `stackprof` and `minitest/around` gems for check all code calls in tests. And I found that `Rack::QueryParser#normalize_params` has big count of allocated object (figures below).

### Before
```
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
    129136  (19.9%)       10014   (1.5%)     Rack::QueryParser#normalize_params
```

### After
```
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     13144   (1.6%)        5802   (0.7%)     Rack::QueryParser#normalize_params
```
