### PR TITLE
Freeze default session options

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -200,7 +200,7 @@ module Rack
           :sidbits =>       128,
           :cookie_only =>   true,
           :secure_random => ::SecureRandom
-        }
+        }.freeze
 
         attr_reader :key, :default_options, :sid_secure
 


### PR DESCRIPTION
Some code in my app have been accidentally mutating the default session options,
which broke some session behaviour.
It wasn't easy to track that down, so I'd like to suggest that we freeze this hash
to avoid mutation.

@matthewd 