### PR TITLE
Use unshift(...) instead of insert(0, ...)

### DIFF
--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -93,7 +93,7 @@ module Rack
       # HTTP Headers
       @header_rules = options[:header_rules] || []
       # Allow for legacy :cache_control option while prioritizing global header_rules setting
-      @header_rules.insert(0, [:all, {CACHE_CONTROL => options[:cache_control]}]) if options[:cache_control]
+      @header_rules.unshift([:all, {CACHE_CONTROL => options[:cache_control]}]) if options[:cache_control]
 
       @file_server = Rack::File.new(root)
     end


### PR DESCRIPTION
According to https://github.com/JuanitoFatas/fast-ruby#arrayinsert-vs-arrayunshift-code using `unshift` is ~262x faster than `insert(0`.

Perhaps this doesn't apply in this case, but I thought I would throw it out there.

Let me know what you think. Thanks!