### PR TITLE
To support minitest 6 and prevent error message from minitest 5.

### DIFF
--- a/test/spec_content_length.rb
+++ b/test/spec_content_length.rb
@@ -36,13 +36,13 @@ describe Rack::ContentLength do
   it "not set Content-Length on 304 responses" do
     app = lambda { |env| [304, {}, []] }
     response = content_length(app).call(request)
-    response[1]['Content-Length'].must_equal nil
+    response[1]['Content-Length'].must_be_nil
   end
 
   it "not set Content-Length when Transfer-Encoding is chunked" do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain', 'Transfer-Encoding' => 'chunked'}, []] }
     response = content_length(app).call(request)
-    response[1]['Content-Length'].must_equal nil
+    response[1]['Content-Length'].must_be_nil
   end
 
   # Using "Connection: close" for this is fairly contended. It might be useful
@@ -51,7 +51,7 @@ describe Rack::ContentLength do
   # should "not force a Content-Length when Connection:close" do
   #   app = lambda { |env| [200, {'Connection' => 'close'}, []] }
   #   response = content_length(app).call({})
-  #   response[1]['Content-Length'].must_equal nil
+  #   response[1]['Content-Length'].must_be_nil
   # end
 
   it "close bodies that need to be closed" do
@@ -64,7 +64,7 @@ describe Rack::ContentLength do
 
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, body] }
     response = content_length(app).call(request)
-    body.closed.must_equal nil
+    body.closed.must_be_nil
     response[2].close
     body.closed.must_equal true
   end

--- a/test/spec_content_type.rb
+++ b/test/spec_content_type.rb
@@ -41,6 +41,6 @@ describe Rack::ContentType do
   it "not set Content-Type on 304 responses" do
     app = lambda { |env| [304, {}, []] }
     response = content_type(app, "text/html").call(request)
-    response[1]['Content-Type'].must_equal nil
+    response[1]['Content-Type'].must_be_nil
   end
 end

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -58,7 +58,7 @@ describe Rack::ETag do
   it "not set Cache-Control if directive isn't present" do
     app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
     response = etag(app, nil, nil).call(request)
-    response[1]['Cache-Control'].must_equal nil
+    response[1]['Cache-Control'].must_be_nil
   end
 
   it "not change ETag if it is already set" do

--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -184,8 +184,8 @@ describe Rack::File do
     status, heads, _ = file(DOCROOT).call(env)
 
     status.must_equal 200
-    heads['Cache-Control'].must_equal nil
-    heads['Access-Control-Allow-Origin'].must_equal nil
+    heads['Cache-Control'].must_be_nil
+    heads['Access-Control-Allow-Origin'].must_be_nil
   end
 
   it "only support GET, HEAD, and OPTIONS requests" do
@@ -239,7 +239,7 @@ describe Rack::File do
     req = Rack::MockRequest.new(Rack::Lint.new(Rack::File.new(DOCROOT, nil, nil)))
     res = req.get "/cgi/test"
     res.must_be :successful?
-    res['Content-Type'].must_equal nil
+    res['Content-Type'].must_be_nil
   end
 
   it "return error when file not found for head request" do

--- a/test/spec_media_type.rb
+++ b/test/spec_media_type.rb
@@ -8,7 +8,7 @@ describe Rack::MediaType do
     before { @content_type = nil }
 
     it '#type is nil' do
-      Rack::MediaType.type(@content_type).must_equal nil
+      Rack::MediaType.type(@content_type).must_be_nil
     end
 
     it '#params is empty' do

--- a/test/spec_mime.rb
+++ b/test/spec_mime.rb
@@ -19,7 +19,7 @@ describe Rack::Mime do
   end
 
   it "should support null fallbacks" do
-    Rack::Mime.mime_type('.nothing', nil).must_equal nil
+    Rack::Mime.mime_type('.nothing', nil).must_be_nil
   end
 
   it "should match exact mimes" do

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -27,7 +27,7 @@ describe Rack::Multipart do
   it "return nil if content type is not multipart" do
     env = Rack::MockRequest.env_for("/",
             "CONTENT_TYPE" => 'application/x-www-form-urlencoded')
-    Rack::Multipart.parse_multipart(env).must_equal nil
+    Rack::Multipart.parse_multipart(env).must_be_nil
   end
 
   it "parse multipart content when content type present but filename is not" do
@@ -315,7 +315,7 @@ describe Rack::Multipart do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:none))
     params = Rack::Multipart.parse_multipart(env)
     params["submit-name"].must_equal "Larry"
-    params["files"].must_equal nil
+    params["files"].must_be_nil
     params.keys.wont_include "files"
   end
 
@@ -563,7 +563,7 @@ Content-Type: image/jpeg\r
 
   it "return nil if no UploadedFiles were used" do
     data = Rack::Multipart.build_multipart("people" => [{"submit-name" => "Larry", "files" => "contents"}])
-    data.must_equal nil
+    data.must_be_nil
   end
 
   it "raise ArgumentError if params is not a Hash" do

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -476,7 +476,7 @@ class RackRequestTest < Minitest::Spec
 
     req = make_request \
       Rack::MockRequest.env_for("/")
-    req.referer.must_equal nil
+    req.referer.must_be_nil
   end
 
   it "extract user agent correctly" do
@@ -486,25 +486,25 @@ class RackRequestTest < Minitest::Spec
 
     req = make_request \
       Rack::MockRequest.env_for("/")
-    req.user_agent.must_equal nil
+    req.user_agent.must_be_nil
   end
 
   it "treat missing content type as nil" do
     req = make_request \
       Rack::MockRequest.env_for("/")
-    req.content_type.must_equal nil
+    req.content_type.must_be_nil
   end
 
   it "treat empty content type as nil" do
     req = make_request \
       Rack::MockRequest.env_for("/", "CONTENT_TYPE" => "")
-    req.content_type.must_equal nil
+    req.content_type.must_be_nil
   end
 
   it "return nil media type for empty content type" do
     req = make_request \
       Rack::MockRequest.env_for("/", "CONTENT_TYPE" => "")
-    req.media_type.must_equal nil
+    req.media_type.must_be_nil
   end
 
   it "cache, but invalidates the cache" do
@@ -1296,13 +1296,13 @@ EOF
     req.trusted_proxy?('unix').must_equal 0
     req.trusted_proxy?('unix:/tmp/sock').must_equal 0
 
-    req.trusted_proxy?("unix.example.org").must_equal nil
-    req.trusted_proxy?("example.org\n127.0.0.1").must_equal nil
-    req.trusted_proxy?("127.0.0.1\nexample.org").must_equal nil
-    req.trusted_proxy?("11.0.0.1").must_equal nil
-    req.trusted_proxy?("172.15.0.1").must_equal nil
-    req.trusted_proxy?("172.32.0.1").must_equal nil
-    req.trusted_proxy?("2001:470:1f0b:18f8::1").must_equal nil
+    req.trusted_proxy?("unix.example.org").must_be_nil
+    req.trusted_proxy?("example.org\n127.0.0.1").must_be_nil
+    req.trusted_proxy?("127.0.0.1\nexample.org").must_be_nil
+    req.trusted_proxy?("11.0.0.1").must_be_nil
+    req.trusted_proxy?("172.15.0.1").must_be_nil
+    req.trusted_proxy?("172.32.0.1").must_be_nil
+    req.trusted_proxy?("2001:470:1f0b:18f8::1").must_be_nil
   end
 
   it "sets the default session to an empty hash" do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -55,7 +55,7 @@ describe Rack::Response do
 
   it "can set and read headers" do
     response = Rack::Response.new
-    response["Content-Type"].must_equal nil
+    response["Content-Type"].must_be_nil
     response["Content-Type"] = "text/plain"
     response["Content-Type"].must_equal "text/plain"
   end
@@ -273,8 +273,8 @@ describe Rack::Response do
     _, header, body = r.finish
     str = ""; body.each { |part| str << part }
     str.must_be :empty?
-    header["Content-Type"].must_equal nil
-    header['Content-Length'].must_equal nil
+    header["Content-Type"].must_be_nil
+    header['Content-Length'].must_be_nil
 
     lambda {
       Rack::Response.new(Object.new)

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -77,7 +77,7 @@ describe Rack::Server do
       o, ENV["REQUEST_METHOD"] = ENV["REQUEST_METHOD"], 'foo'
       server = Rack::Server.new(:app => 'foo')
       server.server.name =~ /CGI/
-      Rack::Server.logging_middleware.call(server).must_equal nil
+      Rack::Server.logging_middleware.call(server).must_be_nil
     ensure
       ENV['REQUEST_METHOD'] = o
     end
@@ -85,7 +85,7 @@ describe Rack::Server do
 
   it "be quiet if said so" do
     server = Rack::Server.new(:app => "FOO", :quiet => true)
-    Rack::Server.logging_middleware.call(server).must_equal nil
+    Rack::Server.logging_middleware.call(server).must_be_nil
   end
 
   it "use a full path to the pidfile" do

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -98,7 +98,7 @@ describe Rack::Session::Cookie do
 
       it 'rescues failures on decode' do
         coder = Rack::Session::Cookie::Base64::Marshal.new
-        coder.decode('lulz').must_equal nil
+        coder.decode('lulz').must_be_nil
       end
     end
 
@@ -117,7 +117,7 @@ describe Rack::Session::Cookie do
 
       it 'rescues failures on decode' do
         coder = Rack::Session::Cookie::Base64::JSON.new
-        coder.decode('lulz').must_equal nil
+        coder.decode('lulz').must_be_nil
       end
     end
 
@@ -139,7 +139,7 @@ describe Rack::Session::Cookie do
 
       it 'rescues failures on decode' do
         coder = Rack::Session::Cookie::Base64::ZipJSON.new
-        coder.decode('lulz').must_equal nil
+        coder.decode('lulz').must_be_nil
       end
     end
   end

--- a/test/spec_session_memcache.rb
+++ b/test/spec_session_memcache.rb
@@ -143,7 +143,7 @@ begin
       res1.body.must_equal '{"counter"=>1}'
 
       res2 = dreq.get("/", "HTTP_COOKIE" => cookie)
-      res2["Set-Cookie"].must_equal nil
+      res2["Set-Cookie"].must_be_nil
       res2.body.must_equal '{"counter"=>2}'
 
       res3 = req.get("/", "HTTP_COOKIE" => cookie)
@@ -183,7 +183,7 @@ begin
       creq = Rack::MockRequest.new(count)
 
       res0 = dreq.get("/")
-      res0["Set-Cookie"].must_equal nil
+      res0["Set-Cookie"].must_be_nil
       res0.body.must_equal '{"counter"=>1}'
 
       res0 = creq.get("/")
@@ -201,7 +201,7 @@ begin
       creq = Rack::MockRequest.new(count)
 
       res0 = sreq.get("/")
-      res0["Set-Cookie"].must_equal nil
+      res0["Set-Cookie"].must_be_nil
       res0.body.must_equal '{"counter"=>1}'
 
       res0 = creq.get("/")

--- a/test/spec_session_pool.rb
+++ b/test/spec_session_pool.rb
@@ -138,7 +138,7 @@ describe Rack::Session::Pool do
     dreq = Rack::MockRequest.new(defer)
 
     res1 = dreq.get("/")
-    res1["Set-Cookie"].must_equal nil
+    res1["Set-Cookie"].must_be_nil
     res1.body.must_equal '{"counter"=>1}'
     pool.pool.size.must_equal 1
   end

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -97,7 +97,7 @@ describe Rack::Static do
   it "serves regular files if client accepts gzip encoding and gzip files are not present" do
     res = @gzip_request.get("/cgi/rackup_stub.rb", 'HTTP_ACCEPT_ENCODING'=>'deflate, gzip')
     res.must_be :ok?
-    res.headers['Content-Encoding'].must_equal nil
+    res.headers['Content-Encoding'].must_be_nil
     res.headers['Content-Type'].must_equal 'text/x-script.ruby'
     res.body.must_match(/ruby/)
   end
@@ -105,7 +105,7 @@ describe Rack::Static do
   it "serves regular files if client does not accept gzip encoding" do
     res = @gzip_request.get("/cgi/test")
     res.must_be :ok?
-    res.headers['Content-Encoding'].must_equal nil
+    res.headers['Content-Encoding'].must_be_nil
     res.headers['Content-Type'].must_equal 'text/plain'
     res.body.must_match(/ruby/)
   end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -394,7 +394,7 @@ describe Rack::Utils do
     Rack::Utils.best_q_match("text/plain,text/html", %w[text/html text/plain]).must_equal "text/html"
 
     # When there are no matches, return nil:
-    Rack::Utils.best_q_match("application/json", %w[text/html text/plain]).must_equal nil
+    Rack::Utils.best_q_match("application/json", %w[text/html text/plain]).must_be_nil
   end
 
   it "escape html entities [&><'\"/]" do
@@ -427,9 +427,9 @@ describe Rack::Utils do
       Rack::Utils.select_best_encoding(a, b)
     end
 
-    helper.call(%w(), [["x", 1]]).must_equal nil
-    helper.call(%w(identity), [["identity", 0.0]]).must_equal nil
-    helper.call(%w(identity), [["*", 0.0]]).must_equal nil
+    helper.call(%w(), [["x", 1]]).must_be_nil
+    helper.call(%w(identity), [["identity", 0.0]]).must_be_nil
+    helper.call(%w(identity), [["*", 0.0]]).must_be_nil
 
     helper.call(%w(identity), [["compress", 1.0], ["gzip", 1.0]]).must_equal "identity"
 
@@ -538,15 +538,15 @@ end
 
 describe Rack::Utils, "byte_range" do
   it "ignore missing or syntactically invalid byte ranges" do
-    Rack::Utils.byte_ranges({},500).must_equal nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "foobar"},500).must_equal nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "furlongs=123-456"},500).must_equal nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes="},500).must_equal nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=-"},500).must_equal nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=123,456"},500).must_equal nil
+    Rack::Utils.byte_ranges({},500).must_be_nil
+    Rack::Utils.byte_ranges({"HTTP_RANGE" => "foobar"},500).must_be_nil
+    Rack::Utils.byte_ranges({"HTTP_RANGE" => "furlongs=123-456"},500).must_be_nil
+    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes="},500).must_be_nil
+    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=-"},500).must_be_nil
+    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=123,456"},500).must_be_nil
     # A range of non-positive length is syntactically invalid and ignored:
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=456-123"},500).must_equal nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=456-455"},500).must_equal nil
+    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=456-123"},500).must_be_nil
+    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=456-455"},500).must_be_nil
   end
 
   it "parse simple byte ranges" do

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -195,7 +195,7 @@ describe Rack::Handler::WEBrick do
     Net::HTTP.start(@host, @port){ |http|
       res = http.get("/chunked")
       res["Transfer-Encoding"].must_equal "chunked"
-      res["Content-Length"].must_equal nil
+      res["Content-Length"].must_be_nil
       res.body.must_equal "chunked"
     }
   end


### PR DESCRIPTION
Using `assert_equal` or `must_equal` to expecting `nil` will not be allowed in minitest 6, this patch will both support minitest 6 and prevent error output from minitest 5.

ref: https://github.com/seattlerb/minitest/blob/f95ef007ec64d956d88fedc37fd2ed7e106b777e/lib/minitest/assertions.rb#L176

# Before

```
$ bundle exec rake
ruby -I./lib:./test -S minitest   test/gemloader.rb test/spec*.rb
Lighttpd isn't installed. Skipping Rack::Handler::CGI and FastCGI tests. Install lighttpd to run them.
Skipping Rack::Session::Memcache tests. Start memcached and try again.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Use assert_nil if expecting nil from /Users/tonytonyjan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb:23:in `must_equal'. This will fail in MT6.
Run options: --seed 49352

# Running:

.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................S............................................................................................S.............................................................

Finished in 4.649968s, 213.3348 runs/s, 777.6397 assertions/s.

992 runs, 3616 assertions, 0 failures, 0 errors, 2 skips

You have skipped tests. Run with --verbose for details.
```

# After

```
$ bundle exec rake
ruby -I./lib:./test -S minitest   test/gemloader.rb test/spec*.rb
Lighttpd isn't installed. Skipping Rack::Handler::CGI and FastCGI tests. Install lighttpd to run them.
Skipping Rack::Session::Memcache tests. Start memcached and try again.
Run options: --seed 65497

# Running:

...........................................................................................................................................................................................................................................S......................................................................S.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 4.576200s, 216.7738 runs/s, 790.1753 assertions/s.

992 runs, 3616 assertions, 0 failures, 0 errors, 2 skips

You have skipped tests. Run with --verbose for details.
```