### PR TITLE
Fix cgi specs

### DIFF
--- a/test/spec_cgi.rb
+++ b/test/spec_cgi.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-if defined? LIGHTTPD_PID
+if defined? Rack::TestCase::LIGHTTPD_PID
 
 require File.expand_path('../testrequest', __FILE__)
 require 'rack/handler/cgi'
@@ -81,4 +81,4 @@ describe Rack::Handler::CGI do
   end
 end
 
-end # if defined? LIGHTTPD_PID
+end # if defined? Rack::TestCase::LIGHTTPD_PID

--- a/test/spec_fastcgi.rb
+++ b/test/spec_fastcgi.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-if defined? LIGHTTPD_PID
+if defined? Rack::TestCase::LIGHTTPD_PID
 
 require File.expand_path('../testrequest', __FILE__)
 require 'rack/handler/fastcgi'
@@ -82,4 +82,4 @@ describe Rack::Handler::FastCGI do
   end
 end
 
-end # if defined? LIGHTTPD_PID
+end # if defined? Rack::TestCase::LIGHTTPD_PID


### PR DESCRIPTION
Correctly rerefernce LIGHTTPD_PID from spec_cgi.rb and spec_fastcgi.rb
allowing specs to run.

See https://github.com/rack/rack/issues/1171