### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -128,7 +128,7 @@ module Rack
         end
       end
 
-      empty_str = ''.force_encoding(Encoding::ASCII_8BIT)
+      empty_str = String.new.force_encoding(Encoding::ASCII_8BIT)
       opts[:input] ||= empty_str
       if String === opts[:input]
         rack_input = StringIO.new(opts[:input])


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Forme's specs
to pass. There may well be other changes that are required.