### PR TITLE
Add frozen_string_literal to utils

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+# frozen_string_literal: true
 require 'uri'
 require 'fileutils'
 require 'set'


### PR DESCRIPTION
Speeds up methods by not requiring string literals to be allocated on every call.