### PR TITLE
Faster Utils.clean_path_info

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -580,9 +580,9 @@ module Rack
         part == '..' ? clean.pop : clean << part
       end
 
-      clean.unshift '/' if parts.empty? || parts.first.empty?
-
-      ::File.join clean
+      clean_path = clean.join(::File::SEPARATOR)
+      clean_path.prepend("/") if parts.empty? || parts.first.empty?
+      clean_path
     end
 
     NULL_BYTE = "\0"


### PR DESCRIPTION
The purpose of the `File.join` is to deal with redundant slashes for example

```
File.join("foo/", "bar")
# => "foo/bar"
```

In this case we are guaranteed that there will be not slashes in our data because we are first splitting by separators:

```
parts = path_info.split PATH_SEPS
```

We can speed up this call then by using the `Array#join` method which does less work:

```
require 'benchmark/ips'

SOURCE_ARRAY = ["foo", "bar"]

Benchmark.ips do |x|
  x.report("Array#join") do |times|
    i = 0
    while i < times
      SOURCE_ARRAY.join(::File::SEPARATOR)
      i +=1
    end
  end
  x.report("File#join") do |times|
    i = 0
    while i < times
      ::File.join(SOURCE_ARRAY)
      i +=1
    end
  end
  x.compare!
end
```

You can see this method of building strings is roughly 2.55 times faster than the current method


```
Warming up --------------------------------------
          Array#join   111.966k i/100ms
           File#join    62.000k i/100ms
Calculating -------------------------------------
          Array#join      2.075M (±12.1%) i/s -     10.189M in   5.022957s
           File#join    813.613k (±11.5%) i/s -      4.030M in   5.052667s

Comparison:
          Array#join:  2075017.5 i/s
           File#join:   813613.1 i/s - 2.55x  slower
```