### PR TITLE
Add multi mapping support via header

### DIFF
--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -150,8 +150,12 @@ module Rack
       if mapping = @mappings.find { |internal,_| internal =~ path }
         path.sub(*mapping)
       elsif mapping = env['HTTP_X_ACCEL_MAPPING']
-        internal, external = mapping.split('=', 2).map(&:strip)
-        path.sub(/^#{internal}/i, external)
+        mapping.split(',').map(&:strip).each do |m|
+          internal, external = m.split('=', 2).map(&:strip)
+          new_path = path.sub(/^#{internal}/i, external)
+          return new_path unless path == new_path
+        end
+        path
       end
     end
   end


### PR DESCRIPTION
nignx sets "HTTP_X_ACCEL_MAPPING" from multi mappings to comma splited string.
like,
```
proxy_set_header X-Accel-Mapping /var/www1/=/files1/;
proxy_set_header X-Accel-Mapping /var/www2/=/files2/;
```
to
```
'/var/www1/=/files1/, /var/www2/=/files2/'
```