### PR TITLE
Updates for frozen string literal compatibility.

### DIFF
--- a/lib/rack/auth/digest/params.rb
+++ b/lib/rack/auth/digest/params.rb
@@ -38,12 +38,12 @@ module Rack
 
         def to_s
           map do |k, v|
-            "#{k}=" << (UNQUOTED.include?(k) ? v.to_s : quote(v))
+            "#{k}=#{(UNQUOTED.include?(k) ? v.to_s : quote(v))}"
           end.join(', ')
         end
 
         def quote(str) # From WEBrick::HTTPUtils
-          '"' << str.gsub(/[\\\"]/o, "\\\1") << '"'
+          '"' + str.gsub(/[\\\"]/o, "\\\1") + '"'
         end
 
       end

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -252,7 +252,7 @@ module Rack
           filename = get_filename(head)
 
           if name.nil? || name.empty?
-            name = filename || "#{content_type || TEXT_PLAIN}[]"
+            name = filename || "#{content_type || TEXT_PLAIN}[]".dup
           end
 
           @collector.on_mime_head @mime_index, head, filename, content_type, name

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -391,7 +391,7 @@ module Rack
 
       def base_url
         url = "#{scheme}://#{host}"
-        url << ":#{port}" if port != DEFAULT_PORTS[scheme]
+        url = "#{url}:#{port}" if port != DEFAULT_PORTS[scheme]
         url
       end
 

--- a/lib/rack/rewindable_input.rb
+++ b/lib/rack/rewindable_input.rb
@@ -72,7 +72,7 @@ module Rack
         @unlinked = true
       end
 
-      buffer = ""
+      buffer = "".dup
       while @io.read(1024 * 4, buffer)
         entire_buffer_written_out = false
         while !entire_buffer_written_out

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -55,7 +55,7 @@ module Rack
     private :accepts_html?
 
     def dump_exception(exception)
-      string = "#{exception.class}: #{exception.message}\n"
+      string = "#{exception.class}: #{exception.message}\n".dup
       string << exception.backtrace.map { |l| "\t#{l}" }.join("\n")
       string
     end

--- a/test/spec_chunked.rb
+++ b/test/spec_chunked.rb
@@ -42,8 +42,8 @@ describe Rack::Chunked do
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
     response.body.encoding.to_s.must_equal "ASCII-8BIT"
-    response.body.must_equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".force_encoding("BINARY")
-    response.body.must_equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".force_encoding(Encoding::BINARY)
+    response.body.must_equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".dup.force_encoding("BINARY")
+    response.body.must_equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".dup.force_encoding(Encoding::BINARY)
   end
 
   it 'not modify response when Content-Length header present' do

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -57,7 +57,7 @@ describe Rack::Deflater do
 
     # verify body
     unless options['skip_body_verify']
-      body_text = ''
+      body_text = ''.dup
       body.each { |part| body_text << part }
 
       deflated_body = case expected_encoding

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -27,7 +27,7 @@ describe Rack::Directory do
 
       assert_equal 200, status
 
-      str = ''
+      str = ''.dup
       body.each { |x| str << x }
       assert_match "foo+bar", str
     end
@@ -113,7 +113,7 @@ describe Rack::Directory do
 
       assert_equal 200, status
 
-      str = ''
+      str = ''.dup
       body.each { |x| str << x }
       assert_match "/foo%20bar/omg%20omg.txt", str
     end

--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -19,7 +19,7 @@ describe Rack::File do
 
       assert_equal 200, status
 
-      str = ''
+      str = ''.dup
       body.each { |x| str << x }
       assert_match "hello world", str
     end

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -483,7 +483,7 @@ describe Rack::Lint do
   end
 
   def assert_lint(*args)
-    hello_str = "hello world"
+    hello_str = "hello world".dup
     hello_str.force_encoding(Encoding::ASCII_8BIT)
 
     Rack::Lint.new(lambda { |env|
@@ -498,8 +498,8 @@ describe Rack::Lint do
     assert_lint 0
     assert_lint 1
     assert_lint nil
-    assert_lint nil, ''
-    assert_lint 1, ''
+    assert_lint nil, ''.dup
+    assert_lint 1, ''.dup
   end
 end
 

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -201,7 +201,7 @@ describe Rack::Multipart do
 
   it "parse multipart upload file using custom tempfile class" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:text))
-    my_tempfile = ""
+    my_tempfile = "".dup
     env['rack.multipart.tempfile_factory'] = lambda { |filename, content_type| my_tempfile }
     params = Rack::Multipart.parse_multipart(env)
     params["files"][:tempfile].object_id.must_equal my_tempfile.object_id
@@ -683,7 +683,7 @@ true\r
   it "fallback to content-type for name" do
     rack_logo = File.read(multipart_file("rack-logo.png"))
 
-    data = <<-EOF
+    data = <<-EOF.dup
 --AaB03x\r
 Content-Type: text/plain\r
 \r
@@ -702,7 +702,7 @@ Content-Type: image/png\r
     options = {
       "CONTENT_TYPE" => "multipart/related; boundary=AaB03x",
       "CONTENT_LENGTH" => data.bytesize.to_s,
-      :input => StringIO.new(data)
+      :input => StringIO.new(data.dup)
     }
     env = Rack::MockRequest.env_for("/", options)
     params = Rack::Multipart.parse_multipart(env)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1106,7 +1106,7 @@ EOF
       [200, {"Content-Type" => "text/html", "Content-Length" => size.to_s}, [content]]
     }
 
-    input = <<EOF
+    input = <<EOF.dup
 --AaB03x\r
 content-disposition: form-data; name="reply"\r
 \r

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -231,12 +231,12 @@ describe Rack::Response do
   it "has a useful constructor" do
     r = Rack::Response.new("foo")
     status, header, body = r.finish
-    str = ""; body.each { |part| str << part }
+    str = "".dup; body.each { |part| str << part }
     str.must_equal "foo"
 
     r = Rack::Response.new(["foo", "bar"])
     status, header, body = r.finish
-    str = ""; body.each { |part| str << part }
+    str = "".dup; body.each { |part| str << part }
     str.must_equal "foobar"
 
     object_with_each = Object.new
@@ -247,7 +247,7 @@ describe Rack::Response do
     r = Rack::Response.new(object_with_each)
     r.write "foo"
     status, header, body = r.finish
-    str = ""; body.each { |part| str << part }
+    str = "".dup; body.each { |part| str << part }
     str.must_equal "foobarfoo"
 
     r = Rack::Response.new([], 500)
@@ -263,7 +263,7 @@ describe Rack::Response do
       res.write "foo"
     }
     status, _, body = r.finish
-    str = ""; body.each { |part| str << part }
+    str = "".dup; body.each { |part| str << part }
     str.must_equal "foo"
     status.must_equal 404
   end
@@ -271,7 +271,7 @@ describe Rack::Response do
   it "doesn't return invalid responses" do
     r = Rack::Response.new(["foo", "bar"], 204)
     _, header, body = r.finish
-    str = ""; body.each { |part| str << part }
+    str = "".dup; body.each { |part| str << part }
     str.must_be :empty?
     header["Content-Type"].must_be_nil
     header['Content-Length'].must_be_nil

--- a/test/spec_rewindable_input.rb
+++ b/test/spec_rewindable_input.rb
@@ -26,14 +26,14 @@ module RewindableTest
   end
 
   it "be able to handle to read(length, buffer)" do
-    buffer = ""
+    buffer = "".dup
     result = @rio.read(1, buffer)
     result.must_equal "h"
     result.object_id.must_equal buffer.object_id
   end
 
   it "be able to handle to read(nil, buffer)" do
-    buffer = ""
+    buffer = "".dup
     result = @rio.read(nil, buffer)
     result.must_equal "hello world"
     result.object_id.must_equal buffer.object_id
@@ -95,7 +95,7 @@ end
 describe Rack::RewindableInput do
   describe "given an IO object that is already rewindable" do
     def setup
-      @io = StringIO.new("hello world")
+      @io = StringIO.new("hello world".dup)
       super
     end
 
@@ -104,7 +104,7 @@ describe Rack::RewindableInput do
 
   describe "given an IO object that is not rewindable" do
     def setup
-      @io = StringIO.new("hello world")
+      @io = StringIO.new("hello world".dup)
       @io.instance_eval do
         undef :rewind
       end
@@ -116,7 +116,7 @@ describe Rack::RewindableInput do
 
   describe "given an IO object whose rewind method raises Errno::ESPIPE" do
     def setup
-      @io = StringIO.new("hello world")
+      @io = StringIO.new("hello world".dup)
       def @io.rewind
         raise Errno::ESPIPE, "You can't rewind this!"
       end

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -423,7 +423,7 @@ describe Rack::Session::Cookie do
     @counter = 0
     app = lambda do |env|
       env["rack.session"]["message"] ||= ""
-      env["rack.session"]["message"] << "#{(@counter += 1).to_s}--"
+      env["rack.session"]["message"] += "#{(@counter += 1).to_s}--"
       hash = env["rack.session"].dup
       hash.delete("session_id")
       Rack::Response.new(hash["message"]).to_a


### PR DESCRIPTION
To be clear, @twalpole did all the hard work previously in #1023, so I've doubled up on their efforts (taking a bit of a different approach, mostly to use `dup` given that seems to be the preference). I've not gone and added all the pragma comments to the files though.

Given that all the testing dependencies seem to be frozen-string-literal friendly, you could take the approach of enabling the flag for MRI 2.4 onwards in the Travis configuration to avoid regressions:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

Or adding the pragma comments will do the trick as well.