### PR TITLE
Update homepage links to be HTTPS

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -296,7 +296,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 == Links
 
-Rack:: <http://rack.github.io/>
+Rack:: <https://rack.github.io/>
 Official Rack repositories:: <https://github.com/rack>
 Rack Bug Tracking:: <https://github.com/rack/rack/issues>
 rack-devel mailing list:: <https://groups.google.com/group/rack-devel>

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -12,7 +12,7 @@ the simplest way possible, it unifies and distills the API for web
 servers, web frameworks, and software in between (the so-called
 middleware) into a single method call.
 
-Also see http://rack.github.io/.
+Also see https://rack.github.io/.
 EOF
 
   s.files           = Dir['{bin/*,contrib/*,example/*,lib/**/*,test/**/*}'] +
@@ -25,7 +25,7 @@ EOF
 
   s.author          = 'Christian Neukirchen'
   s.email           = 'chneukirchen@gmail.com'
-  s.homepage        = 'http://rack.github.io/'
+  s.homepage        = 'https://rack.github.io/'
   s.required_ruby_version = '>= 2.2.2'
 
   s.add_development_dependency 'minitest', "~> 5.0"


### PR DESCRIPTION
GitHub Pages can be served under [HTTPS](https://github.com/blog/2186-https-for-github-pages), and maybe it should be [enforced](https://help.github.com/articles/securing-your-github-pages-site-with-https/).

This is needed to make rack/rack.github.com#12 work too.