### PR TITLE
Allow Disabling Header Hash

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -410,7 +410,11 @@ module Rack
     # header when set.
     class HeaderHash < Hash
       def self.new(hash={})
-        HeaderHash === hash ? hash : super(hash)
+        if ENV["RACK_DISABLE_HEADER_HASH"]
+          return hash
+        else
+          HeaderHash === hash ? hash : super(hash)
+        end
       end
 
       def initialize(hash={})


### PR DESCRIPTION
Using a HeaderHash in place of a hash is extremely expensive. The hash seeks to normalize the case of keys. For any apps using correctly cased keys they should be allowed to bypass this behavior.

Using an a super simple Rack app, I was able to see a 22.77% performance increase by disabling this behavior.

![](http://i.imgur.com/LLDocYa.png)

## Benchmark Reproduction

Make an app with a `Gemfile`

```ruby
# Gemfile
source 'https://rubygems.org'

gem 'rack', path: '~/documents/projects/rack'
gem 'rack-test'
gem 'derailed'
```

And a `perf.rake`

```ruby
# perf.rake
CONST_RESPONSE = [
    200,
    {
      'Content-Type'  => 'text/html',
    },
    ["hello world".freeze]
  ]

namespace :perf do
  task :rack_load do
    DERAILED_APP = lambda { |env| CONST_RESPONSE }
  end
end
```

Then hit the app with the flag on and off

```term
export TEST_COUNT=100_000

echo "============ CURRENT =================="
for run in {1..20}
do
  echo "=="
  bundle exec derailed exec perf:test
done

echo "=============================="
echo "=============================="
echo "=============================="
echo "=============================="
echo "=============================="
echo "=============================="


echo "============ PATCH =================="

for run in {1..20}
do
  echo "=="
  RACK_DISABLE_HEADER_HASH=1 bundle exec derailed exec perf:test
done
```

I then graphed the results

## Why it's faster

There are interpreter level hash optimizations such as automatically [freezing key strings](https://github.com/ruby/ruby/commit/58f800a278b8b70463f4afdbb23a918d8ab441ff), and [hash lookups](https://github.com/ruby/ruby/blob/066e9a8b4ac36907f8e7915b5f94fdc7ca851de0/vm_insnhelper.c#L3575-L3577). When you subclass hash many of these optimizations cannot be applied.