### PR TITLE
Missing empty multipart params

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -100,8 +100,6 @@ module Rack
               # Generic multipart cases, not coming from a form
               data = {:type => content_type,
                       :name => name, :tempfile => body, :head => head}
-            elsif !filename && data.empty?
-              return
             end
 
             yield data

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -95,6 +95,7 @@ describe Rack::Multipart do
     env['CONTENT_TYPE'] = "multipart/form-data; boundary=----WebKitFormBoundaryWLHCs9qmcJJoyjKR"
     params = Rack::Multipart.parse_multipart(env)
     params['profile']['bio'].must_include 'hello'
+    params['profile'].keys.must_include 'public_email'
   end
 
   it "reject insanely long boundaries" do


### PR DESCRIPTION
After upgrading to Rails 5.0.0.beta1.1 and Rack 2.0.0.alpha I'm missing empty parameters from params.

I added a failing assertion.

However, this assertion is failing for me also on Rack 1.6.4, so right now I'm totally confused.