### PR TITLE
Use SCRIPT_NAME + PATH_INFO when logging request paths

### DIFF
--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -47,7 +47,7 @@ module Rack
         env["REMOTE_USER"] || "-",
         now.strftime("%d/%b/%Y:%H:%M:%S %z"),
         env[REQUEST_METHOD],
-        env[PATH_INFO],
+        path(env),
         env[QUERY_STRING].empty? ? "" : "?#{env[QUERY_STRING]}",
         env[HTTP_VERSION],
         status.to_s[0..3],
@@ -62,6 +62,10 @@ module Rack
       else
         logger << msg
       end
+    end
+
+    def path(env)
+      env[SCRIPT_NAME] + env[PATH_INFO]
     end
 
     def extract_content_length(headers)

--- a/test/spec_common_logger.rb
+++ b/test/spec_common_logger.rb
@@ -85,6 +85,22 @@ describe Rack::CommonLogger do
     (0..1).must_include duration.to_f
   end
 
+  it "log path with PATH_INFO" do
+    logdev = StringIO.new
+    log = Logger.new(logdev)
+    Rack::MockRequest.new(Rack::CommonLogger.new(app, log)).get("/hello")
+
+    logdev.string.must_match(/"GET \/hello " 200 #{length} /)
+  end
+
+  it "log path with SCRIPT_NAME" do
+    logdev = StringIO.new
+    log = Logger.new(logdev)
+    Rack::MockRequest.new(Rack::CommonLogger.new(app, log)).get("/path", script_name: "/script")
+
+    logdev.string.must_match(/"GET \/script\/path " 200 #{length} /)
+  end
+
   def length
     123
   end


### PR DESCRIPTION
Just noticed that `Rack::CommonLogger` is not using `SCRIPT_NAME` when logging request paths. Not sure if this was intended, but if it's indeed a bug, this PR hopes to address that.
