### PR TITLE
Use "strict encoding" for Base64 encoded session cookies

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -49,7 +49,7 @@ module Rack
       # Encode session cookies as Base64
       class Base64
         def encode(str)
-          [str].pack('m')
+          [str].pack('m0')
         end
 
         def decode(str)


### PR DESCRIPTION
The prior implementation would include new lines characters. Subsequently, these characters would then be URI encoded when the headers are written (as "%0A"). Not including new lines via "strict encoding" will slightly reduce the size for long session values.

In order to handle existing sessions encoded with new lines, Base64#decode will handle ArgumentError exceptions and try to decode using non-strict encoding. A couple of small specs have also been added
for this case.