### PR TITLE
Add file-based session mechanism

### DIFF
--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -143,5 +143,6 @@ module Rack
     autoload :Cookie, "rack/session/cookie"
     autoload :Pool, "rack/session/pool"
     autoload :Memcache, "rack/session/memcache"
+    autoload :File, "rack/session/file"
   end
 end

--- a/lib/rack/session/file.rb
+++ b/lib/rack/session/file.rb
@@ -138,6 +138,9 @@ module Rack
       def persistent_session_id(data, sid = nil)
         data ||= {}
         data[SESSION_ID] ||= sid || generate_sid
+        while ::File.exist? path_for_sid(data[SESSION_ID])
+          data[SESSION_ID] = generate_sid
+        end
         data
       end
 

--- a/lib/rack/session/file.rb
+++ b/lib/rack/session/file.rb
@@ -1,0 +1,183 @@
+require 'pstore'
+require 'tmpdir'
+require 'openssl'
+require 'rack/request'
+require 'rack/response'
+require 'rack/session/abstract/id'
+
+module Rack
+
+  module Session
+
+    # Rack::Session::File provides simple filed based session management.
+    # By default, the session is stored in /tmp while cookie holds only
+    # session id.
+    #
+    # When the :secret key is set (recommended), cookie data is checked
+    # for data integrity. The :old_secret key is also accepted allowing
+    # smooth secret rotation.
+    #
+    # Garbage collection is controlled via :gc_probability and :gc_maxlife.
+    # Every call to write_session, garbage collector is called with probability
+    # of :gc_probability. It scans :dir for sessions files and deletes ones
+    # with mtime older than :gc_maxlife.
+    #
+    # Supported options for constructor are:
+    #
+    #   :dir            directory into which save sessions
+    #   :prefix         session file prefix
+    #   :key            under what cookie save the session_id
+    #   :domain         domain should the session_id cookie is valid for
+    #   :path           path the session_id cookie is valid for
+    #   :expire_after   session_id cookie expires after this seconds
+    #   :secret         secret to use for integrity check
+    #   :old_secret     secret previously used, allowing smooth secret rotation
+    #
+    #   :gc_probability probability of gc to run, in interval [0; 1]
+    #   :gc_maxlife     how old (in seconds) session files should be cleaned up
+    #
+    # Default values:
+    #
+    #   :dir            File.join(Dir.tmpdir(), 'file-rack')
+    #   :prefix         'file-rack-session-'
+    #   :key            rack.session
+    #   :domain         nil
+    #   :path           nil
+    #   :expire_after   nil
+    #   :secret         nil
+    #   :old_secret     nil
+    #   :gc_probability 0.01
+    #   :gc_maxlife     1200
+    #
+    # Example:
+    #
+    #   use Rack::Session::File, dir: '/tmp',
+    #                            prefix: 'session-',
+    #
+    #   All parameters are optional.
+    class File < Abstract::Persisted
+
+      SESSION_ID = 'session_id'.freeze
+
+      def initialize(app, options = {})
+        @secrets = options.values_at(:secret, :old_secret).compact
+        @hmac = options.fetch(:hmac, OpenSSL::Digest::SHA1)
+
+        @dir = options[:dir] || ::File.join(Dir.tmpdir(), 'file-rack')
+        @prefix = options[:prefix] || 'file-rack-session-'
+        FileUtils.mkdir_p @dir
+
+        @gc_probability = options[:gc_probability] || 0.01
+        @gc_maxlife = options[:gc_maxlife] || 1200
+
+        warn <<~MSG unless secure?(options)
+          SECURITY WARNING: No secret option provided to Rack::Session::Cookie.
+          This poses a security threat. It is strongly recommended that you
+          provide a secret to prevent exploits that may be possible from crafted
+          cookies. This will not be supported in future versions of Rack, and
+          future versions will even invalidate your existing user cookies.
+
+          Called from: #{caller[0]}.
+        MSG
+
+        super(app, options.merge!(cookie_only: false))
+      end
+
+      private
+
+      def find_session(req, sid)
+        data = load_data(req)
+        data = persistent_session_id(data)
+        [data[SESSION_ID], data]
+      end
+
+      def write_session(req, session_id, session, options)
+        if options[:renew]
+          session[SESSION_ID] = generate_sid
+        end
+
+        store = PStore.new(path_for_sid(session_id))
+        store.transaction { store[:session] = session }
+
+        try_gc_run!
+
+        if @secrets.first
+          "#{session_id}--#{generate_hmac(session_id, @secrets.first)}"
+        else
+          session_id
+        end
+      end
+
+      def delete_session(req, session_id, options)
+        begin
+          File.delete(path_for_sid(session_id))
+        rescue => e
+          warn "Cannot delete session #{session_id}: #{e}"
+        end
+
+        unless options[:drop]
+          generate_sid
+        else
+          nil
+        end
+      end
+
+      def load_data(req)
+        sid = req.cookies[@key]
+        if @secrets.size > 0 and sid
+          sid, digest = sid.split('--', 2)
+          sid = nil unless digest_match?(sid, digest)
+        end
+        if sid
+          store = PStore.new(path_for_sid(sid), read_only: true)
+          store.transaction { store[:session] }
+        else
+          {}
+        end
+      end
+      def persistent_session_id(data, sid = nil)
+        data ||= {}
+        data[SESSION_ID] ||= sid || generate_sid
+        data
+      end
+
+      def path_for_sid(sid)
+        ::File.join @dir, "#{@prefix}#{sid}"
+      end
+
+      def digest_match?(data, digest)
+        return unless data && digest
+        @secrets.any? do |secret|
+          Rack::Utils.secure_compare(digest, generate_hmac(data, secret))
+        end
+      end
+
+      def generate_hmac(data, secret)
+        OpenSSL::HMAC.hexdigest(@hmac.new, secret, data)
+      end
+
+      def secure?(options)
+        @secrets.size >= 1
+      end
+
+      def try_gc_run!
+        return unless Random.rand < @gc_probability
+
+        threshold = Time.now - @gc_maxlife
+        Dir.chdir(@dir) do
+          Dir.entries(@dir).each do |entry|
+            next unless entry[/#{@prefix}/]
+            begin
+              ::File.delete(entry) if ::File.mtime(entry) < threshold
+            rescue => e
+              warn "Cannot delete session file #{entry}: #{e}"
+            end
+          end
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/lib/rack/session/file.rb
+++ b/lib/rack/session/file.rb
@@ -137,9 +137,11 @@ module Rack
       end
       def persistent_session_id(data, sid = nil)
         data ||= {}
-        data[SESSION_ID] ||= sid || generate_sid
-        while ::File.exist? path_for_sid(data[SESSION_ID])
-          data[SESSION_ID] = generate_sid
+        data[SESSION_ID] ||= sid
+        unless data[SESSION_ID]
+          begin
+            data[SESSION_ID] = generate_sid
+          end while ::File.exist? path_for_sid(data[SESSION_ID])
         end
         data
       end

--- a/test/spec_session_file.rb
+++ b/test/spec_session_file.rb
@@ -1,0 +1,304 @@
+require 'minitest/autorun'
+require 'rack/session/file'
+require 'rack/lint'
+require 'rack/mock'
+
+describe Rack::Session::File do
+  incrementor = lambda do |env|
+    env["rack.session"]["counter"] ||= 0
+    env["rack.session"]["counter"] += 1
+    hash = env["rack.session"].dup
+    hash.delete("session_id")
+    Rack::Response.new(hash.inspect).to_a
+  end
+
+  session_id = lambda do |env|
+    Rack::Response.new(env["rack.session"].to_hash.inspect).to_a
+  end
+
+  session_option = lambda do |opt|
+    lambda do |env|
+      Rack::Response.new(env["rack.session.options"][opt].inspect).to_a
+    end
+  end
+
+  nothing = lambda do |env|
+    Rack::Response.new("Nothing").to_a
+  end
+
+  renewer = lambda do |env|
+    env["rack.session.options"][:renew] = true
+    Rack::Response.new("Nothing").to_a
+  end
+
+  only_session_id = lambda do |env|
+    Rack::Response.new(env["rack.session"]["session_id"].to_s).to_a
+  end
+
+  bigcookie = lambda do |env|
+    env["rack.session"]["cookie"] = "big" * 3000
+    Rack::Response.new(env["rack.session"].inspect).to_a
+  end
+
+  destroy_session = lambda do |env|
+    env["rack.session"].destroy
+    Rack::Response.new("Nothing").to_a
+  end
+
+  def response_for(options={})
+    request_options = options.fetch(:request, {})
+    cookie = if options[:cookie].is_a?(Rack::Response)
+      options[:cookie]["Set-Cookie"]
+    else
+      options[:cookie]
+    end
+    request_options["HTTP_COOKIE"] = cookie || ""
+
+    app_with_cookie = Rack::Session::File.new(*options[:app])
+    app_with_cookie = Rack::Lint.new(app_with_cookie)
+    Rack::MockRequest.new(app_with_cookie).get("/", request_options)
+  end
+
+  before do
+    @warnings = warnings = []
+    Rack::Session::File.class_eval do
+      define_method(:warn) { |m| warnings << m }
+    end
+  end
+
+  after do
+    Rack::Session::File.class_eval { remove_method :warn }
+  end
+
+  it "warns if no secret is given" do
+    Rack::Session::File.new(incrementor)
+    @warnings.first.must_match(/no secret/i)
+    @warnings.clear
+    Rack::Session::File.new(incrementor, :secret => 'abc')
+    @warnings.must_be :empty?
+  end
+
+  it "creates a new cookie" do
+    response = response_for(:app => incrementor)
+    response["Set-Cookie"].must_include "rack.session="
+    response.body.must_equal '{"counter"=>1}'
+  end
+
+  it "loads from a cookie" do
+    response = response_for(:app => incrementor)
+
+    response = response_for(:app => incrementor, :cookie => response)
+    response.body.must_equal '{"counter"=>2}'
+
+    response = response_for(:app => incrementor, :cookie => response)
+    response.body.must_equal '{"counter"=>3}'
+  end
+
+  it "renew session id" do
+    response = response_for(:app => incrementor)
+    cookie   = response['Set-Cookie']
+    response = response_for(:app => only_session_id, :cookie => cookie)
+    cookie   = response['Set-Cookie'] if response['Set-Cookie']
+
+    response.body.wont_equal ""
+    old_session_id = response.body
+
+    response = response_for(:app => renewer, :cookie => cookie)
+    cookie   = response['Set-Cookie'] if response['Set-Cookie']
+    response = response_for(:app => only_session_id, :cookie => cookie)
+
+    response.body.wont_equal ""
+    response.body.wont_equal old_session_id
+  end
+
+  it "destroys session" do
+    response = response_for(:app => incrementor)
+    response = response_for(:app => only_session_id, :cookie => response)
+
+    response.body.wont_equal ""
+    old_session_id = response.body
+
+    response = response_for(:app => destroy_session, :cookie => response)
+    response = response_for(:app => only_session_id, :cookie => response)
+
+    response.body.wont_equal ""
+    response.body.wont_equal old_session_id
+  end
+
+  it "survives broken cookies" do
+    response = response_for(
+      :app => incrementor,
+      :cookie => "rack.session=blarghfasel"
+    )
+    response.body.must_equal '{"counter"=>1}'
+
+    response = response_for(
+      :app => [incrementor, { :secret => "test" }],
+      :cookie => "rack.session="
+    )
+    response.body.must_equal '{"counter"=>1}'
+  end
+
+  it "loads from a cookie with integrity hash" do
+    app = [incrementor, { :secret => "test" }]
+
+    response = response_for(:app => app)
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>2}'
+
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>3}'
+
+    app = [incrementor, { :secret => "other" }]
+
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>1}'
+  end
+
+  it "loads from a cookie with accept-only integrity hash for graceful key rotation" do
+    response = response_for(:app => [incrementor, { :secret => "test" }])
+
+    app = [incrementor, { :secret => "test2", :old_secret => "test" }]
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>2}'
+
+    app = [incrementor, { :secret => "test3", :old_secret => "test2" }]
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>3}'
+  end
+
+  it "ignores tampered with session cookies" do
+    app = [incrementor, { :secret => "test" }]
+    response = response_for(:app => app)
+    response.body.must_equal '{"counter"=>1}'
+
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>2}'
+
+    _, digest = response["Set-Cookie"].split("--")
+    tampered_with_cookie = "hackerman-was-here" + "--" + digest
+
+    response = response_for(:app => app, :cookie => tampered_with_cookie)
+    response.body.must_equal '{"counter"=>1}'
+  end
+
+  it "supports either of secret or old_secret" do
+    app = [incrementor, { :secret => "test" }]
+    response = response_for(:app => app)
+    response.body.must_equal '{"counter"=>1}'
+
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>2}'
+
+    app = [incrementor, { :old_secret => "test" }]
+    response = response_for(:app => app)
+    response.body.must_equal '{"counter"=>1}'
+
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>2}'
+  end
+
+  it "supports custom digest class" do
+    app = [incrementor, { :secret => "test", hmac: OpenSSL::Digest::SHA256 }]
+
+    response = response_for(:app => app)
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>2}'
+
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>3}'
+
+    app = [incrementor, { :secret => "other" }]
+
+    response = response_for(:app => app, :cookie => response)
+    response.body.must_equal '{"counter"=>1}'
+  end
+
+  it "can handle Rack::Lint middleware" do
+    response = response_for(:app => incrementor)
+
+    lint = Rack::Lint.new(session_id)
+    response = response_for(:app => lint, :cookie => response)
+    response.body.wont_be :nil?
+  end
+
+  it "can handle middleware that inspects the env" do
+    class TestEnvInspector
+      def initialize(app)
+        @app = app
+      end
+      def call(env)
+        env.inspect
+        @app.call(env)
+      end
+    end
+
+    response = response_for(:app => incrementor)
+
+    inspector = TestEnvInspector.new(session_id)
+    response = response_for(:app => inspector, :cookie => response)
+    response.body.wont_be :nil?
+  end
+
+  it "returns the session id in the session hash" do
+    response = response_for(:app => incrementor)
+    response.body.must_equal '{"counter"=>1}'
+
+    response = response_for(:app => session_id, :cookie => response)
+    response.body.must_match(/"session_id"=>/)
+    response.body.must_match(/"counter"=>1/)
+  end
+
+  it "does not return a cookie if set to secure but not using ssl" do
+    app = [incrementor, { :secure => true }]
+
+    response = response_for(:app => app)
+    response["Set-Cookie"].must_be_nil
+
+    response = response_for(:app => app, :request => { "HTTPS" => "on" })
+    response["Set-Cookie"].wont_be :nil?
+    response["Set-Cookie"].must_match(/secure/)
+  end
+
+  it "does not return a cookie if cookie was not read/written" do
+    response = response_for(:app => nothing)
+    response["Set-Cookie"].must_be_nil
+  end
+
+  it "does not return a cookie if cookie was not written (only read)" do
+    response = response_for(:app => session_id)
+    response["Set-Cookie"].must_be_nil
+  end
+
+  it "returns even if not read/written if :expire_after is set" do
+    app = [nothing, { :expire_after => 3600 }]
+    request = { "rack.session" => { "not" => "empty" }}
+    response = response_for(:app => app, :request => request)
+    response["Set-Cookie"].wont_be :nil?
+  end
+
+  it "returns no cookie if no data was written and no session was created previously, even if :expire_after is set" do
+    app = [nothing, { :expire_after => 3600 }]
+    response = response_for(:app => app)
+    response["Set-Cookie"].must_be_nil
+  end
+
+  it "exposes :secret in env['rack.session.option']" do
+    response = response_for(:app => [session_option[:secret], { :secret => "foo" }])
+    response.body.must_equal '"foo"'
+  end
+
+  it "allows passing in a hash with session data from middleware in front" do
+    request = { 'rack.session' => { :foo => 'bar' }}
+    response = response_for(:app => session_id, :request => request)
+    response.body.must_match(/foo/)
+  end
+
+  it "allows modifying session data with session data from middleware in front" do
+    request = { 'rack.session' => { :foo => 'bar' }}
+    response = response_for(:app => incrementor, :request => request)
+    response.body.must_match(/counter/)
+    response.body.must_match(/foo/)
+  end
+
+end

--- a/test/spec_session_file.rb
+++ b/test/spec_session_file.rb
@@ -301,4 +301,11 @@ describe Rack::Session::File do
     response.body.must_match(/foo/)
   end
 
+  it "clears old files" do
+    app = [ incrementor, { gc_probability: 1, gc_maxlife: 0 }]
+    request = { 'rack.session' => { :foo => 'bar' }}
+    response = response_for(:app => app, :request => request)
+    assert_equal Dir.entries(File.join(Dir.tmpdir(), 'file-rack')).size, 2
+  end
+
 end


### PR DESCRIPTION
This pull request adds new file-based session mechanism. Only session id is stored in cookie (with hmac protection same way as Session::Cookie) and actual session is stored on disk using PStore.

Code is heavily inspired by how Session::Cookie works. Same with tests.

Please consider for merging, feedback is welcomed :)