### PR TITLE
Use Mutex instead of Thread.exclusive for reloader

### DIFF
--- a/lib/rack/reloader.rb
+++ b/lib/rack/reloader.rb
@@ -26,6 +26,7 @@ module Rack
       @last = (Time.now - cooldown)
       @cache = {}
       @mtimes = {}
+      @reload_mutex = Mutex.new
 
       extend backend
     end
@@ -33,7 +34,7 @@ module Rack
     def call(env)
       if @cooldown and Time.now > @last + @cooldown
         if Thread.list.size > 1
-          Thread.exclusive{ reload! }
+          @reload_mutex.synchronize{ reload! }
         else
           reload!
         end


### PR DESCRIPTION
Because Thread.exclusive is deprecated since Ruby 2.3.0:

  * https://github.com/ruby/ruby/blob/v2_3_0/ChangeLog#L2398-L2400
  * https://github.com/ruby/ruby/blob/v2_3_0/prelude.rb#L11