### PR TITLE
Fix warnings and usage of $VERBOSE

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -422,7 +422,7 @@ module Rack
 
       # shortcut for <tt>request.params[key]</tt>
       def [](key)
-        if $verbose
+        if $VERBOSE
           warn("Request#[] is deprecated and will be removed in a future version of Rack. Please use request.params[] instead")
         end
 
@@ -433,7 +433,7 @@ module Rack
       #
       # Note that modifications will not be persisted in the env. Use update_param or delete_param if you want to destructively modify params.
       def []=(key, value)
-        if $verbose
+        if $VERBOSE
           warn("Request#[]= is deprecated and will be removed in a future version of Rack. Please use request.params[]= instead")
         end
 


### PR DESCRIPTION
The correct global variable is called $VERBOSE, not $verbose. Fixed #1116
