### PR TITLE
Backport 1.6 nested query fix to 1.5 stable

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -170,12 +170,12 @@ module Rack
       when Hash
         value.map { |k, v|
           build_nested_query(v, prefix ? "#{prefix}[#{escape(k)}]" : escape(k))
-        }.join("&")
-      when String
+        }.reject(&:empty?).join('&')
+      when nil
+        prefix
+      else
         raise ArgumentError, "value must be a Hash" if prefix.nil?
         "#{prefix}=#{escape(value)}"
-      else
-        prefix
       end
     end
     module_function :build_nested_query


### PR DESCRIPTION
This issue was causing us issues in production so I wanted to backport it
to 1.5. Previously if you passed a fixnum into build_nested_query it would
not be put into the query string. This backports a fix to make fixnums show
up in nested queries.
