### PR TITLE
Fix querystring `foo[]bar=` to be flat key

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -92,7 +92,7 @@ module Rack
         params[k] ||= []
         raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
         params[k] << v
-      elsif after =~ %r(^\[\]\[([^\[\]]+)\]$) || after =~ %r(^\[\](.+)$)
+      elsif after =~ %r(^\[\]\[([^\[\]]+)\]$) || after =~ %r(^\[\](\[.*\])$)
         child_key = $1
         params[k] ||= []
         raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
@@ -101,6 +101,8 @@ module Rack
         else
           params[k] << normalize_params(make_params, child_key, v, depth - 1)
         end
+      elsif after !~ %r(\]$)
+        params[k + after] = v
       else
         params[k] ||= make_params
         raise ParameterTypeError, "expected Hash (got #{params[k].class.name}) for param `#{k}'" unless params_hash_type?(params[k])

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -137,6 +137,8 @@ describe Rack::Utils do
       must_equal "foo" => "bar"
     Rack::Utils.parse_nested_query("foo=\"bar\"").
       must_equal "foo" => "\"bar\""
+    Rack::Utils.parse_nested_query("foo[]bar").
+      must_equal "foo[]bar" => nil
 
     Rack::Utils.parse_nested_query("foo=bar&foo=quux").
       must_equal "foo" => "quux"
@@ -206,7 +208,7 @@ describe Rack::Utils do
     Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][w]=a&x[y][][z]=2&x[y][][w]=3").
       must_equal "x" => {"y" => [{"z" => "1", "w" => "a"}, {"z" => "2", "w" => "3"}]}
 
-    lambda { Rack::Utils.parse_nested_query("x[y]=1&x[y]z=2") }.
+    lambda { Rack::Utils.parse_nested_query("x[y]=1&x[y][z]=2") }.
       must_raise(Rack::Utils::ParameterTypeError).
       message.must_equal "expected Hash (got String) for param `y'"
 


### PR DESCRIPTION
Fixes #964

Currently the key `foo[]bar` is parsed as `{"foo"=>[{"bar"=>nil}]}`. This changes it to `{"foo[]bar"=>nil}`. However, this might have been intended behavior (see `test/spec_utils.rb:211` which tests `x[y]z=2`)

I feel like there's a better way to do this than by adding a special case. Maybe by modifying the regex `name =~ %r(\A[\[\]]*([^\[\]]+)\]*)` used in `#normalize_params`?

Any feedback would be appreciated!
