### PR TITLE
Use RFC 6265 date format for expires time.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -221,31 +221,8 @@ module Rack
         domain  = "; domain=#{value[:domain]}"   if value[:domain]
         path    = "; path=#{value[:path]}"       if value[:path]
         max_age = "; max-age=#{value[:max_age]}" if value[:max_age]
-        # There is an RFC mess in the area of date formatting for Cookies. Not
-        # only are there contradicting RFCs and examples within RFC text, but
-        # there are also numerous conflicting names of fields and partially
-        # cross-applicable specifications.
-        #
-        # These are best described in RFC 2616 3.3.1. This RFC text also
-        # specifies that RFC 822 as updated by RFC 1123 is preferred. That is a
-        # fixed length format with space-date delimited fields.
-        #
-        # See also RFC 1123 section 5.2.14.
-        #
-        # RFC 6265 also specifies "sane-cookie-date" as RFC 1123 date, defined
-        # in RFC 2616 3.3.1. RFC 6265 also gives examples that clearly denote
-        # the space delimited format. These formats are compliant with RFC 2822.
-        #
-        # For reference, all involved RFCs are:
-        # RFC 822
-        # RFC 1123
-        # RFC 2109
-        # RFC 2616
-        # RFC 2822
-        # RFC 2965
-        # RFC 6265
         expires = "; expires=" +
-          rfc2822(value[:expires].clone.gmtime) if value[:expires]
+          rfc2616(value[:expires].clone.gmtime) if value[:expires]
         secure = "; secure"  if value[:secure]
         httponly = "; HttpOnly" if (value.key?(:httponly) ? value[:httponly] : value[:http_only])
         same_site =
@@ -327,6 +304,11 @@ module Rack
 
     end
     module_function :add_remove_cookie_to_header
+
+    def rfc2616(time)
+      time.httpdate
+    end
+    module_function :rfc2616
 
     def rfc2822(time)
       time.rfc2822

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -186,7 +186,7 @@ describe Rack::Response do
     response.delete_cookie "foo"
     response["Set-Cookie"].must_equal [
       "foo2=bar2",
-      "foo=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"
+      "foo=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"
     ].join("\n")
   end
 
@@ -196,10 +196,10 @@ describe Rack::Response do
     response.set_cookie "foo", {:value => "bar", :domain => ".example.com"}
     response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=bar; domain=.example.com"].join("\n")
     response.delete_cookie "foo", :domain => ".example.com"
-    response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=; domain=.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"].join("\n")
+    response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=; domain=.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
     response.delete_cookie "foo", :domain => "sample.example.com"
-    response["Set-Cookie"].must_equal ["foo=; domain=.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000",
-                                         "foo=; domain=sample.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"].join("\n")
+    response["Set-Cookie"].must_equal ["foo=; domain=.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT",
+                                         "foo=; domain=sample.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
   end
 
   it "can delete cookies with the same name with different paths" do
@@ -211,7 +211,7 @@ describe Rack::Response do
 
     response.delete_cookie "foo", :path => "/path"
     response["Set-Cookie"].must_equal ["foo=bar; path=/",
-                                         "foo=; path=/path; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"].join("\n")
+                                         "foo=; path=/path; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
   end
 
   it "can do redirects" do

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -461,6 +461,10 @@ describe Rack::Utils do
     Rack::Utils.status_code(:ok).must_equal 200
   end
 
+  it "return rfc2616 format from rfc2616 helper" do
+    Rack::Utils.rfc2616(Time.at(0).gmtime).must_equal "Thu, 01 Jan 1970 00:00:00 GMT"
+  end
+
   it "return rfc2822 format from rfc2822 helper" do
     Rack::Utils.rfc2822(Time.at(0).gmtime).must_equal "Thu, 01 Jan 1970 00:00:00 -0000"
   end


### PR DESCRIPTION
Many browsers are forgiving when it comes to interpreting the `expires` value set in a cookie. 

With that said, Rack has been using a date format for its `expires` time that is not consistent with the rest of the web. This PR changes one tiny thing... the timezone format is "GMT" and not "-0000". This is consistent with `Time#httpdate` and `CGI::Cookie` formatting found elsewhere in Ruby.

Exploring the expiration times for various popular sites around the web illustrate this format:

```
curl -I http://www.wikipedia.com | grep Set-Cookie
Set-Cookie: WMF-Last-Access=19-Aug-2016;Path=/;HttpOnly;secure;Expires=Tue, 20 Sep 2016 12:00:00 GMT

curl -I http://www.google.com | grep Set-Cookie
Set-Cookie: xxx; expires=Sat, 18-Feb-2017 18:33:43 GMT; path=/; domain=.google.com; HttpOnly
```

This closes #1100. See the discussion there for more details.
