### PR TITLE
Upgrade to CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+workflows:
+  version: 2
+
+  test:
+    jobs:
+      - test-ruby-2.2
+      - test-ruby-2.3
+      - test-ruby-2.4
+
+version: 2
+jobs:
+  test-ruby-2.2:
+    docker:
+      - image: circleci/ruby:2.2
+        # Spawn a process owned by root
+        # This works around an issue explained here:
+        # https://github.com/circleci/circleci-images/pull/132
+        command: sudo /bin/sh
+      - image: memcached:1.4
+    steps:
+      - checkout
+      - run: sudo apt-get install lighttpd libfcgi-dev libmemcached-dev
+
+      # Restore bundle cache
+      - type: cache-restore
+        key: rack-{{ checksum "rack.gemspec" }}
+
+      # Bundle install dependencies
+      - run: bundle install --path vendor/bundle
+
+      # Store bundle cache
+      - type: cache-save
+        key: rack-{{ checksum "rack.gemspec" }}
+        paths:
+          - vendor/bundle
+
+      - run: bundle exec rake ci
+
+  test-ruby-2.3:
+    docker:
+      - image: circleci/ruby:2.3
+        # Spawn a process owned by root
+        # This works around an issue explained here:
+        # https://github.com/circleci/circleci-images/pull/132
+        command: sudo /bin/sh
+      - image: memcached:1.4
+    steps:
+      - checkout
+      - run: sudo apt-get install lighttpd libfcgi-dev libmemcached-dev
+
+      # Restore bundle cache
+      - type: cache-restore
+        key: rack-{{ checksum "rack.gemspec" }}
+
+      # Bundle install dependencies
+      - run: bundle install --path vendor/bundle
+
+      # Store bundle cache
+      - type: cache-save
+        key: rack-{{ checksum "rack.gemspec" }}
+        paths:
+          - vendor/bundle
+
+      - run: bundle exec rake ci
+
+  test-ruby-2.4:
+    docker:
+      - image: circleci/ruby:2.4
+        # Spawn a process owned by root
+        # This works around an issue explained here:
+        # https://github.com/circleci/circleci-images/pull/132
+        command: sudo /bin/sh
+      - image: memcached:1.4
+    steps:
+      - checkout
+      - run: sudo apt-get install lighttpd libfcgi-dev libmemcached-dev
+
+      # Restore bundle cache
+      - type: cache-restore
+        key: rack-{{ checksum "rack.gemspec" }}
+
+      # Bundle install dependencies
+      - run: bundle install --path vendor/bundle
+
+      # Store bundle cache
+      - type: cache-save
+        key: rack-{{ checksum "rack.gemspec" }}
+        paths:
+          - vendor/bundle
+
+      - run: bundle exec rake ci
+
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,0 @@
-dependencies:
-  pre:
-    - sudo apt-get install lighttpd libfcgi-dev libmemcache-dev memcached
-machine:
-  ruby:
-    version: ruby-head


### PR DESCRIPTION
This config was written to support Workflows 2.0:
https://circleci.com/docs/2.0/workflows/

Particularly, we can use Workflows to run 3 parallel jobs
against a matrix of Ruby versions.

Here is an example workflow once it was passing:
https://circleci.com/workflow-run/57e7398c-d3df-4907-85bc-ab9258db6cf7

This particular job of the workflow shows a build on Ruby 2.4:
https://circleci.com/gh/zzak/rack/47

We use our official Ruby images which are based on `debian:jessie`.

I'm still planning to roll out something like `ruby:head`,
which would be a nightly build of trunk.

We ran into one issue with `Rack::Server` spec for `pidfile_process_status`,
due to these docker images spawning the entry point command as the user.

This is explained in depth here:
https://github.com/circleci/circleci-images/pull/132

In order to solve this, we add a command to the primary container
that spawns a process owned by root to get the build to pass.

Ideally this would be solved by mocking `Process.kill` in some way,
but a much more dramatic change to be sure.