### PR TITLE
Handle NULL byte in multipart file name

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -8,7 +8,7 @@ module Rack
       BUFSIZE = 16384
       TEXT_PLAIN = "text/plain"
       TEMPFILE_FACTORY = lambda { |filename, content_type|
-        Tempfile.new(["RackMultipart", ::File.extname(filename)])
+        Tempfile.new(["RackMultipart", ::File.extname(filename.gsub("\0".freeze, '%00'.freeze))])
       }
 
       class BoundedIO # :nodoc:

--- a/test/multipart/filename_with_null_byte
+++ b/test/multipart/filename_with_null_byte
@@ -1,0 +1,7 @@
+--AaB03x
+Content-Type: image/jpeg
+Content-Disposition: attachment; name="files"; filename="flowers.exe%00.jpg"
+Content-Description: a complete map of the human genome
+
+contents
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -305,6 +305,12 @@ describe Rack::Multipart do
     params["files"][:filename].must_equal "bob's flowers.jpg"
   end
 
+  it "parse multipart form with a null byte in the filename" do
+    env = Rack::MockRequest.env_for '/', multipart_fixture(:filename_with_null_byte)
+    params = Rack::Multipart.parse_multipart(env)
+    params["files"][:filename].must_equal "flowers.exe\u0000.jpg"
+  end
+
   it "not include file params if no file was selected" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:none))
     params = Rack::Multipart.parse_multipart(env)


### PR DESCRIPTION
Rack 1.x was handling those just fine.

Rack 2.x blow up with:

```ruby
    ArgumentError: string contains null byte
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:11 in `extname`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:11 in `in `block in <class`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:137 in `call`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:137 in `on_mime_head`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:262 in `handle_mime_head`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:215 in `block in run_parser`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:208 in `loop`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:208 in `run_parser`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:191 in `on_read`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart/parser.rb:70 in `parse`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/multipart.rb:52 in `extract_multipart`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/request.rb:472 in `parse_multipart`
    ~/.gem/ruby/2.2.3/gems/rack-2.0.1/lib/rack/request.rb:335 in `POST`
```

What is happening is that `File.extname` internally convert the ruby string to a C string, and C strings can't contain NULL bytes.

cc @rafaelfranca @kirs 