### PR TITLE
Rely on input responding to #size instead of #length in MockRequest.env_for

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -139,7 +139,7 @@ module Rack
       rack_input.set_encoding(Encoding::BINARY)
       env[RACK_INPUT] = rack_input
 
-      env["CONTENT_LENGTH"] ||= env[RACK_INPUT].length.to_s
+      env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s
 
       opts.each { |field, value|
         env[field] = value  if String === field

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -139,7 +139,7 @@ module Rack
       rack_input.set_encoding(Encoding::BINARY)
       env[RACK_INPUT] = rack_input
 
-      env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s
+      env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s if env[RACK_INPUT].respond_to?(:size)
 
       opts.each { |field, value|
         env[field] = value  if String === field

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -84,6 +84,12 @@ describe Rack::MockRequest do
   it "set content length" do
     env = Rack::MockRequest.env_for("/", :input => "foo")
     env["CONTENT_LENGTH"].must_equal "3"
+
+    env = Rack::MockRequest.env_for("/", :input => StringIO.new("foo"))
+    env["CONTENT_LENGTH"].must_equal "3"
+
+    env = Rack::MockRequest.env_for("/", :input => Tempfile.new("name").tap { |t| t << "foo" })
+    env["CONTENT_LENGTH"].must_equal "3"
   end
 
   it "allow posting" do

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -90,6 +90,9 @@ describe Rack::MockRequest do
 
     env = Rack::MockRequest.env_for("/", :input => Tempfile.new("name").tap { |t| t << "foo" })
     env["CONTENT_LENGTH"].must_equal "3"
+
+    env = Rack::MockRequest.env_for("/", :input => IO.pipe.first)
+    env["CONTENT_LENGTH"].must_be_nil
   end
 
   it "allow posting" do

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -107,8 +107,8 @@ describe Rack::Multipart do
     def rd.rewind; end
     wr.sync = true
 
-    # mock out length to make this pipe look like a Tempfile
-    def rd.length
+    # mock out size to make this pipe look like a Tempfile
+    def rd.size
       1024 * 1024 * 8
     end
 
@@ -136,7 +136,7 @@ describe Rack::Multipart do
 
     fixture = {
       "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
-      "CONTENT_LENGTH" => rd.length.to_s,
+      "CONTENT_LENGTH" => rd.size.to_s,
       :input => rd,
     }
 

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -107,11 +107,6 @@ describe Rack::Multipart do
     def rd.rewind; end
     wr.sync = true
 
-    # mock out size to make this pipe look like a Tempfile
-    def rd.size
-      1024 * 1024 * 8
-    end
-
     # write to a pipe in a background thread, this will write a lot
     # unless Rack (properly) shuts down the read end
     thr = Thread.new do
@@ -136,7 +131,7 @@ describe Rack::Multipart do
 
     fixture = {
       "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
-      "CONTENT_LENGTH" => rd.size.to_s,
+      "CONTENT_LENGTH" => (1024 * 1024 * 8).to_s,
       :input => rd,
     }
 


### PR DESCRIPTION
The changes are described in commit messages.