### PR TITLE
Compare host and server name only once per call

### DIFF
--- a/lib/rack/urlmap.rb
+++ b/lib/rack/urlmap.rb
@@ -47,11 +47,13 @@ module Rack
       server_name = env[SERVER_NAME]
       server_port = env[SERVER_PORT]
 
+      is_same_server = casecmp?(http_host, server_name) ||
+                       casecmp?(http_host, "#{server_name}:#{server_port}")
+
       @mapping.each do |host, location, match, app|
         unless casecmp?(http_host, host) \
             || casecmp?(server_name, host) \
-            || (!host && (casecmp?(http_host, server_name) ||
-                          casecmp?(http_host, "#{server_name}:#{server_port}")))
+            || (!host && is_same_server)
           next
         end
 


### PR DESCRIPTION
The host name and the server name are not changed inside `#call(env)`,
so there is no need to compare them every time a mapping is tested.