### PR TITLE
split lighttpd condition to fix failing builds on travis

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,8 @@ require 'minitest/autorun'
 
 module Rack
   class TestCase < Minitest::Test
-    if `which lighttpd` && $?.success?
+    `which lighttpd`
+    if $?.success?
       begin
         # Keep this first.
         LIGHTTPD_PID = fork {


### PR DESCRIPTION
ruby-head is failing on this line in [test/helper.rb](https://github.com/rack/rack/blob/master/test/helper.rb#L5):
`` if `which lighttpd` && $?.success? ``
This line works fine in IRB, but if you create a .rb file with just this line:
`` `which lighttpd` && $?.success? ? true : false ``
and run it through command-line ruby, it will give the same error.
`` `which lighttpd` `` will always be truthy, as long as it's run in an environment that has `which`, so it doesn't need to be in the condition, anyway.