### PR TITLE
Fix the code block used to generate the HTTP_STATUS_CODES hash

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -486,9 +486,9 @@ module Rack
 
     # Every standard HTTP code mapped to the appropriate message.
     # Generated with:
-    # curl -s https://www.iana.org/assignments/http-status-codes/http-status-codes-1.csv | \
-    #   ruby -ne 'm = /^(\d{3}),(?!Unassigned|\(Unused\))([^,]+)/.match($_) and \
-    #             puts "#{m[1]} => \x27#{m[2].strip}\x27,"'
+    #   curl -s https://www.iana.org/assignments/http-status-codes/http-status-codes-1.csv | \
+    #     ruby -ne 'm = /^(\d{3}),(?!Unassigned|\(Unused\))([^,]+)/.match($_) and \
+    #               puts "#{m[1]} => \x27#{m[2].strip}\x27,"'
     HTTP_STATUS_CODES = {
       100 => 'Continue',
       101 => 'Switching Protocols',


### PR DESCRIPTION
The [RDoc documentation for Rack::Utils][rack-utils] looks a little bit messy with the current comment about how HTTP_STATUS_CODES hash is generated:

![http_status_codes_before](https://user-images.githubusercontent.com/1037088/28103228-96d353aa-6689-11e7-9193-b55e3637d09a.png)

If accepted, the previous code block will look more organized:

![http_status_codes_after](https://user-images.githubusercontent.com/1037088/28103347-18650d14-668a-11e7-8c86-116b1b42a6c3.png)


[rack-utils]: http://www.rubydoc.info/github/rack/rack/master/Rack/Utils