### PR TITLE
Return 400 if Rack::File or Rack::Directory path contains null byte

### DIFF
--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -65,12 +65,24 @@ table { width:100%%; }
       script_name = env[SCRIPT_NAME]
       path_info = Utils.unescape_path(env[PATH_INFO])
 
-      if forbidden = check_forbidden(path_info)
+      if bad_request = check_bad_request(path_info)
+        bad_request
+      elsif forbidden = check_forbidden(path_info)
         forbidden
       else
         path = ::File.join(@root, path_info)
         list_path(env, path, path_info, script_name)
       end
+    end
+
+    def check_bad_request(path_info)
+      return if Utils.valid_path?(path_info)
+
+      body = "Bad Request\n"
+      size = body.bytesize
+      return [400, {CONTENT_TYPE => "text/plain",
+        CONTENT_LENGTH => size.to_s,
+        "X-Cascade" => "pass"}, [body]]
     end
 
     def check_forbidden(path_info)

--- a/lib/rack/file.rb
+++ b/lib/rack/file.rb
@@ -38,8 +38,9 @@ module Rack
       end
 
       path_info = Utils.unescape_path request.path_info
-      clean_path_info = Utils.clean_path_info(path_info)
+      return fail(400, "Bad Request") unless Utils.valid_path?(path_info)
 
+      clean_path_info = Utils.clean_path_info(path_info)
       path = ::File.join(@root, clean_path_info)
 
       available = begin

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -609,5 +609,12 @@ module Rack
     end
     module_function :clean_path_info
 
+    NULL_BYTE = "\0".freeze
+
+    def valid_path?(path)
+      path.valid_encoding? && !path.include?(NULL_BYTE)
+    end
+    module_function :valid_path?
+
   end
 end

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -63,6 +63,13 @@ describe Rack::Directory do
     assert_match(res, /passed!/)
   end
 
+  it "serve uri with URL encoded null byte (%00) in filenames" do
+    res = Rack::MockRequest.new(Rack::Lint.new(app))
+      .get("/cgi/test%00")
+
+    res.must_be :bad_request?
+  end
+
   it "not allow directory traversal" do
     res = Rack::MockRequest.new(Rack::Lint.new(app)).
       get("/cgi/../test")

--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -68,6 +68,11 @@ describe Rack::File do
     assert_match(res, /ruby/)
   end
 
+  it "serve uri with URL encoded null byte (%00) in filenames" do
+    res = Rack::MockRequest.new(file(DOCROOT)).get("/cgi/test%00")
+    res.must_be :bad_request?
+  end
+
   it "allow safe directory traversal" do
     req = Rack::MockRequest.new(file(DOCROOT))
 


### PR DESCRIPTION
When using Rack::File or Rack::Directory to serve files, if the path contains a null byte a 500 error is produced.

**Steps to reproduce**

create the following rack app:

config.ru
```
# This is the root of our app
@root = File.expand_path(File.join(File.dirname(__FILE__), "www"))

run Proc.new { |env|
  Rack::File.new(@root).call(env)
  # Same issue is seen with Rack::Directory.new(@root).call(env)
}
```

run `rackup config.ru`

run `curl -I localhost:9292/test%00`

**Output**:
````
HTTP/1.1 500 Internal Server Error 
Content-Type: text/html; charset=ISO-8859-1
Server: WEBrick/1.3.1 (Ruby/2.2.4/2015-12-16)
Date: Tue, 12 Jan 2016 21:54:26 GMT
Content-Length: 305
Connection: close
```

**Stacktrace:**
```
[2016-01-12 16:42:46] ERROR ArgumentError: string contains null byte
	/Users/jordan/.rvm/gems/ruby-2.2.4/bundler/gems/rack-545532b01d33/lib/rack/utils.rb:598:in `join'
	/Users/jordan/.rvm/gems/ruby-2.2.4/bundler/gems/rack-545532b01d33/lib/rack/utils.rb:598:in `clean_path_info'
	/Users/jordan/.rvm/gems/ruby-2.2.4/bundler/gems/rack-545532b01d33/lib/rack/file.rb:34:in `call'
	/Users/jordan/projects/rails_test/config.ru:14:in `block (2 levels) in <main>'
	/Users/jordan/.rvm/gems/ruby-2.2.4/bundler/gems/rack-545532b01d33/lib/rack/handler/webrick.rb:86:in `call'
	/Users/jordan/.rvm/gems/ruby-2.2.4/bundler/gems/rack-545532b01d33/lib/rack/handler/webrick.rb:86:in `service'
	/Users/jordan/.rvm/rubies/ruby-2.2.4/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
	/Users/jordan/.rvm/rubies/ruby-2.2.4/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
	/Users/jordan/.rvm/rubies/ruby-2.2.4/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
```

I believe this should return a 400 status code instead of resulting in a 500.