### PR TITLE
Support RFC 7239: HTTP Forwarded header

### DIFF
--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -41,9 +41,10 @@ module Rack
     def log(env, status, header, began_at)
       now = Time.now
       length = extract_content_length(header)
+      forwarded_for = Utils::forwarded_values(env['HTTP_FORWARDED'])[:for].last
 
       msg = FORMAT % [
-        env['HTTP_X_FORWARDED_FOR'] || env["REMOTE_ADDR"] || "-",
+        forwarded_for || env['HTTP_X_FORWARDED_FOR'] || env["REMOTE_ADDR"] || "-",
         env["REMOTE_USER"] || "-",
         now.strftime("%d/%b/%Y:%H:%M:%S %z"),
         env[REQUEST_METHOD],

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -140,6 +140,19 @@ module Rack
     end
     module_function :q_values
 
+    def forwarded_values(forwarded_header)
+      values = Hash.new{ |k,v| k[v] = [] }
+      forwarded_header.to_s.split(/\s*,\s*/).each do |field|
+        field.split(/\s*;\s*/).each do |pair|
+          if /\A\s*(by|for|host|proto)\s*=\s*"?([^"]+)"?\s*\Z/i =~ pair
+            values[$1.downcase.to_sym] << $2
+          end
+        end
+      end
+      values
+    end
+    module_function :forwarded_values
+
     def best_q_match(q_value_header, available_mimes)
       values = q_values(q_value_header)
 

--- a/test/spec_common_logger.rb
+++ b/test/spec_common_logger.rb
@@ -58,6 +58,20 @@ describe Rack::CommonLogger do
     res.errors.must_match(/"GET \/ " 200 - /)
   end
 
+  it "log - records host from X-Forwarded-For header" do
+    res = Rack::MockRequest.new(Rack::CommonLogger.new(app)).get("/", 'HTTP_X_FORWARDED_FOR' => '203.0.113.0')
+
+    res.errors.wont_be :empty?
+    res.errors.must_match(/203\.0\.113\.0 - /)
+  end
+
+  it "log - records host from RFC 7239 forwarded for header" do
+    res = Rack::MockRequest.new(Rack::CommonLogger.new(app)).get("/", 'HTTP_FORWARDED' => 'for=203.0.113.0')
+
+    res.errors.wont_be :empty?
+    res.errors.must_match(/203\.0\.113\.0 - /)
+  end
+
   def with_mock_time(t = 0)
     mc = class << Time; self; end
     mc.send :alias_method, :old_now, :now

--- a/test/spec_common_logger.rb
+++ b/test/spec_common_logger.rb
@@ -36,7 +36,7 @@ describe Rack::CommonLogger do
     log.string.must_match(/"GET \/ " 200 #{length} /)
   end
 
-  it "work with standartd library logger" do
+  it "work with standard library logger" do
     logdev = StringIO.new
     log = Logger.new(logdev)
     Rack::MockRequest.new(Rack::CommonLogger.new(app, log)).get("/")

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -354,6 +354,43 @@ describe Rack::Utils do
     ]
   end
 
+  it "parses RFC 7239 Forwarded header" do
+    Rack::Utils.forwarded_values('for=3.4.5.6').must_equal({
+      :for => [ '3.4.5.6' ],
+    })
+
+    Rack::Utils.forwarded_values(';;;for=3.4.5.6,,').must_equal({
+      :for => [ '3.4.5.6' ],
+    })
+
+    Rack::Utils.forwarded_values('for=3.4.5.6').must_equal({
+      :for => [ '3.4.5.6' ],
+    })
+
+    Rack::Utils.forwarded_values('for =  3.4.5.6').must_equal({
+      :for => [ '3.4.5.6' ],
+    })
+
+    Rack::Utils.forwarded_values('for="3.4.5.6"').must_equal({
+      :for => [ '3.4.5.6' ],
+    })
+
+    Rack::Utils.forwarded_values('for=3.4.5.6;proto=https').must_equal({
+      :for   => [ '3.4.5.6' ],
+      :proto => [ 'https' ]
+    })
+
+    Rack::Utils.forwarded_values('for=3.4.5.6; proto=http, proto=https').must_equal({
+      :for   => [ '3.4.5.6' ],
+      :proto => [ 'http', 'https' ]
+    })
+
+    Rack::Utils.forwarded_values('for=3.4.5.6; proto=http, proto=https; for=1.2.3.4').must_equal({
+      :for   => [ '3.4.5.6', '1.2.3.4' ],
+      :proto => [ 'http', 'https' ]
+    })
+  end
+
   it "select best quality match" do
     Rack::Utils.best_q_match("text/html", %w[text/html]).must_equal "text/html"
 


### PR DESCRIPTION
[RFC 7239](https://tools.ietf.org/html/rfc7239) is an IETF proposed standard for a HTTP `Forwarded` request
header that aims to replace non-standard `X-Forwarded-*` headers.

This commit supports all relevant tokens that may be set in the
Forwarded header:
- proto
- host
- for

I have prioritised the Forwarded header over the non-standard headers
as I think it's preferable to use the standard header when specified.

Multiple values for each token are allowed by the standard. When
multiple values are supplied, I've followed these rules:
- for the `proto` token, use the first value specified as it's most
  likely to be the protocol used by the original client
- for the `host` token, use the last value specified following the
  convention already used by Rack for multiple `X-Forwarded-For`
  headers

When both `X-Forwarded-For` and `Forwarded` headers are supplied and the
latter includes `for` values, I've concatenated both sets of values with
the `Forwarded` values coming last.

I've been careful to support mixed case in the header and optional
double quotes encapsulating the token value as specified in the RFC.
