### PR TITLE
head requests for missing files are now working (issue #945)

### DIFF
--- a/lib/rack/file.rb
+++ b/lib/rack/file.rb
@@ -27,7 +27,7 @@ module Rack
     def call(env)
       request = Rack::Request.new env
       unless ALLOWED_VERBS.include? request.request_method
-        return fail(405, "Method Not Allowed", {'Allow' => ALLOW_HEADER})
+        return fail(405, request.request_method, "Method Not Allowed", {'Allow' => ALLOW_HEADER})
       end
 
       path_info = Utils.unescape_path request.path_info
@@ -44,7 +44,7 @@ module Rack
       if available
         serving(request, path)
       else
-        fail(404, "File not found: #{path_info}")
+        fail(404, request.request_method, "File not found: #{path_info}")
       end
     end
 
@@ -75,7 +75,7 @@ module Rack
         range = 0..size-1
       elsif ranges.empty?
         # Unsatisfiable. Return error, and file size:
-        response = fail(416, "Byte range unsatisfiable")
+        response = fail(416, request.request_method, "Byte range unsatisfiable")
         response[1]["Content-Range"] = "bytes */#{size}"
         return response
       else
@@ -129,8 +129,11 @@ module Rack
       end
     end
 
-    def fail(status, body, headers = {})
+    def fail(status, request_method, body, headers = {})
       body += "\n"
+      
+      return [status, headers, []] if request_method == "HEAD"
+
       [
         status,
         {

--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -240,6 +240,7 @@ describe Rack::File do
   it "return error when file not found for head request" do
     res = Rack::MockRequest.new(file(DOCROOT)).head("/cgi/missing")
     res.must_be :not_found?
+    res.body.must_be :empty?
   end
 
 end

--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -237,4 +237,9 @@ describe Rack::File do
     res['Content-Type'].must_equal nil
   end
 
+  it "return error when file not found for head request" do
+    res = Rack::MockRequest.new(file(DOCROOT)).head("/cgi/missing")
+    res.must_be :not_found?
+  end
+
 end


### PR DESCRIPTION
`fail` needs to know the request method in order to send the appropriate response, since HEAD responses cannot have a body.