### PR TITLE
Accept multiple require options

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -41,7 +41,7 @@ module Rack
 
           opts.on("-r", "--require LIBRARY",
                   "require the library, before executing your script") { |library|
-            options[:require] = library
+            (options[:require] ||= []) << library
           }
 
           opts.separator ""
@@ -263,8 +263,10 @@ module Rack
         $LOAD_PATH.unshift(*includes)
       end
 
-      if library = options[:require]
-        require library
+      if libraries = options[:require]
+        libraries.each do |library|
+          require library
+        end
       end
 
       if options[:debug]


### PR DESCRIPTION
This PR makes `rackup` accept multiple **require** options. Currently only last **require** library is loaded. Other library are ignored. For example

```
% rackup -r foo -r bar
```

`bar` is loaded but `foo` is not loaded.
