### PR TITLE
Escape URL to render HTML

### DIFF
--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -44,15 +44,14 @@ table { width:100%%; }
     class DirectoryBody < Struct.new(:root, :path, :files)
       def each
         show_path = Rack::Utils.escape_html(path.sub(/^#{root}/, ''))
-        listings = files.map{|f| DIR_FILE % DIR_FILE_escape(*f) } * "\n"
+        listings = files.map{|f| DIR_FILE % DIR_FILE_escape(f) } * "\n"
         page = DIR_PAGE % [ show_path, show_path, listings ]
         page.each_line{|l| yield l }
       end
 
       private
-      # Assumes url is already escaped.
-      def DIR_FILE_escape url, *html
-        [url, *html.map { |e| Utils.escape_html(e) }]
+      def DIR_FILE_escape htmls
+        htmls.map { |e| Utils.escape_html(e) }
       end
     end
 


### PR DESCRIPTION
DIR_FILE have `<a href='%s'>`, so single quotes in URL should be escaped.