### PR TITLE
When a symbol is passed as a status code it must match a valid http status code.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -574,7 +574,8 @@ module Rack
 
     def status_code(status)
       if status.is_a?(Symbol)
-        SYMBOL_TO_STATUS_CODE[status] || 500
+        raise ArgumentError, "Unrecognized status_code symbol" unless SYMBOL_TO_STATUS_CODE[status]
+        SYMBOL_TO_STATUS_CODE[status]
       else
         status.to_i
       end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -449,6 +449,12 @@ describe Rack::Utils do
     Rack::Utils.status_code(:ok).must_equal 200
   end
 
+  it "raise an error for an invalid symbol" do
+    assert_raises(ArgumentError, "Unrecognized status_code symbol") do
+      Rack::Utils.status_code(:foobar)
+    end
+  end
+
   it "return rfc2822 format from rfc2822 helper" do
     Rack::Utils.rfc2822(Time.at(0).gmtime).must_equal "Thu, 01 Jan 1970 00:00:00 -0000"
   end


### PR DESCRIPTION
It is unexpected to get a `500` status code back with no exception raised and no obvious deliberate raising of a `500`.

For instance if one was to provide `:success` as a status symbol by accident instead of `:ok` then a 500 would be raised with no obvious reason.
