### PR TITLE
Try harder when deciding whether to add a new array element

### DIFF
--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -231,6 +231,18 @@ describe Rack::Utils do
       message.must_equal "invalid byte sequence in UTF-8"
   end
 
+  it "only moves to a new array when the full key has been seen" do
+    Rack::Utils.parse_nested_query("x[][y][][z]=1&x[][y][][w]=2").
+      must_equal "x" => [{"y" => [{"z" => "1", "w" => "2"}]}]
+
+    Rack::Utils.parse_nested_query(
+      "x[][id]=1&x[][y][a]=5&x[][y][b]=7&x[][z][id]=3&x[][z][w]=0&x[][id]=2&x[][y][a]=6&x[][y][b]=8&x[][z][id]=4&x[][z][w]=0"
+    ).must_equal "x" => [
+        {"id" => "1", "y" => {"a" => "5", "b" => "7"}, "z" => {"id" => "3", "w" => "0"}},
+        {"id" => "2", "y" => {"a" => "6", "b" => "8"}, "z" => {"id" => "4", "w" => "0"}},
+      ]
+  end
+
   it "allow setting the params hash class to use for parsing query strings" do
     begin
       default_parser = Rack::Utils.default_query_parser


### PR DESCRIPTION
Only move to a new entry if the end key is taken; checking only the top-level key is insufficient.

This implementation is pretty unfortunate, but is the option that minimizes changes to `normalize_params`. I'm tempted to try for a more invasive (and correspondingly less tacked-on) alternative, though.

Fixes #1086, https://github.com/rails/rails/issues/23997

cc @rthbound @bquorning @bmedenwald