### PR TITLE
use secure_compare in auth examples

### DIFF
--- a/example/protectedlobster.rb
+++ b/example/protectedlobster.rb
@@ -4,7 +4,7 @@ require 'rack/lobster'
 lobster = Rack::Lobster.new
 
 protected_lobster = Rack::Auth::Basic.new(lobster) do |username, password|
-  'secret' == password
+  Rack::Utils.secure_compare('secret', password)
 end
 
 protected_lobster.realm = 'Lobster 2.0'

--- a/example/protectedlobster.ru
+++ b/example/protectedlobster.ru
@@ -2,7 +2,7 @@ require 'rack/lobster'
 
 use Rack::ShowExceptions
 use Rack::Auth::Basic, "Lobster 2.0" do |username, password|
-  'secret' == password
+  Rack::Utils.secure_compare('secret', password)
 end
 
 run Rack::Lobster.new


### PR DESCRIPTION
I was setting up something for a prototype and found myself following the examples without too much thought, and then stumbled across the secure method and figured better safe than sorry (especially since it is so easy to forget stuff like this).