### PR TITLE
Drop JRuby 1.7 support on Travis since Rack 2.0 requires Ruby 2.2.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
   - 2.3.0
   - ruby-head
   - rbx-2
-  - jruby
   - jruby-9.0.4.0
   - jruby-head
 
@@ -20,5 +19,4 @@ notifications:
 
 matrix:
   allow_failures:
-    - rvm: jruby
     - rvm: rbx-2


### PR DESCRIPTION
JRuby 1.7 supports only Ruby 1.9 or 1.8.7