### PR TITLE
Don't fall back to REMOTE_ADDR unless X_FORWARDED_FOR is empty

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -261,7 +261,9 @@ module Rack
 
         forwarded_ips = split_ip_addresses(get_header('HTTP_X_FORWARDED_FOR'))
 
-        return reject_trusted_ip_addresses(forwarded_ips).last || get_header("REMOTE_ADDR")
+        return get_header("REMOTE_ADDR") if forwarded_ips.empty?
+
+        ([ forwarded_ips.first ] + reject_trusted_ip_addresses(forwarded_ips[1..-1])).last
       end
 
       # The media type (type/subtype) portion of the CONTENT_TYPE header

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1251,6 +1251,16 @@ EOF
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '8.8.8.8, fe80::202:b3ff:fe1e:8329'
     res.body.must_equal 'fe80::202:b3ff:fe1e:8329'
 
+    res = mock.get '/',
+      'REMOTE_ADDR' => '10.1.0.1',
+      'HTTP_X_FORWARDED_FOR' => '10.1.0.2'
+    res.body.must_equal '10.1.0.2'
+
+    res = mock.get '/',
+      'REMOTE_ADDR' => '10.1.0.1',
+      'HTTP_X_FORWARDED_FOR' => '10.1.0.2,10.1.0.3'
+    res.body.must_equal '10.1.0.2'
+
     # Unix Sockets
     res = mock.get '/',
       'REMOTE_ADDR' => 'unix',


### PR DESCRIPTION
The previous, faulty behaviour was to remove all trusted ip addresses
from X_FORWARDED_FOR and returning the last one remaining, falling back
to the REMOTE_ADDR if none remain.

A problem arises if all the address in X_FORWARDED_FOR are trusted.
They can't all be proxies. One of them (the first one) is the ip that
made the request. The correct behaviour is to return the first one, but
the previous implementation would remove them all, and fall back to
REMOTE_ADDR.

This patch removes trusted ips only from the tail of X_FORWARDED_FOR,
and returns the last address in the resulting list, ensuring that we
don't fall back to REMOTE_ADDR if X_FORWARDED_FOR is non-empty.