### PR TITLE
Fix MethodOverride EOFError failure

### DIFF
--- a/lib/rack/method_override.rb
+++ b/lib/rack/method_override.rb
@@ -37,7 +37,7 @@ module Rack
 
     def method_override_param(req)
       req.POST[METHOD_OVERRIDE_PARAM_KEY]
-    rescue Utils::InvalidParameterError, Utils::ParameterTypeError
+    rescue Utils::InvalidParameterError, Utils::ParameterTypeError, EOFError
     end
   end
 end

--- a/lib/rack/method_override.rb
+++ b/lib/rack/method_override.rb
@@ -37,7 +37,10 @@ module Rack
 
     def method_override_param(req)
       req.POST[METHOD_OVERRIDE_PARAM_KEY]
-    rescue Utils::InvalidParameterError, Utils::ParameterTypeError, EOFError
+    rescue Utils::InvalidParameterError, Utils::ParameterTypeError
+      req.get_header(RACK_ERRORS).puts "Invalid or incomplete POST params"
+    rescue EOFError
+      req.get_header(RACK_ERRORS).puts "Bad request content body"
     end
   end
 end

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -66,10 +66,7 @@ EOF
                       "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size.to_s,
                       :method => "POST", :input => input)
-    begin
-      app.call env
-    rescue EOFError
-    end
+    app.call env
 
     env["REQUEST_METHOD"].must_equal "POST"
   end

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -71,6 +71,22 @@ EOF
     env["REQUEST_METHOD"].must_equal "POST"
   end
 
+  it "writes error to RACK_ERRORS when given invalid multipart form data" do
+    input = <<EOF
+--AaB03x\r
+content-disposition: form-data; name="huge"; filename="huge"\r
+EOF
+    env = Rack::MockRequest.env_for("/",
+                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_LENGTH" => input.size.to_s,
+                      Rack::RACK_ERRORS => StringIO.new,
+                      :method => "POST", :input => input)
+    Rack::MethodOverride.new(proc { [200, {"Content-Type" => "text/plain"}, []] }).call env
+
+    env[Rack::RACK_ERRORS].rewind
+    env[Rack::RACK_ERRORS].read.must_match /Bad request content body/
+  end
+
   it "not modify REQUEST_METHOD for POST requests when the params are unparseable" do
     env = Rack::MockRequest.env_for("/", :method => "POST", :input => "(%bad-params%)")
     app.call env

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require 'rack/mock'
+require 'concurrent/utility/native_integer'
 require 'concurrent/atomic/count_down_latch'
 require File.expand_path('../testrequest', __FILE__)
 


### PR DESCRIPTION
Invalid multipart params should not bubble an error out of the middleware stack and cause the whole stack to fail, especially not when the middleware in question is just checking to see if there is a method override parameter.

Instead of failing outright and requiring additional middleware to capture and handle the `EOFError` raised by `Rack::Multipart::Parser`, this pull changes the `Rack::MethodOverride` middleware to record the error and move on. Based on similar behavior found in `Rack::Sendfile`, this change writes the errors to `env[RACK_ERRORS]`.

For users who want the error to bubble or want to handle the invalid multipart params differently, an additional/custom middleware would be the appropriate solution instead of relying on a side effect of `MethodOverride`.

Fixes #903