### PR TITLE
Increase the multipart parser buffer size

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -5,7 +5,7 @@ module Rack
     class MultipartPartLimitError < Errno::EMFILE; end
 
     class Parser
-      BUFSIZE = 16384
+      BUFSIZE = 1_048_576
       TEXT_PLAIN = "text/plain"
       TEMPFILE_FACTORY = lambda { |filename, content_type|
         Tempfile.new(["RackMultipart", ::File.extname(filename.gsub("\0".freeze, '%00'.freeze))])


### PR DESCRIPTION
This increases the buffer size to 1mb to get better performance parsing larger files. Buffer sizes of 16kb, 1mb, 10mb, and 100mb were compared based on performance and cpu/memory usage. See #1075. Benchmarks for CPU % and memory weren't super scientific, but I think they're close enough to help narrow the field. 

Even though 10mb seemed to be the sweet spot, it used more memory in the JVM causing [one spec](https://github.com/rack/rack/blob/2.0.3/test/spec_multipart.rb#L101) to fail with an `OutOfMemoryError` when running the tests (unless JVM heap size was bumped up to 768m). Since #1179 has been merged, the performance difference between 1mb and 10mb is no doubt even less.

Benchmarks:

**16kb buffer**

| File Size | Time | CPU % | Memory (mb) |
|-----|----|----|----|
| 1kb | 0.001487 | 0 | 17 |
| 1mb | 0.013964 | 1.3 | 24 |
| 10mb | 0.538451 | 13.9 | 42 |
| 100mb | 48.409497 | 99.9 | 447 |

**1mb buffer**

| File Size | Time | CPU % | Memory (mb) |
|-----|----|----|----|
| 1kb | 0.005332 | 0 | 17 |
| 1mb | 0.007175 | 0.4 | 26 |
| 10mb | 0.090291 | 4.7 | 41 |
| 100mb | 1.337987 | 21 | 249 |

**10mb buffer**

| File Size | Time | CPU % | Memory (mb) |
|-----|----|----|----|
| 1kb | 0.000590 | 0.2 | 18 |
| 1mb | 0.005289 | 0.4 | 25 |
| 10mb | 0.078966 | 2.9 | 48 |
| 100mb | 0.730517 | 13.5 | 271 |

**100mb buffer**

| File Size | Time | CPU % | Memory (mb) |
|-----|----|----|----|
| 1kb | 0.005558 | 0.1 | 18 |
| 1mb | 0.005362 | 0.7 | 25 |
| 10mb | 0.063400 | 2.3 | 78 |
| 100mb | 0.727143 | 12.5 | 447 |
