### PR TITLE
Added (Unused) 306 HTTP Status Code

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -509,6 +509,7 @@ module Rack
       303 => 'See Other',
       304 => 'Not Modified',
       305 => 'Use Proxy',
+      306 => '(Unused)',
       307 => 'Temporary Redirect',
       308 => 'Permanent Redirect',
       400 => 'Bad Request',


### PR DESCRIPTION
Per RFC 7231 Section 6.4.6, I added Status Code 306. While it is unused, it is a reserved status code and unlike the other status codes that are not in this document, this was explicitly noted as unused and not unassigned making it a possible safeguard against people trying to use it for custom status codes (much like nginx does with 499 and 599). 