### PR TITLE
Fix mistake in encoding change

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -143,7 +143,7 @@ module Rack
       env
     end
 
-    if "<3".respond_to? :encoding
+    if "<3".respond_to? :b
       def self.env_with_encoding(env, opts, uri)
         env[REQUEST_METHOD] = (opts[:method] ? opts[:method].to_s.upcase : "GET").b
         env["SERVER_NAME"] = (uri.host || "example.org").b

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -212,7 +212,7 @@ describe Rack::MockRequest do
     called.should.equal true
   end
 
-  unless "<3".respond_to? :encoding
+  if "<3".respond_to? :b
     should "defaults encoding to ASCII 8BIT" do
       req = Rack::MockRequest.env_for("/foo")
 


### PR DESCRIPTION
1) I wasn't even testing my change on the branches I made changes on
because I accidentally used `unless` instead of `if`. This test should
only run IF encoding them to binary is supported. :flushed:

2) 1.9.3 does respond to `:encoding` but it doesn't respond to `:b` and
since it's `:b` we're calling on these env vars it's best to ask if it
responds to that method, not to `:encoding`.

Fixes #1168