### PR TITLE
Changing unavailable nginx document url

### DIFF
--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -53,7 +53,7 @@ module Rack
   # that it maps to. The middleware performs a simple substitution on the
   # resulting path.
   #
-  # See Also: https://www.nginx.com/resources/wiki/start/topics/examples/xsendfile/?highlight=sendfile
+  # See Also: https://www.nginx.com/resources/wiki/start/topics/examples/xsendfile
   #
   # === lighttpd
   #

--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -53,7 +53,7 @@ module Rack
   # that it maps to. The middleware performs a simple substitution on the
   # resulting path.
   #
-  # See Also: http://wiki.codemongers.com/NginxXSendfile
+  # See Also: https://www.nginx.com/resources/wiki/start/topics/examples/xsendfile/?highlight=sendfile
   #
   # === lighttpd
   #


### PR DESCRIPTION
The old nginx xsendfile document url is currently unavailable. So I found official nginx xsendfile document url. Hope this helps.