### PR TITLE
sort select_best_encoding candidates by available_encodings order

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -185,7 +185,9 @@ module Rack
           mem + list
         }
 
-      encoding_candidates = expanded_accept_encoding.sort_by { |_, q| -q }.map { |m, _| m }
+      encoding_candidates = expanded_accept_encoding.sort_by do |m, q|
+        [-q, available_encodings.index(m) || available_encodings.length]
+      end.map { |m, _| m }
 
       unless encoding_candidates.include?("identity")
         encoding_candidates.push("identity")

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -435,6 +435,7 @@ describe Rack::Utils do
 
     helper.call(%w(compress gzip identity), [["compress", 1.0], ["gzip", 1.0]]).must_equal "compress"
     helper.call(%w(compress gzip identity), [["compress", 0.5], ["gzip", 1.0]]).must_equal "gzip"
+    helper.call(%w(compress gzip identity), [["gzip", 1.0], ["compress", 1.0]]).must_equal "compress"
 
     helper.call(%w(foo bar identity), []).must_equal "identity"
     helper.call(%w(foo bar identity), [["*", 1.0]]).must_equal "foo"


### PR DESCRIPTION
This PR makes a small change to [`Rack::Utils#select_best_encoding`](https://github.com/wjordan/rack/blob/03850b61b38b32fc0258d4698fad8a97df82f105/lib/rack/utils.rb#L174-L202) that allows extra server-side control over the encoding returned in the case of a tie (multiple encodings at the same qvalue).

The reason this extra control is necessary is because the `Accept-Encoding` header field (ref. [rfc7231#5.3.4](https://tools.ietf.org/html/rfc7231#section-5.3.4)) uses HTTP content negotiation which contains a bit of ambiguity regarding tie-breakers at the same qvalue.

My use-case is the Chrome browser currently sending the following `Accept-Encoding` header for most requests over an HTTPS connection:

    Accept-Encoding: gzip, deflate, br

Because `br` (the [official](https://www.iana.org/assignments/http-parameters/http-parameters.xml#content-coding) identifier for [Brotli Compressed Data Format](https://tools.ietf.org/html/rfc7932)) has a better compression ratio than `gzip` or `deflate`, I'd like to tell Rack to prefer sending `br`-encoded content above the others.

The current implementation of `#select_best_encoding` interprets these encoding preferences in sorted-order, e.g.: "I prefer `gzip` most, next `deflate`, and `br` least", so `gzip` is returned.

This PR interprets these encoding preferences equally, e.g.: "I prefer `gzip`, `deflate`, and `br` equally, so send me whatever the server decides is best". The tie-breaker would be determined by the order of the encodings provided to `#select_best_encoding`, so `#select_best_encoding(%w(br gzip identity), request.accept_encoding)` for the above request would return `br` instead of `gzip`, as desired.