### PR TITLE
Attempt server.pid deletion without throwing exception

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -359,7 +359,7 @@ module Rack
 
       def write_pid
         ::File.open(options[:pid], ::File::CREAT | ::File::EXCL | ::File::WRONLY ){ |f| f.write("#{Process.pid}") }
-        at_exit { ::File.delete(options[:pid]) if ::File.exist?(options[:pid]) }
+        at_exit { ::File.delete(options[:pid]) if ::File.exist?(options[:pid]) rescue nil }
       rescue Errno::EEXIST
         check_pid!
         retry


### PR DESCRIPTION
When multiple workers are attempting to delete server.pid at exit, one or more workers can find the file before it is deleted and then try to delete it after its already deleted.  Rescuing the exception that can result eliminates some unnecessary noise.