### PR TITLE
Update first-party-only cookie syntax

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -248,13 +248,20 @@ module Rack
           rfc2822(value[:expires].clone.gmtime) if value[:expires]
         secure = "; secure"  if value[:secure]
         httponly = "; HttpOnly" if (value.key?(:httponly) ? value[:httponly] : value[:http_only])
-        first_party = "; First-Party" if value[:first_party]
+        same_site = if value[:same_site]
+          case value[:same_site]
+          when Symbol, String
+            "; SameSite=#{value[:same_site]}"
+          else
+            "; SameSite"
+          end
+        end
         value = value[:value]
       end
       value = [value] unless Array === value
 
       cookie = "#{escape(key)}=#{value.map { |v| escape v }.join('&')}#{domain}" \
-        "#{path}#{max_age}#{expires}#{secure}#{httponly}#{first_party}"
+        "#{path}#{max_age}#{expires}#{secure}#{httponly}#{same_site}"
 
       case header
       when nil, ''

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -115,16 +115,28 @@ describe Rack::Response do
     response["Set-Cookie"].must_equal "foo=bar"
   end
 
-  it "can set First-Party cookies" do
+  it "can set SameSite cookies with any truthy value" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :first_party => true}
-    response["Set-Cookie"].must_equal "foo=bar; First-Party"
+    response.set_cookie "foo", {:value => "bar", :same_site => Object.new}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite"
+  end
+
+  it "can set SameSite cookies with string value" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => "Lax"}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
+  end
+
+  it "can set SameSite cookies with symbol value" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :Strict}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   [ nil, false ].each do |non_truthy|
-    it "omits First-Party attribute given a #{non_truthy.inspect} value" do
+    it "omits SameSite attribute given a #{non_truthy.inspect} value" do
       response = Rack::Response.new
-      response.set_cookie "foo", {:value => "bar", :first_party => non_truthy}
+      response.set_cookie "foo", {:value => "bar", :same_site => non_truthy}
       response["Set-Cookie"].must_equal "foo=bar"
     end
   end


### PR DESCRIPTION
The spec for first-party-only cookies has been updated. The new attribute name is `SameSite` and a few different values are now supported. The new syntax will [supposedly](https://twitter.com/mikewest/status/709676633712676864) be landing in Chrome 51.

[Current spec](https://tools.ietf.org/html/draft-west-first-party-cookies-06)
/cc @mikewest