### PR TITLE
Valid Rack::Deflater :if config example

### DIFF
--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -22,7 +22,7 @@ module Rack
     # [app] rack app instance
     # [options] hash of deflater options, i.e.
     #           'if' - a lambda enabling / disabling deflation based on returned boolean value
-    #                  e.g use Rack::Deflater, :if => lambda { |env, status, headers, body| body.map(&:bytesize).reduce(0, :+) > 512 }
+    #                  e.g use Rack::Deflater, :if => lambda { |*, body| sum=0; body.each { |i| sum += i.length }; sum > 512 }
     #           'include' - a list of content types that should be compressed
     #           'sync' - determines if the stream is going to be flused after every chunk.
     #                    Flushing after every chunk reduces latency for


### PR DESCRIPTION
Since Rack::File::Iterators can pass through here need a more generic check. The only iter defined for that class is `:each`.

Not to add cruft into `file.rb`, we just make a more long winded check.

Using the current example the error received:
```
NoMethodError: undefined method `map' for #<Rack::File::Iterator:0x007fea7321b898>
    /.../.rvm/gems/ruby-2.4.1/gems/rack-2.0.3/lib/rack/deflater.rb:114:in `should_deflate?'
```