### PR TITLE
Omit response body for HEAD requests to Rack::Directory

### DIFF
--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -59,9 +59,15 @@ table { width:100%%; }
     def initialize(root, app=nil)
       @root = ::File.expand_path(root)
       @app = app || Rack::File.new(@root)
+      @head = Rack::Head.new(lambda { |env| get env })
     end
 
     def call(env)
+      # strip body if this is a HEAD call
+      @head.call env
+    end
+
+    def get(env)
       script_name = env[SCRIPT_NAME]
       path_info = Utils.unescape_path(env[PATH_INFO])
 

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -130,4 +130,12 @@ describe Rack::Directory do
     res = mr.get("/script-path/cgi/test+directory/test+file")
     res.must_be :ok?
   end
+
+  it "return error when file not found for head request" do
+    res = Rack::MockRequest.new(Rack::Lint.new(app)).
+      head("/cgi/missing")
+
+    res.must_be :not_found?
+    res.body.must_be :empty?
+  end
 end


### PR DESCRIPTION
`Rack::Directory` suffers from the same issue described in issue #945. I have applied the fix that was used in PR #1062.

I'm am not aware of any other endpoints that would need to be made head-aware. The issue seems to be when a method (such as `Rack::Directory#entity_not_found`) is used to build an error response and it does not consider the request method before including a response body.

cc: @jeremy @tgrindinger