### PR TITLE
Add Rack::QueryParser::Params#inspect

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -176,6 +176,10 @@ module Rack
         end
         hash
       end
+
+      def inspect
+        "#<#{self.class}: #{@params.inspect} >"
+      end
     end
   end
 end


### PR DESCRIPTION
With a custom inspect method, debugging instances of `Rack::QueryParser::Params` is more readable:

Before

    #<Rack::QueryParser::Params:0x007f99a3087610 @limit=65536, @size=6, @params={"foo"=>"bar", "baz"=>["1", "2", "3"]}>

After

    #<Rack::QueryParser::Params: {"foo"=>"bar", "baz"=>["1", "2", "3"]} >