### PR TITLE
Prevent exception caused by a race condition on multi-threaded servers

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'fileutils'
 
 
 module Rack

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -359,7 +359,7 @@ module Rack
 
       def write_pid
         ::File.open(options[:pid], ::File::CREAT | ::File::EXCL | ::File::WRONLY ){ |f| f.write("#{Process.pid}") }
-        at_exit { ::File.delete(options[:pid]) rescue Errno::ENOENT }
+        at_exit { ::FileUtils.rm_f(options[:pid]) }
       rescue Errno::EEXIST
         check_pid!
         retry

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -359,7 +359,7 @@ module Rack
 
       def write_pid
         ::File.open(options[:pid], ::File::CREAT | ::File::EXCL | ::File::WRONLY ){ |f| f.write("#{Process.pid}") }
-        at_exit { ::File.delete(options[:pid]) if ::File.exist?(options[:pid]) }
+        at_exit { ::File.delete(options[:pid]) rescue Errno::ENOENT }
       rescue Errno::EEXIST
         check_pid!
         retry


### PR DESCRIPTION
I opened an issue earlier today: https://github.com/rack/rack/issues/1077 :

> I have that same error really well described here:
puma/puma#915

> TL;DR : When using Puma, that method of server.rb bellow (Rack) tries to delete the pid file. Every Puma thread executes it and they all see that the file exists. So only the first thread can delete it and every other will raise a ENOENT No such file tmp/pids/server.pid

> ```
  def write_pid
    ::File.open(options[:pid], ::File::CREAT | ::File::EXCL | ::File::WRONLY ){ |f| f.write("#{Process.pid}") }
        at_exit { ::File.delete(options[:pid]) if ::File.exist?(options[:pid]) }
  rescue Errno::EEXIST
    check_pid!
    retry
  end
```

> This is something I'd love to submit a pull request for, but I am not sure of the approach you'd prefer.

> It is clear to me that we could rescue the Errno::ENOENT. I'd like to replace the if entirely with it but I don't know if you'd like it.