### PR TITLE
CI: Refresh and repair builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,45 @@
-before_install: sudo apt-get install lighttpd libfcgi-dev libmemcache-dev memcached
-install:
+language: ruby
+sudo: false
+cache:
+  - bundler
+  - apt
+
+services:
+  - memcached
+
+addons:
+  apt:
+    packages:
+      - lighttpd
+      - libfcgi-dev
+
+before_install:
   - gem env version | grep '^\(2\|1.\(8\|9\|[0-9][0-9]\)\)' || gem update --system
-  - gem install --conservative rake
-  - rake deps
-script: rake ci
+
+script: bundle exec rake ci
+
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.0-preview2
+  - 2.1
+  - 2.2.4
+  - 2.3.0
+  - ruby-head
   - rbx
+  - rbx-2
   - jruby
+  - jruby-9.0.4.0
+  - jruby-head
   - ree
+
 notifications:
   email: false
   irc: "irc.freenode.org#rack"
+
 matrix:
   allow_failures:
     - rvm: 2.0.0
+    - rvm: rbx-2
+    - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,26 @@ source 'https://rubygems.org'
 
 gemspec
 
+# Rake 11+ is Ruby 1.9+ only. Stick with 10.x to avoid awkward Bundler
+# platform and RUBY_VERSION gymnastics, or separate Gemfiles.
+gem "rake", "< 11.0"
+
+# What we need to do here is just *exclude* JRuby, but bundler has no way to do
+# this, because of some argument that I know I had with Yehuda and Carl years
+# ago, but I've since forgotten. Anyway, we actually need it here, and it's not
+# avaialable, so prepare yourself for a yak shave when this breaks.
+c_platforms = Bundler::Dsl::VALID_PLATFORMS.dup.delete_if do |platform|
+  # to_s because we still run 1.8
+  platform.to_s =~ /jruby/
+end
+
+# Alternative solution that might work, but it has bad interactions with
+# Gemfile.lock if that gets committed/reused:
+# c_platforms = [:mri] if Gem.platforms.last.os == "java"
+
 group :extra do
-  gem 'ruby-fcgi'
+  gem 'fcgi', :platforms => c_platforms
   gem 'memcache-client'
-  gem 'mongrel', '>= 1.2.0.pre2'
-  gem 'thin'
+  gem 'mongrel', '>= 1.2.0.pre2', :platforms => c_platforms
+  gem 'thin', :platforms => c_platforms
 end


### PR DESCRIPTION
* Pin to Rake < 11.0 for 1.8 compat
* Backport Travis bump: 8c31cef
* Build on Ruby 2.x, rbx-2, and jruby-head