### PR TITLE
Travis: use latest JRuby stable release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ rvm:
   - 2.4.1
   - ruby-head
   - rbx-2
-  - jruby-9.0.4.0
+  - jruby-9.1.15.0
   - jruby-head
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script: bundle exec rake ci
 rvm:
   - 2.2.7
   - 2.3.4
-  - 2.4.1
+  - 2.4.3
   - ruby-head
   - rbx-2
   - jruby-9.1.15.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ before_install:
 script: bundle exec rake ci
 
 rvm:
-  - 2.2.7
-  - 2.3.4
+  - 2.2.9
+  - 2.3.6
   - 2.4.3
+  - 2.5.0
   - ruby-head
   - rbx-2
   - jruby-9.1.15.0


### PR DESCRIPTION
This PR updates the CI matrix to use 

- latest JRuby http://jruby.org/2017/12/07/jruby-9-1-15-0.html
- latest patch versions of MRI