### PR TITLE
Improve and test SessionHash#fetch

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -18,6 +18,8 @@ module Rack
         include Enumerable
         attr_writer :id
 
+        Unspecified = Object.new
+
         def self.find(req)
           req.get_header RACK_SESSION
         end
@@ -54,7 +56,15 @@ module Rack
           load_for_read!
           @data[key.to_s]
         end
-        alias :fetch :[]
+
+        def fetch(key, default=Unspecified, &block)
+          load_for_read!
+          if default == Unspecified
+            @data.fetch(key.to_s, &block)
+          else
+            @data.fetch(key.to_s, default, &block)
+          end
+        end
 
         def has_key?(key)
           load_for_read!

--- a/test/spec_session_abstract_session_hash.rb
+++ b/test/spec_session_abstract_session_hash.rb
@@ -37,5 +37,9 @@ describe Rack::Session::Abstract::SessionHash do
     it "works with a block" do
       assert_equal :default, hash.fetch(:unkown) { :default }
     end
+
+    it "it raises when fetching unknown keys without defaults" do
+      lambda { hash.fetch(:unknown) }.must_raise KeyError
+    end
   end
 end

--- a/test/spec_session_abstract_session_hash.rb
+++ b/test/spec_session_abstract_session_hash.rb
@@ -25,4 +25,17 @@ describe Rack::Session::Abstract::SessionHash do
     assert_equal [:bar, :qux], hash.values
   end
 
+  describe "#fetch" do
+    it "returns value for a matching key" do
+      assert_equal :bar, hash.fetch(:foo)
+    end
+
+    it "works with a default value" do
+      assert_equal :default, hash.fetch(:unknown, :default)
+    end
+
+    it "works with a block" do
+      assert_equal :default, hash.fetch(:unkown) { :default }
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Implement `Rack::Session::Abstract::SessionHash#fetch` to accept a default argument or a block. 
### Reason

We had some exceptions in production where we'd expect to be working with an object that works like a hash. When calling `session.fetch("foo", "bar")`, we'd get the error:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
File "/local/ruby23/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/session/abstract/id.rb" line 59 in []
```

Which was pretty cryptic at first, because we weren't using `[]`. That's when we realised it was aliased.
