### PR TITLE
Dynamic cookie key for session ID

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -284,8 +284,9 @@ module Rack
         # Extract session id from request object.
 
         def extract_session_id(request)
-          sid = request.cookies[@key]
-          sid ||= request.params[@key] unless @cookie_only
+          cookie_key = key
+          sid = request.cookies[cookie_key]
+          sid ||= request.params[cookie_key] unless @cookie_only
           sid
         end
 
@@ -369,9 +370,10 @@ module Rack
         # setting if the value didn't change (sid is the same) or expires was given.
 
         def set_cookie(request, res, cookie)
-          if request.cookies[@key] != cookie[:value] || cookie[:expires]
+          cookie_key = key
+          if request.cookies[cookie_key] != cookie[:value] || cookie[:expires]
             res.set_cookie_header =
-              Utils.add_cookie_to_header(res.set_cookie_header, @key, cookie)
+              Utils.add_cookie_to_header(res.set_cookie_header, cookie_key, cookie)
           end
         end
 


### PR DESCRIPTION
Allows custom session stores that extend the abstract session store to
dynamically select which cookie key will be used for fetching/setting
the session's id. This allows the user to maintain multiple, different sessions.
The web application can determine which session to be used for the
current request based on any number of conditions (URL, headers, cookies, IP,
etc).

Fixes #1155