### PR TITLE
Remove "mongrel" from server option's description

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -47,7 +47,7 @@ module Rack
 
           opts.separator ""
           opts.separator "Rack options:"
-          opts.on("-s", "--server SERVER", "serve using SERVER (thin/puma/webrick/mongrel)") { |s|
+          opts.on("-s", "--server SERVER", "serve using SERVER (thin/puma/webrick)") { |s|
             options[:server] = s
           }
 


### PR DESCRIPTION
Currently [mongrel](https://github.com/mongrel/mongrel) is not maintained.
And it couldn't be built with any Ruby versions that supported by Rack.