### PR TITLE
support custom trusted proxies

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -200,6 +200,13 @@ Set to 0 for no limit.
 
 Can also be set via the RACK_MULTIPART_PART_LIMIT environment variable.
 
+=== trusted_proxies
+
+The trusted proxies to be used when determining the IP address of the remote client making a request.
+Client addresses which match the specified proxy addresses are discarded from the X-Forwarded-For addresses.
+
+The value provided may be a string, IPAddr or Regexp object, or an Array including any of those types of objects.
+
 == History
 
 See <https://github.com/rack/rack/blob/master/HISTORY.md>.

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -434,7 +434,7 @@ module Rack
       end
 
       def trusted_proxy?(ip)
-        ip =~ /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i
+        Utils.trusted_proxy?(ip)
       end
 
       private

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -599,5 +599,16 @@ module Rack
     end
     module_function :clean_path_info
 
+    class << self
+      attr_accessor :trusted_proxies
+    end
+
+    # The default regex to match trusted proxy addresses.
+    self.trusted_proxies = /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i
+
+    def self.trusted_proxy?(ip)
+      Array(trusted_proxies).any? { |proxy| proxy === ip }
+    end
+
   end
 end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1283,26 +1283,38 @@ EOF
 
   it "regard local addresses as proxies" do
     req = make_request(Rack::MockRequest.env_for("/"))
-    req.trusted_proxy?('127.0.0.1').must_equal 0
-    req.trusted_proxy?('10.0.0.1').must_equal 0
-    req.trusted_proxy?('172.16.0.1').must_equal 0
-    req.trusted_proxy?('172.20.0.1').must_equal 0
-    req.trusted_proxy?('172.30.0.1').must_equal 0
-    req.trusted_proxy?('172.31.0.1').must_equal 0
-    req.trusted_proxy?('192.168.0.1').must_equal 0
-    req.trusted_proxy?('::1').must_equal 0
-    req.trusted_proxy?('fd00::').must_equal 0
-    req.trusted_proxy?('localhost').must_equal 0
-    req.trusted_proxy?('unix').must_equal 0
-    req.trusted_proxy?('unix:/tmp/sock').must_equal 0
+    req.trusted_proxy?('127.0.0.1').must_equal true
+    req.trusted_proxy?('10.0.0.1').must_equal true
+    req.trusted_proxy?('172.16.0.1').must_equal true
+    req.trusted_proxy?('172.20.0.1').must_equal true
+    req.trusted_proxy?('172.30.0.1').must_equal true
+    req.trusted_proxy?('172.31.0.1').must_equal true
+    req.trusted_proxy?('192.168.0.1').must_equal true
+    req.trusted_proxy?('::1').must_equal true
+    req.trusted_proxy?('fd00::').must_equal true
+    req.trusted_proxy?('localhost').must_equal true
+    req.trusted_proxy?('unix').must_equal true
+    req.trusted_proxy?('unix:/tmp/sock').must_equal true
 
-    req.trusted_proxy?("unix.example.org").must_equal nil
-    req.trusted_proxy?("example.org\n127.0.0.1").must_equal nil
-    req.trusted_proxy?("127.0.0.1\nexample.org").must_equal nil
-    req.trusted_proxy?("11.0.0.1").must_equal nil
-    req.trusted_proxy?("172.15.0.1").must_equal nil
-    req.trusted_proxy?("172.32.0.1").must_equal nil
-    req.trusted_proxy?("2001:470:1f0b:18f8::1").must_equal nil
+    req.trusted_proxy?("unix.example.org").must_equal false
+    req.trusted_proxy?("example.org\n127.0.0.1").must_equal false
+    req.trusted_proxy?("127.0.0.1\nexample.org").must_equal false
+    req.trusted_proxy?("11.0.0.1").must_equal false
+    req.trusted_proxy?("172.15.0.1").must_equal false
+    req.trusted_proxy?("172.32.0.1").must_equal false
+    req.trusted_proxy?("2001:470:1f0b:18f8::1").must_equal false
+  end
+
+  it "supports custom trusted proxies" do
+    old, Rack::Utils.trusted_proxies = Rack::Utils.trusted_proxies, ['172.32.0.1']
+
+    begin
+      req = make_request(Rack::MockRequest.env_for("/"))
+      req.trusted_proxy?('127.0.0.1').must_equal false
+      req.trusted_proxy?('172.32.0.1').must_equal true
+    ensure
+      Rack::Utils.trusted_proxies = old
+    end
   end
 
   it "sets the default session to an empty hash" do


### PR DESCRIPTION
here's a PR which closes #735

I propose making `Rack::Request#trusted_proxy?` support custom proxy addresses by allowing them to be specified by adding a `trusted_proxies` configuration option to the `Rack::Utils` module