### PR TITLE
Remove json gem

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -28,8 +28,6 @@ EOF
   s.homepage        = 'http://rack.github.io/'
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency 'json'
-
   s.add_development_dependency 'minitest', "~> 5.0"
   s.add_development_dependency 'minitest-sprint'
   s.add_development_dependency 'concurrent-ruby'


### PR DESCRIPTION
The json gem has been included in Ruby stdlib since 1.9.  The gem itself causes difficulties building on Windows so depending on the gem is actually a net negative these days.