### PR TITLE
Allow specifying array index in #parse_query

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -13,6 +13,7 @@ module Rack
   module Utils
     ParameterTypeError = QueryParser::ParameterTypeError
     InvalidParameterError = QueryParser::InvalidParameterError
+    MissingParameterError = QueryParser::MissingParameterError
     DEFAULT_SEP = QueryParser::DEFAULT_SEP
     COMMON_SEP = QueryParser::COMMON_SEP
     KeySpaceConstrainedParams = QueryParser::Params


### PR DESCRIPTION
Once it's been established that a certain param is an array, allow referencing parts of the array with an index. Some of the new tests show outputs that would otherwise be impossible, the most prominent is an array of different types and an array of objects with different keys.

Note that this means that the first element of an array must still start with a `[]`, since `[0]` is ambiguous for being an object with `"0"` key.

Also removed the seemingly unnecessary check `after =~ %r(^\[\]\[([^\[\]]+)\]$)`, maybe someone could shed some light on that check - this is obviously not the main feature in this PR.