### PR TITLE
Validate the SameSite cookie option

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -251,7 +251,11 @@ module Rack
         same_site = if value[:same_site]
           case value[:same_site]
           when Symbol, String
-            "; SameSite=#{value[:same_site]}"
+            same_site_rule = value[:same_site].to_s
+            unless ["Lax", "Strict"].include?(same_site_rule)
+              raise ArgumentError, "Unrecognized cookie header value for SameSite option: #{same_site_rule}"
+            end
+            "; SameSite=#{same_site_rule}"
           else
             "; SameSite"
           end

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -248,18 +248,17 @@ module Rack
           rfc2822(value[:expires].clone.gmtime) if value[:expires]
         secure = "; secure"  if value[:secure]
         httponly = "; HttpOnly" if (value.key?(:httponly) ? value[:httponly] : value[:http_only])
-        same_site = if value[:same_site]
+        same_site =
           case value[:same_site]
-          when Symbol, String
-            same_site_rule = value[:same_site].to_s
-            unless ["Lax", "Strict"].include?(same_site_rule)
-              raise ArgumentError, "Unrecognized cookie header value for SameSite option: #{same_site_rule}"
-            end
-            "; SameSite=#{same_site_rule}"
+          when false, nil
+            nil
+          when :lax, 'Lax', :Lax
+            '; SameSite=Lax'.freeze
+          when true, :strict, 'Strict', :Strict
+            '; SameSite=Strict'.freeze
           else
-            "; SameSite"
+            raise ArgumentError, "Invalid SameSite value: #{value[:same_site].inspect}"
           end
-        end
         value = value[:value]
       end
       value = [value] unless Array === value

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -115,10 +115,46 @@ describe Rack::Response do
     response["Set-Cookie"].must_equal "foo=bar"
   end
 
-  it "can set SameSite cookies with string value" do
+  it "can set SameSite cookies with symbol value :lax" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :lax}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
+  end
+
+  it "can set SameSite cookies with symbol value :Lax" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :lax}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
+  end
+
+  it "can set SameSite cookies with string value 'Lax'" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => "Lax"}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
+  end
+
+  it "can set SameSite cookies with boolean value true" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => true}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
+  end
+
+  it "can set SameSite cookies with symbol value :strict" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :strict}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
+  end
+
+  it "can set SameSite cookies with symbol value :Strict" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :Strict}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
+  end
+
+  it "can set SameSite cookies with string value 'Strict'" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => "Strict"}
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "validates the SameSite option value" do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -127,6 +127,14 @@ describe Rack::Response do
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
   end
 
+  it "validates the SameSite option value" do
+    response = Rack::Response.new
+    lambda {
+      response.set_cookie "foo", {:value => "bar", :same_site => "Foo"}
+    }.must_raise(ArgumentError).
+      message.must_match(/Unrecognized cookie header value for SameSite option: Foo/)
+  end
+
   it "can set SameSite cookies with symbol value" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :Strict}

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -115,12 +115,6 @@ describe Rack::Response do
     response["Set-Cookie"].must_equal "foo=bar"
   end
 
-  it "can set SameSite cookies with any truthy value" do
-    response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => Object.new}
-    response["Set-Cookie"].must_equal "foo=bar; SameSite"
-  end
-
   it "can set SameSite cookies with string value" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => "Lax"}
@@ -132,7 +126,7 @@ describe Rack::Response do
     lambda {
       response.set_cookie "foo", {:value => "bar", :same_site => "Foo"}
     }.must_raise(ArgumentError).
-      message.must_match(/Unrecognized cookie header value for SameSite option: Foo/)
+      message.must_match(/Invalid SameSite value: "Foo"/)
   end
 
   it "can set SameSite cookies with symbol value" do


### PR DESCRIPTION
The [draft spec](https://tools.ietf.org/html/draft-west-first-party-cookies-07) for the SameSite option mentions two configuration
options: Strict & Lax. This commit introduces validation of the
associated same_site attribute.

The main motivation for validating this value is ensuring that awry
option values don't cause unexpected behaviour. As this is a sensitive
security option, I think validation is warranted.

The main drawback of validating the option value is that Rack won't
immediately support new options.