### PR TITLE
Travis: Allow ruby-head and jruby-head builds to fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ notifications:
 
 matrix:
   allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
     - rvm: rbx-2


### PR DESCRIPTION
Development versions of the various Ruby interpreters may have problems that lead the builds to fail, even though the commits are fine and work without problems with the released versions of the interpreters.

For example, these recent PRs failed because of a temporary misconfiguration of the Travis VMs, unrelated to the PRs: <https://travis-ci.org/rack/rack/jobs/120208553>, <https://travis-ci.org/rack/rack/jobs/120842905>. Other builds failed because of a problem with the compilation of a dependency: <https://travis-ci.org/rack/rack/jobs/120208550>.