### PR TITLE
Add rdoc dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,7 @@ group :extra do
   gem 'memcache-client'
   gem 'thin', :platforms => c_platforms
 end
+
+group :doc do
+  gem 'rdoc'
+end


### PR DESCRIPTION
Bundler will replace bin path and only considers gems in Gemfile, it should be part of dependency.

```
$ bundle exec rake doc
rdoc --line-numbers --main README.rdoc --title 'Rack Documentation' --charset utf-8 -U -o doc README.rdoc KNOWN-ISSUES SPEC ChangeLog lib/rack/body_proxy.rb lib/rack/builder.rb lib/rack/cascade.rb lib/rack/chunked.rb lib/rack/common_logger.rb lib/rack/conditional_get.rb lib/rack/config.rb lib/rack/content_length.rb lib/rack/content_type.rb lib/rack/deflater.rb lib/rack/directory.rb lib/rack/etag.rb lib/rack/events.rb lib/rack/file.rb lib/rack/handler.rb lib/rack/head.rb lib/rack/lint.rb lib/rack/lobster.rb lib/rack/lock.rb lib/rack/logger.rb lib/rack/media_type.rb lib/rack/method_override.rb lib/rack/mime.rb lib/rack/mock.rb lib/rack/multipart.rb lib/rack/null_logger.rb lib/rack/query_parser.rb lib/rack/recursive.rb lib/rack/reloader.rb lib/rack/request.rb lib/rack/response.rb lib/rack/rewindable_input.rb lib/rack/runtime.rb lib/rack/sendfile.rb lib/rack/server.rb lib/rack/show_exceptions.rb lib/rack/show_status.rb lib/rack/static.rb lib/rack/tempfile_reaper.rb lib/rack/urlmap.rb lib/rack/utils.rb
~/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/rubygems_integration.rb:393:in `block in replace_bin_path': can't find executable rdoc (Gem::Exception)
        from ~/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/rubygems_integration.rb:410:in `block in replace_bin_path'
        from ~/.rbenv/versions/2.3.1/bin/rdoc:22:in `<main>'
rake aborted!
Command failed with status (1): [rdoc --line-numbers --main README.rdoc --t...]
~/codes/rack/Rakefile:101:in `block in <top (required)>'
~/.rbenv/versions/2.3.1/bin/bundle:22:in `load'
~/.rbenv/versions/2.3.1/bin/bundle:22:in `<main>'
Tasks: TOP => doc => rdoc
(See full trace by running task with --trace)
```