### PR TITLE
Unfreeze default session options

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -210,7 +210,7 @@ module Rack
           :sidbits =>       128,
           :cookie_only =>   true,
           :secure_random => ::SecureRandom
-        }.freeze
+        }
 
         attr_reader :key, :default_options, :sid_secure
 


### PR DESCRIPTION
I would like to suggest to unfreeze default session options.

Freezing session options causes an error when combining certain libraries.
For example, session options are modified in warden gem.
https://github.com/hassox/warden/blob/v1.2.7/lib/warden/proxy.rb#L175