### PR TITLE
Support HTTP Forwarded proto header from RFC 7239

### DIFF
--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -539,6 +539,38 @@ class RackRequestTest < Minitest::Spec
     request.scheme.must_equal "http"
     request.wont_be :ssl?
 
+    request = make_request(Rack::MockRequest.env_for("/", 'HTTP_FORWARDED' => ';;;proto = https'))
+    request.scheme.must_equal "https"
+    request.must_be :ssl?
+
+    request = make_request(Rack::MockRequest.env_for("/", 'HTTP_FORWARDED' => 'proto = https'))
+    request.scheme.must_equal "https"
+    request.must_be :ssl?
+
+    request = make_request(Rack::MockRequest.env_for("/", 'HTTP_FORWARDED' => 'Proto=https'))
+    request.scheme.must_equal "https"
+    request.must_be :ssl?
+
+    request = make_request(Rack::MockRequest.env_for("/", 'HTTP_FORWARDED' => 'proto=https'))
+    request.scheme.must_equal "https"
+    request.must_be :ssl?
+
+    request = make_request(Rack::MockRequest.env_for("/", 'HTTP_FORWARDED' => 'proto="https"'))
+    request.scheme.must_equal "https"
+    request.must_be :ssl?
+
+    request = make_request(Rack::MockRequest.env_for("/", 'HTTP_FORWARDED' => 'bar = 1; proto=https'))
+    request.scheme.must_equal "https"
+    request.must_be :ssl?
+
+    request = make_request(Rack::MockRequest.env_for("/", 'HTTP_FORWARDED' => 'bar = 1; proto=https, proto=http'))
+    request.scheme.must_equal "https"
+    request.must_be :ssl?
+
+    request = make_request(Rack::MockRequest.env_for("/", 'HTTP_FORWARDED' => 'bar = 1; proto=http, proto=https'))
+    request.scheme.must_equal "http"
+    request.wont_be :ssl?
+
     request = make_request(Rack::MockRequest.env_for("/", 'HTTPS' => 'on'))
     request.scheme.must_equal "https"
     request.must_be :ssl?


### PR DESCRIPTION
[RFC 7239][] is an IETF proposed standard for a HTTP `Forwarded` request
header that aims to replace non-standard `X-Forwarded-*` headers.

This commit allows the URI scheme to be detected based on the value of
the `proto` token in that header.

I have prioritised the `Forwarded` header over the non-standard headers
as I think it's preferable to use the standard header when specified.

Multiple values for `proto` are allowed by the standard; the first one
is preferred here as it's the most likely to indicate the protocol used
by the original client.

I've been careful to support mixed case in the header and optional
double quotes for the `proto` value as specified in the RFC.

[RFC 7239]: https://tools.ietf.org/html/rfc7239#section-4