### PR TITLE
Dynamic cookie key for session ID

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -235,6 +235,10 @@ module Rack
           [status, headers, body]
         end
 
+        def cookie_key(request)
+          @key
+        end
+
         private
 
         def make_request(env)
@@ -284,8 +288,9 @@ module Rack
         # Extract session id from request object.
 
         def extract_session_id(request)
-          sid = request.cookies[@key]
-          sid ||= request.params[@key] unless @cookie_only
+          key = cookie_key(request)
+          sid = request.cookies[key]
+          sid ||= request.params[key] unless @cookie_only
           sid
         end
 
@@ -369,9 +374,10 @@ module Rack
         # setting if the value didn't change (sid is the same) or expires was given.
 
         def set_cookie(request, res, cookie)
-          if request.cookies[@key] != cookie[:value] || cookie[:expires]
+          key = cookie_key(request)
+          if request.cookies[key] != cookie[:value] || cookie[:expires]
             res.set_cookie_header =
-              Utils.add_cookie_to_header(res.set_cookie_header, @key, cookie)
+              Utils.add_cookie_to_header(res.set_cookie_header, key, cookie)
           end
         end
 


### PR DESCRIPTION
Allows custom session stores that extend the abstract session store to
dynamically select which cookie key will be used for fetching/setting
the session's id. This allows the user to maintain multiple, different sessions.
The web application can determine which session to be used for the
current request based on any number of conditions (URL, headers, cookies, IP,
etc).

Fixes #1155

No tests are written for this change yet. Please let me know if this
functionality is desired in rack, or similar functionality with a different
implementation, and I'll happily add tests and seek review. Thanks!