### PR TITLE
Minor query parser refactorings

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -30,11 +30,12 @@ module Rack
     # cookies by changing the characters used in the second
     # parameter (which defaults to '&;').
     def parse_query(qs, d = nil, &unescaper)
+      return {} if qs.nil? || qs.empty?
       unescaper ||= method(:unescape)
 
       params = make_params
 
-      (qs || '').split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
+      qs.split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
         next if p.empty?
         k, v = p.split('='.freeze, 2).map!(&unescaper)
 
@@ -61,7 +62,7 @@ module Rack
       return {} if qs.nil? || qs.empty?
       params = make_params
 
-      (qs || '').split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
+      qs.split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
         k, v = p.split('='.freeze, 2).map! { |s| unescape(s) }
 
         normalize_params(params, k, v, param_depth_limit)

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -31,11 +31,13 @@ module Rack
     # parameter (which defaults to '&;').
     def parse_query(qs, d = nil, &unescaper)
       return {} if qs.nil? || qs.empty?
+
+      delimiter = d ? COMMON_SEP.fetch(d) { %r{[#{d}] *}n } : DEFAULT_SEP
       unescaper ||= method(:unescape)
 
       params = make_params
 
-      qs.split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
+      qs.split(delimiter).each do |p|
         next if p.empty?
         k, v = p.split('='.freeze, 2).map!(&unescaper)
 
@@ -60,9 +62,12 @@ module Rack
     # case.
     def parse_nested_query(qs, d = nil)
       return {} if qs.nil? || qs.empty?
+
+      delimiter = d ? COMMON_SEP.fetch(d) { %r{[#{d}] *}n } : DEFAULT_SEP
+
       params = make_params
 
-      qs.split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
+      qs.split(delimiter).each do |p|
         k, v = p.split('='.freeze, 2).map! { |s| unescape(s) }
 
         normalize_params(params, k, v, param_depth_limit)


### PR DESCRIPTION
This PR cleans up query_parser ~3~ 2 places:
1. In `#parse_nested_query` there is a guard clause for `qs` being nil or empty, so there should be no need for the `qs || ''` conditional. I applied the same guard clause to `#parse_query`.
2. The logic determining the regex for splitting the query string (`d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP`) looks a bit too complex for using directly as a method argument. I extracted it to a local variable `delimiter`, and also changed it to use `#fetch` with a block, instead of using `||` for fallback.
3. ~Speed up extracting `first_key` from `child_key`: Using `gsub` and splitting over the inserted whitespaces, only to use the first element isn’t particularly fast. It’s much faster to fetch the first match using a regex:~ 

Please let me know if I should split into multiple PRs.
