### PR TITLE
Allow subclasses to override ShowExceptions::TEMPLATE

### DIFF
--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -97,7 +97,7 @@ module Rack
     end
 
     def template
-      self.class::TEMPLATE
+      TEMPLATE
     end
 
     def h(obj)                  # :nodoc:

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -93,7 +93,11 @@ module Rack
         end
       }.compact
 
-      TEMPLATE.result(binding)
+      template.result(binding)
+    end
+
+    def template
+      self.class::TEMPLATE
     end
 
     def h(obj)                  # :nodoc:

--- a/test/spec_show_exceptions.rb
+++ b/test/spec_show_exceptions.rb
@@ -77,4 +77,22 @@ describe Rack::ShowExceptions do
     assert_match(res, /ShowExceptions/)
     assert_match(res, /unknown location/)
   end
+
+  it "allows subclasses to override template" do
+    c = Class.new(Rack::ShowExceptions) do
+      self::TEMPLATE = ERB.new("foo")
+    end
+
+    app = lambda { |env| raise RuntimeError, "", [] }
+
+    req = Rack::MockRequest.new(
+      Rack::Lint.new c.new(app)
+    )
+
+    res = req.get("/", "HTTP_ACCEPT" => "text/html")
+
+    res.must_be :server_error?
+    res.status.must_equal 500
+    res.body.must_equal "foo"
+  end
 end

--- a/test/spec_show_exceptions.rb
+++ b/test/spec_show_exceptions.rb
@@ -80,7 +80,11 @@ describe Rack::ShowExceptions do
 
   it "allows subclasses to override template" do
     c = Class.new(Rack::ShowExceptions) do
-      self::TEMPLATE = ERB.new("foo")
+      TEMPLATE = ERB.new("foo")
+
+      def template
+        TEMPLATE
+      end
     end
 
     app = lambda { |env| raise RuntimeError, "", [] }


### PR DESCRIPTION
This issue came up in the Sinatra project. Sinatra extends `Rack::ShowExceptions` to implement a custom template, but the only way to do that right now with this code:

https://github.com/sinatra/sinatra/blob/master/lib/sinatra/show_exceptions.rb#L364

```
Rack::ShowExceptions.send :remove_const, "TEMPLATE"
Rack::ShowExceptions.const_set "TEMPLATE", Sinatra::ShowExceptions::TEMPLATE
```

This was added after #922, but this causes problems when Sinatra is mounted along with other Rack apps.

See: sinatra/sinatra/issues/1376
  