### PR TITLE
Add middleware type - middleware can also be proc.

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -83,7 +83,13 @@ module Rack
         mapping, @map = @map, nil
         @use << proc { |app| generate_map app, mapping }
       end
-      @use << proc { |app| middleware.new(app, *args, &block) }
+      @use << proc do |app|
+        if middleware.class == Proc
+          middleware.curry[app]
+        else
+          middleware.new(app, *args, &block)
+        end
+      end
     end
 
     # Takes an argument that is an object that responds to #call and returns a Rack response.

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -77,6 +77,21 @@ describe Rack::Builder do
     Rack::MockRequest.new(app).get("/").must_be :server_error?
   end
 
+  it "supports proc on use" do
+    upcase_middleware = proc do |app,env|
+      code, header, body = app.call(env)
+      [code, header, body.map(&:upcase)]
+    end
+
+    app = builder do
+      use upcase_middleware
+      run lambda { |env| [200, {"Content-Type" => "text/plain"}, ['Hi Boss']] }
+    end
+
+    response = Rack::MockRequest.new(app).get("/")
+    response.body.to_s.must_equal 'HI BOSS'
+  end
+
   it "supports blocks on use" do
     app = builder do
       use Rack::ShowExceptions


### PR DESCRIPTION
By default, the Rack middleware must be a class. Proc-style middleware provides simplicity when someone wants to learn Rack middleware. So I added some code.

Someone can write:
```ruby
require 'rack'

upcase_middleware = proc do |app,env|
  st, hd, body = app.call(env)
  [st, hd, body.map(&:upcase)]
end

app = Rack::Builder.app do
  use upcase_middleware
  run lambda { |env| [200, {"Content-Type" => "text/plain"}, ['Hi Boss']] }
end

Rack::Handler::WEBrick.run app
```

