### PR TITLE
leave modification of rack.multithread from rack::lock

### DIFF
--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -12,7 +12,7 @@ module Rack
     def call(env)
       @mutex.lock
       begin
-        response = @app.call(env.merge(RACK_MULTITHREAD => false))
+        response = @app.call(env.merge!(RACK_MULTITHREAD => false))
         returned = response << BodyProxy.new(response.pop) { @mutex.unlock }
       ensure
         @mutex.unlock unless returned


### PR DESCRIPTION
Please correct me if I am wrong, because in the web server's point of view, the modification should at least have the same life span as the mutex, and it's ok to leave it modified until the end of the request.

The situation I am running into is that after `app.call(env)`, the response body is not closed yet, and the mutex is still hold. if the response is handled in a separate thread, if triggers`ThreadError`.
