### PR TITLE
Add WABuR to list of frameworks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -54,6 +54,7 @@ These frameworks include Rack adapters in their distributions:
 * Sinatra
 * Sin
 * Vintage
+* WABuR
 * Waves
 * Wee
 * ... and many others.


### PR DESCRIPTION
The gem is at https://github.com/ohler55/wabur