### PR TITLE
Dont break on `nil` Authorization header

### DIFF
--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -13,7 +13,11 @@ module Rack
       end
 
       def provided?
-        !authorization_key.nil?
+        !authorization_key.nil? && valid?
+      end
+
+      def valid?
+        !@env[authorization_key].nil?
       end
 
       def parts

--- a/test/spec_auth_basic.rb
+++ b/test/spec_auth_basic.rb
@@ -75,6 +75,14 @@ describe Rack::Auth::Basic do
     end
   end
 
+  it 'return 400 Bad Request for a nil authorization header' do
+    request 'HTTP_AUTHORIZATION' => nil do |response|
+      response.must_be :client_error?
+      response.status.must_equal 400
+      response.wont_include 'WWW-Authenticate'
+    end
+  end
+
   it 'takes realm as optional constructor arg' do
     app = Rack::Auth::Basic.new(unprotected_app, realm) { true }
     realm.must_equal app.realm

--- a/test/spec_auth_basic.rb
+++ b/test/spec_auth_basic.rb
@@ -75,11 +75,10 @@ describe Rack::Auth::Basic do
     end
   end
 
-  it 'return 400 Bad Request for a nil authorization header' do
+  it 'return 401 Bad Request for a nil authorization header' do
     request 'HTTP_AUTHORIZATION' => nil do |response|
       response.must_be :client_error?
-      response.status.must_equal 400
-      response.wont_include 'WWW-Authenticate'
+      response.status.must_equal 401
     end
   end
 


### PR DESCRIPTION
It turns out you can pass a bogus Authorization header and cause Rack to 500. For example:

```
$ curl -v https://api.github.com/ -H "Authorization;"

> GET / HTTP/1.1
> Host: api.github.com
> User-Agent: curl/7.43.0
> Accept: */*
> Authorization:
> 
< HTTP/1.1 500 Internal Server Error
< Server: GitHub.com
< Date: Sun, 06 Mar 2016 21:06:15 GMT
< Transfer-Encoding: chunked
< X-GitHub-Request-Id: 1F0A973D:1D92C:2A066E9:56DC9BC6
```

Although `provided?` passes through just fine, since the *value* of the Authorization header is considered `nil`, a later check to [work with `params`](https://github.com/rack/rack/blob/ee18520bd9894e68a5d2b26c82835c2e67a43a8b/lib/rack/auth/basic.rb#L48) blows up.

Please let me know if you have any questions or if I can help move this along!