### PR TITLE
Don't use #eof? when parsing multipart

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -39,8 +39,6 @@ module Rack
           str
         end
 
-        def eof?; @content_length == @cursor; end
-
         def rewind
           @io.rewind
         end
@@ -65,11 +63,11 @@ module Rack
         io = BoundedIO.new(io, content_length) if content_length
 
         parser = new(boundary, tmpfile, bufsize, qp)
-        parser.on_read io.read(bufsize), io.eof?
+        parser.on_read io.read(bufsize)
 
         loop do
           break if parser.state == :DONE
-          parser.on_read io.read(bufsize), io.eof?
+          parser.on_read io.read(bufsize)
         end
 
         io.rewind
@@ -181,8 +179,8 @@ module Rack
         @collector = Collector.new tempfile
       end
 
-      def on_read content, eof
-        handle_empty_content!(content, eof)
+      def on_read content
+        handle_empty_content!(content)
         @buf << content
         run_parser
       end
@@ -358,10 +356,9 @@ module Rack
       end
 
 
-      def handle_empty_content!(content, eof)
+      def handle_empty_content!(content)
         if content.nil? || content.empty?
-          raise EOFError if eof
-          return true
+          raise EOFError
         end
       end
     end


### PR DESCRIPTION
On chunked requests (`Transfer-Encoding: chunked`) content length won't be present, so `#eof?` will be called on the Rack input directly. However, the Rack input doesn't have to respond to `#eof?`, it's not part of the Rack specification. For example, `Rack::Lint::InputWrapper` and `Unicorn::StreamInput` don't respond to `#eof?`. This means that in development and on Unicorn, multipart parsing will fail for chunked requests.

This change refactors the multipart parser so that it doesn't call `#eof?`.