### PR TITLE
improve total allocated objects of Response#finish

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -60,13 +60,14 @@ module Rack
     def finish(&block)
       @block = block
 
-      if [204, 205, 304].include?(status.to_i)
+      status_code = status.to_i
+      if status_code == 204 || status_code == 205 || status_code == 304
         delete_header CONTENT_TYPE
         delete_header CONTENT_LENGTH
         close
-        [status.to_i, header, []]
+        [status_code, header, []]
       else
-        [status.to_i, header, BodyProxy.new(self){}]
+        [status_code, header, BodyProxy.new(self){}]
       end
     end
     alias to_a finish           # For *response


### PR DESCRIPTION
https://github.com/rack/rack/blob/e836fad64ba3a79f8169ef44aa97b7004fca5e86/lib/rack/response.rb#L63 unnecessarily allocates an Array and uses `#include?` to compare the response code to the three integers.

Here is a simple benchmark that shows a minor allocated objects impact:

``` ruby
require 'benchmark'
require 'rack'
require 'rack/test'
require 'ruby-prof'

GC.disable

class App
  def call(env)
    [200, {"Content-Type" => "text/html"}, ["Hello Rack!"]]
  end
end

include Rack::Test::Methods

def app
  @app ||= App.new
end

get '/'

N = 20000

#RubyProf.start

puts "Total objects before: #{@old_total = GC.stat(:total_allocated_object)}"

N.times do
  get '/'
end

puts "Total objects after: #{@new_total = GC.stat(:total_allocated_object)}"
puts "Allocated objects during #{N} requests: #{@new_total - @old_total}"

#result = RubyProf.stop
#printer = RubyProf::GraphHtmlPrinter.new(result)
#File.open('result.html', 'w') do |file|
#  printer.print(file, :min_percent => 1)
#end
```

Before patch:

```
$ time bundle exec ruby benchmark.rb
Total objects before: 350680
Total objects after: 3110684
Allocated objects during 20000 requests: 2760004

real    0m2.339s
user    0m2.172s
sys     0m0.136s
```

After patch:

```
$ time bundle exec ruby benchmark.rb
Total objects before: 350685
Total objects after: 3090689
Allocated objects during 20000 requests: 2740004

real    0m2.282s
user    0m2.116s
sys     0m0.136s
```

If you enable `ruby-prof` in the benchmark, you can also see the that with this patch total time of `Response#finish` goes from `2.38%` to `1.67%`.
