### PR TITLE
avoid errors: undefined method `shutdown' for nil:NilClass (NoMethodError)

### DIFF
--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -45,8 +45,10 @@ module Rack
       end
 
       def self.shutdown
-        @server.shutdown
-        @server = nil
+        if @server
+          @server.shutdown
+          @server = nil
+        end
       end
 
       def initialize(server, app)


### PR DESCRIPTION
When SIGINT is sent multiple times to the webrick handler, the server crashes.

backtrace:

```
/Users/gfx/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-2.0.3/lib/rack/handler/webrick.rb:48:in `shutdown': undefined method `shutdown' for nil:NilClass (NoMethodError)
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-2.0.3/lib/rack/server.rb:291:in `block in start'
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/2.3.0/webrick/server.rb:215:in `join'
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/2.3.0/webrick/server.rb:215:in `block (2 levels) in start'
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/2.3.0/webrick/server.rb:215:in `each'
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/2.3.0/webrick/server.rb:215:in `block in start'
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/2.3.0/webrick/server.rb:33:in `start'
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/2.3.0/webrick/server.rb:164:in `start'
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-2.0.3/lib/rack/handler/webrick.rb:34:in `run'
	from /Users/gfx/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rack-2.0.3/lib/rack/server.rb:297:in `start'
```