### PR TITLE
Puma should be the default webserver for rackup

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -52,7 +52,7 @@ module Rack
       elsif ENV.include?("RACK_HANDLER")
         self.get(ENV["RACK_HANDLER"])
       else
-        pick ['thin', 'puma', 'webrick']
+        pick ['puma', 'thin', 'webrick']
       end
     end
 


### PR DESCRIPTION
 * Thin is based on fully unmaintained code (EM)
 * Puma is significantly faster, on a tuned 16 core VM the difference is 50kqps.