### PR TITLE
Fix Rack::Lock mutex usage (for 1-6-stable)

### DIFF
--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -12,18 +12,15 @@ module Rack
     end
 
     def call(env)
-      old, env[FLAG] = env[FLAG], false
       @mutex.lock
       begin
-        response = @app.call(env)
+        response = @app.call(env.merge(FLAG => false))
         body = BodyProxy.new(response[2]) { @mutex.unlock }
         response[2] = body
         response
       ensure
         @mutex.unlock unless body
       end
-    ensure
-      env[FLAG] = old
     end
   end
 end

--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -15,11 +15,9 @@ module Rack
       @mutex.lock
       begin
         response = @app.call(env.merge(FLAG => false))
-        body = BodyProxy.new(response[2]) { @mutex.unlock }
-        response[2] = body
-        response
+        returned = response << BodyProxy.new(response.pop) { @mutex.unlock }
       ensure
-        @mutex.unlock unless body
+        @mutex.unlock unless returned
       end
     end
   end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -187,4 +187,12 @@ describe Rack::Lock do
     response = app.call(Rack::MockRequest.env_for("/"))[2]
     response.env['rack.multithread'].should.equal false
   end
+
+  should "unlock if an exception occurs before returning" do
+    lock = Lock.new
+    env  = Rack::MockRequest.env_for("/")
+    app  = lock_app(proc { [].freeze }, lock)
+    lambda { app.call(env) }.should.raise(RuntimeError)
+    lock.synchronized.should.equal false
+  end
 end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -9,11 +9,6 @@ class Lock
     @synchronized = false
   end
 
-  def synchronize
-    @synchronized = true
-    yield
-  end
-
   def lock
     @synchronized = true
   end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -161,4 +161,17 @@ describe Rack::Lock do
     }.new(lambda { |env| [200, {"Content-Type" => "text/plain"}, %w{ a b c }] })
     Rack::Lint.new(app).call(Rack::MockRequest.env_for("/"))
   end
+
+  should 'not unlock if an error is raised before the mutex is locked' do
+    lock = Class.new do
+      def initialize() @unlocked = false end
+      def unlocked?() @unlocked end
+      def lock() raise Exception end
+      def unlock() @unlocked = true end
+    end.new
+    env = Rack::MockRequest.env_for("/")
+    app = lock_app(proc { [200, {"Content-Type" => "text/plain"}, []] }, lock)
+    lambda { app.call(env) }.should.raise(Exception)
+    lock.unlocked?.should.equal false
+  end
 end

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -149,7 +149,10 @@ describe Rack::Lock do
       env['rack.multithread'].should.equal false
       [200, {"Content-Type" => "text/plain"}, %w{ a b c }]
     }, false)
-    app.call(Rack::MockRequest.env_for("/"))
+    env = Rack::MockRequest.env_for("/")
+    env['rack.multithread'].should.equal true
+    app.call(env)
+    env['rack.multithread'].should.equal true
   end
 
   should "reset original multithread flag when exiting lock" do
@@ -173,5 +176,15 @@ describe Rack::Lock do
     app = lock_app(proc { [200, {"Content-Type" => "text/plain"}, []] }, lock)
     lambda { app.call(env) }.should.raise(Exception)
     lock.unlocked?.should.equal false
+  end
+
+  should "not reset the environment while the body is proxied" do
+    proxy = Class.new do
+      attr_reader :env
+      def initialize(env) @env = env end
+    end
+    app = Rack::Lock.new lambda { |env| [200, {"Content-Type" => "text/plain"}, proxy.new(env)] }
+    response = app.call(Rack::MockRequest.env_for("/"))[2]
+    response.env['rack.multithread'].should.equal false
   end
 end


### PR DESCRIPTION
This branch applies the fixes in #828 to the `1-6-stable` branch. The fix was already [merged](https://github.com/rack/rack/commit/e364ecbcca9c5b32204bb1361cbcadfa715dd2f5) into the `master` branch.

For more information about the change see #828.