### PR TITLE
CI: fix 1.8 deps and stale bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,43 @@
-before_install: sudo apt-get install lighttpd libfcgi-dev libmemcache-dev memcached
-install:
+language: ruby
+sudo: false
+cache:
+  - bundler
+  - apt
+
+services:
+  - memcached
+
+addons:
+  apt:
+    packages:
+      - lighttpd
+      - libfcgi-dev
+
+before_install:
   - gem env version | grep '^\(2\|1.\(8\|9\|[0-9][0-9]\)\)' || gem update --system
-  - bundle install --jobs=3 --retry=3
+
 script: bundle exec rake ci
+
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2
+  - 2.2.4
+  - 2.3.0
   - ruby-head
   - rbx-2
   - jruby
+  - jruby-9.0.4.0
   - jruby-head
   - ree
+
 notifications:
   email: false
   irc: "irc.freenode.org#rack"
+
+matrix:
+  allow_failures:
+    - rvm: rbx-2
+    - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+# Rake 11+ is Ruby 1.9+ only. Stick with 10.x to avoid awkward Bundler
+# platform and RUBY_VERSION gymnastics, or separate Gemfiles.
+gem "rake", "< 11.0"
+
 # What we need to do here is just *exclude* JRuby, but bundler has no way to do
 # this, because of some argument that I know I had with Yehuda and Carl years
 # ago, but I've since forgotten. Anyway, we actually need it here, and it's not

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -23,10 +23,19 @@ describe Rack::Handler do
     lambda {
       Rack::Handler.get('boom')
     }.should.raise(LoadError)
+  end
 
-    lambda {
-      Rack::Handler.get('Object')
-    }.should.raise(LoadError)
+  should "raise LoadError if handler isn't nested under Rack::Handler" do
+    # Feature-detect whether Ruby can do non-inherited const lookups.
+    # If it can't, then Rack::Handler may lookup non-handler toplevel
+    # constants, so the best we can do is no-op here and not test it.
+    begin
+      Rack::Handler._const_get('Object', false)
+    rescue NameError
+      lambda {
+        Rack::Handler.get('Object')
+      }.should.raise(LoadError)
+    end
   end
 
   should "get unregistered, but already required, handler by name" do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -100,13 +100,13 @@ describe Rack::Response do
   it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :lax}
-    response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with symbol value :Lax" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :lax}
-    response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with string value 'Lax'" do
@@ -118,33 +118,33 @@ describe Rack::Response do
   it "can set SameSite cookies with boolean value true" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => true}
-    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with symbol value :strict" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :strict}
-    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with symbol value :Strict" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :Strict}
-    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with string value 'Strict'" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => "Strict"}
-    response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
   end
 
   it "validates the SameSite option value" do
     response = Rack::Response.new
     lambda {
       response.set_cookie "foo", {:value => "bar", :same_site => "Foo"}
-    }.must_raise(ArgumentError).
-      message.must_match(/Invalid SameSite value: "Foo"/)
+    }.should.raise(ArgumentError).
+      message.should.match(/Invalid SameSite value: "Foo"/)
   end
 
   it "can set SameSite cookies with symbol value" do


### PR DESCRIPTION
Fixing up Travis builds on current stable branch

* Pin to Rake < 11.0 for 1.8 compat
* Upgrade Bundler to fix ye olde https://github.com/bundler/bundler/pull/3559 
* Build on Ruby 2.3
* Allow failures on jruby-head and rbx-2