### PR TITLE
Fix handling of parsing empty nested queries

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -64,13 +64,14 @@ module Rack
     # ParameterTypeError is raised. Users are encouraged to return a 400 in this
     # case.
     def parse_nested_query(qs, d = nil)
-      return {} if qs.nil? || qs.empty?
       params = make_params
 
-      qs.split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
-        k, v = p.split('=', 2).map! { |s| unescape(s) }
+      unless qs.nil? || qs.empty?
+        (qs || '').split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
+          k, v = p.split('=', 2).map! { |s| unescape(s) }
 
-        normalize_params(params, k, v, param_depth_limit)
+          normalize_params(params, k, v, param_depth_limit)
+        end
       end
 
       return params.to_h

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -254,8 +254,12 @@ describe Rack::Utils do
         end
       end
       Rack::Utils.default_query_parser = Rack::QueryParser.new(param_parser_class, 65536, 100)
-      Rack::Utils.parse_query(",foo=bar;,", ";,")[:foo].must_equal "bar"
-      Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][w]=2")[:x][:y][0][:z].must_equal "1"
+      h1 = Rack::Utils.parse_query(",foo=bar;,", ";,")
+      h1[:foo].must_equal "bar"
+      h2 = Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][w]=2")
+      h2[:x][:y][0][:z].must_equal "1"
+      h3 = Rack::Utils.parse_nested_query("")
+      h3.merge(h1)[:foo].must_equal "bar"
     ensure
       Rack::Utils.default_query_parser = default_parser
     end


### PR DESCRIPTION
If the query string is empty, instead of using a plain hash, we
still need to use params.to_params_hash, as params.to_params_hash
may return a different object, such a hash with a default proc.

This fixes request.params in cases where indifferent query
params are used, and r.GET is empty but r.POST is not.  Before
this commit, this would result in request.params ending up with
a non-indifferent hash, when it should have used an indifferent
hash.

The cause of this issue can originally be traced to an optimization
in c4596b3e3d821d19b25c2d48d619097a3ad39ec0, which was before I
added the code to allow user-configurable query params in
7e7a3890449b5cf5b86929c79373506e5f1909fb.  Now that
user-configurable query params are supported, the optimization is
invalid and needs to be removed.
