### PR TITLE
Prefer Event over CountDownLatch

### DIFF
--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require 'rack/mock'
-require 'concurrent/utility/native_integer'
-require 'concurrent/atomic/count_down_latch'
+require 'concurrent/atomic/event'
 require File.expand_path('../testrequest', __FILE__)
 
 Thread.abort_on_exception = true
@@ -120,8 +119,7 @@ describe Rack::Handler::WEBrick do
   end
 
   it "provide a .run" do
-    block_ran = false
-    latch = Concurrent::CountDownLatch.new 1
+    latch = Concurrent::Event.new
 
     t = Thread.new do
       Rack::Handler::WEBrick.run(lambda {},
@@ -130,10 +128,9 @@ describe Rack::Handler::WEBrick do
                                    :Port => 9210,
                                    :Logger => WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
                                    :AccessLog => []}) { |server|
-        block_ran = true
         assert_kind_of WEBrick::HTTPServer, server
         @s = server
-        latch.count_down
+        latch.set
       }
     end
 


### PR DESCRIPTION
It's slightly nicer to read, and incidentally avoids a missing require.

db45a93daab59ddee520890d104701bf089ccd2b attempted to fix it by manually requiring the missing `concurrent/utility/native_integer`, but per #1197, that breaks compatibility with older concurrent-ruby versions.

Closes #1197 