### PR TITLE
accept two optional args in Rack::Session::Abstract::SessionHash#fetch

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -18,6 +18,9 @@ module Rack
         include Enumerable
         attr_writer :id
 
+        # Singleton object used to determine if an optional param wasn't specified
+        Unspecified = Object.new
+
         def self.find(req)
           req.get_header RACK_SESSION
         end
@@ -54,7 +57,15 @@ module Rack
           load_for_read!
           @data[key.to_s]
         end
-        alias :fetch :[]
+
+        def fetch(key, default=Unspecified, &block)
+          load_for_read!
+          if default == Unspecified
+            @data.fetch(key.to_s, &block)
+          else
+            @data.fetch(key.to_s, default, &block)
+          end
+        end
 
         def has_key?(key)
           load_for_read!

--- a/test/spec_session_abstract_session_hash.rb
+++ b/test/spec_session_abstract_session_hash.rb
@@ -25,4 +25,15 @@ describe Rack::Session::Abstract::SessionHash do
     assert_equal [:bar, :qux], hash.values
   end
 
+  it "returns the correct value" do
+    assert_equal :bar, hash.fetch(:foo)
+  end
+
+  it "returns the correct value using a default" do
+    assert_equal :default, hash.fetch(:missing, :default)
+  end
+
+  it "returns the correct value using a block" do
+    assert_equal 'missing', hash.fetch(:missing) { |el| el.to_s }
+  end
 end


### PR DESCRIPTION
I got bitten by a bug in rails that lead me to this class. They inherit from `Rack::Session::Abstract::SessionHash` for some session hash classes relating to forgery protection (https://github.com/rails/rails/blob/e7feaff70f13b56a0507e9f4dfaf3ebc361cb8e6/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L135). Whilst in the normal session hash they have implemented `fetch` with two optional arguments (https://github.com/rails/rails/blob/e7feaff70f13b56a0507e9f4dfaf3ebc361cb8e6/actionpack/lib/action_dispatch/request/session.rb#L133-L140). They also have a separate session hash class for testing which implements the two optional args for `fetch`.

I had some shared code between controllers called `session.fetch` with the default argument, this caused exceptions for controllers that used forgery protection it also didn't exception in the tests for these controllers.

Whilst this is a bug in rails it seems like this class in `rack` was the right place to fix it and properly mimic the behaviour of Ruby's `Hash`.

I would have added another spec but it outputs the warning `rack/lib/rack/session/abstract/id.rb:66: warning: block supersedes default value argument` in the middle of the test suite. Given the current tests for this class it seemed better to just not include it than to hide the warning.

```
it "returns the correct value using a block and default" do
  assert_equal 'missing', hash.fetch(:missing, :default) { |el| el.to_s }
end
```
