### PR TITLE
Fix Puma + Rack + Rails cannot restart itself

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -381,6 +381,7 @@ module Rack
 
         pid = ::File.read(options[:pid]).to_i
         return :dead if pid == 0
+        return :this_process if pid == Process.pid
 
         Process.kill(0, pid)
         :running


### PR DESCRIPTION
This PR fixes the rack part, puma is almost done with their part.

More detail https://github.com/puma/puma/issues/1117

It's not just Puma, but how Rails configures Rack AND Process.pid doesn't change on restart with Puma servers when it detects `tmp/restart.txt` changes.

Fixes #1159