### PR TITLE
Avoid overwriting response body when it's already overridden

### DIFF
--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -99,7 +99,7 @@ module Rack
       response[2] = [response_body] unless response_body.nil?
 
       response[1][CONTENT_LENGTH] = size.to_s
-      response[2] = make_body request, path, range
+      response[2] = make_body request, path, range unless response[2]
       response
     end
 

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -261,6 +261,7 @@ describe Rack::Files do
     res  = Rack::MockRequest.new(file).get("/cgi/test")
 
     res.must_be :ok?
+    res.body.must_equal "hello world"
   end
 
 end


### PR DESCRIPTION
It appears that the intention of #570 was to provide a seam on
Rack::File where the response body may be provided by an overriding
class (see their markdown example). However e0ac32 overwrites the value
of response[2] (the body) after this is set.

This is the simplest possible fix, ignore the step of overwriting if a
value is already set. However it's worth noting that the design of the
entire method would probably be served well to improve. At this point, I
don't want to take that on.

Also of note, there may very well be a latent bug in the previous
implementation. Specifically, when response_body is overridden, it
affects the calculation of filesize, therefore if the method is
overridden the filesize of that overridden response_body would be
returned which is probably not the correct size for the response read
from the path. If that is in fact a defect, this PR may very well
address it to, though it is unverified.