### PR TITLE
 Enclose IPv6 address in X-Forwarded-Host in brackets

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -1,5 +1,6 @@
 require 'rack/utils'
 require 'rack/media_type'
+require 'resolv'
 
 module Rack
   # Rack::Request provides a convenient interface to a Rack
@@ -224,7 +225,12 @@ module Rack
 
       def host_with_port
         if forwarded = get_header(HTTP_X_FORWARDED_HOST)
-          forwarded.split(/,\s?/).last
+          host = forwarded.split(/,\s?/).last
+
+          # If the reverse proxy sends an IPv6 address without brackets,
+          # prevent the last hextet from being stripped off by host() by
+          # enclosing the address in brackets.
+          host =~ Resolv::IPv6::Regex ? "[#{host}]" : host
         else
           get_header(HTTP_HOST) || "#{get_header(SERVER_NAME) || get_header(SERVER_ADDR)}:#{get_header(SERVER_PORT)}"
         end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -124,6 +124,14 @@ class RackRequestTest < Minitest::Spec
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org:9292")
     req.host.must_equal "example.org"
 
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "192.168.1.1")
+    req.host.must_equal "192.168.1.1"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "1:2:3:4:5:6:7:8")
+    req.host.must_equal "[1:2:3:4:5:6:7:8]"
+
     env = Rack::MockRequest.env_for("/", "SERVER_ADDR" => "192.168.1.1", "SERVER_PORT" => "9292")
     env.delete("SERVER_NAME")
     req = make_request(env)


### PR DESCRIPTION
Prevent Rack::Request#host from stripping off the last hextet of an IPv6 address contained in X-Forwarded-Host (and returned by Rack::Request#host_with_port) by enclosing the address in brackets.

IPv6 addresses in the HTTP_HOST, SERVER_NAME, and SERVER_ADDR CGI variables will (should) always be enclosed in brackets.