### PR TITLE
Middleware Stack

### DIFF
--- a/example/lobster_stack.ru
+++ b/example/lobster_stack.ru
@@ -1,0 +1,9 @@
+require 'rack/lobster'
+
+stack = Rack::MiddlewareStack.new
+stack.use Rack::Chunked
+stack.use Rack::ShowExceptions
+
+use stack
+
+run Rack::Lobster.new

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -87,6 +87,7 @@ module Rack
   RACK_SESSION_UNPACKED_COOKIE_DATA   = 'rack.session.unpacked_cookie_data'.freeze
 
   autoload :Builder, "rack/builder"
+  autoload :MiddlewareStack, "rack/middleware_stack"
   autoload :BodyProxy, "rack/body_proxy"
   autoload :Cascade, "rack/cascade"
   autoload :Chunked, "rack/chunked"

--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -82,7 +82,7 @@ module Rack
       if @map
         mapping, @map = @map, nil
         @use << proc { |app| generate_map app, mapping }
-      elsif middleware.respond_to?(:<<) &&
+      elsif middleware.respond_to?(:use) &&
          middleware.respond_to?(:to_app)
         # assume this is a custom middleware chain
         @use = middleware

--- a/lib/rack/middleware_stack.rb
+++ b/lib/rack/middleware_stack.rb
@@ -1,0 +1,29 @@
+module Rack
+  # A Middleware Stack accepts being injected with new middleware (+use+) and
+  # can be transformed into an app (+to_app+)
+  class MiddlewareStack
+   
+    def initialize
+      @middlewares = []
+    end
+
+    def <<(midproc)
+      @middlewares << midproc
+    end
+ 
+    def use(middleware, *args, &block)
+      @middlewares.unshift build_middleware(middleware, *args, &block)
+    end
+
+    def to_app(app)
+      @middlewares.inject(app) { |a, mid| mid[a] }
+    end
+
+    private
+
+    def build_middleware(middleware, *args, &block)
+      ->(app) { middleware.new(app, *args, &block) }
+    end
+
+  end
+end

--- a/test/spec_middleware_stack.rb
+++ b/test/spec_middleware_stack.rb
@@ -1,0 +1,21 @@
+require 'minitest/autorun'
+require 'rack/middleware_stack'
+
+describe Rack::MiddlewareStack do
+  before do
+    @stack = Rack::MiddlewareStack.new
+  end
+
+  it "implements #use" do
+    assert_respond_to @stack, :use
+  end
+
+  it "implements <<" do
+    assert_respond_to @stack, :<<
+  end
+
+  it "implements #to_app" do
+    assert_respond_to @stack, :to_app
+
+  end
+end


### PR DESCRIPTION
This proposes a basic spec for the middleware chain/stack, which is built within the Rack::Builder class (ivar `@use`). 

A class implementing the middleware stack should implement both `#use`and `#to_app`,where:
- `#use` receives a middleware class, arguments and block;
- `#to_app` receives a rack app and returns the app chained with the middlewares. 

This is an attempt to support #1111 , which proposes to replace the main rack builder app middleware stack with the rails application middleware object, removing the need to support 2 different middleware stacks. 
