### PR TITLE
Safely handle modules in `Rack::Session::Abstract::ID` subclass ancestor list

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -408,7 +408,7 @@ module Rack
 
       class ID < Persisted
         def self.inherited(klass)
-          k = klass.ancestors.find { |kl| kl.superclass == ID }
+          k = klass.ancestors.find { |kl| kl.respond_to?(:superclass) && kl.superclass == ID }
           unless k.instance_variable_defined?(:"@_rack_warned")
             warn "#{klass} is inheriting from #{ID}.  Inheriting from #{ID} is deprecated, please inherit from #{Persisted} instead" if $VERBOSE
             k.instance_variable_set(:"@_rack_warned", true)


### PR DESCRIPTION
Hello! I hit this while upgrading our app to Rails 5. We implement a class that inherits from a subclass of `Rack::Session::Abstract::ID`. Here's the stacktrace I see:

```
/Users/Jordan/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/session/abstract/id.rb:401:in `block in inherited': undefined method `superclass' for ActionDispatch::Session::SessionObject:Module (NoMethodError)
	from /Users/Jordan/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/session/abstract/id.rb:401:in `each'
	from /Users/Jordan/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/session/abstract/id.rb:401:in `find'
	from /Users/Jordan/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/session/abstract/id.rb:401:in `inherited'
	from /Users/Jordan/projects/foo/extensions/my_class.rb:28:in `<module:Session>'

```

Here is a boiled-down version of the bug with a potential fix:

```ruby
ID = Class.new
IDChild = Class.new(ID)
MyMod = Module.new
Foo = Class.new(IDChild)
Foo.include(MyMod)

Foo.ancestors.find { |kl| kl.superclass == ID }
# NoMethodError: undefined method `superclass' for MyMod:Module

Foo.ancestors.find { |kl| kl.respond_to?(:superclass) && kl.superclass == ID }
# => IDChild
```

This PR contains a similar fix. I haven't included tests but would be happy to do you plan to merge this.