### PR TITLE
Fix Rack::Utils.make_delete_cookie_header deletes all subpath cookies of a deleted cookie with path

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -276,7 +276,7 @@ module Rack
         if value[:domain]
           cookie =~ /\A#{escape(key)}=.*domain=#{value[:domain]}/
         elsif value[:path]
-          cookie =~ /\A#{escape(key)}=.*path=#{value[:path]}/
+          cookie =~ /\A#{escape(key)}=.*path=#{value[:path]}(;|\z)/
         else
           cookie =~ /\A#{escape(key)}=/
         end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -205,13 +205,16 @@ describe Rack::Response do
   it "can delete cookies with the same name with different paths" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :path => "/"}
-    response.set_cookie "foo", {:value => "bar", :path => "/path"}
+    response.set_cookie "foo", {:value => "bar", :path => "/a"}
+    response.set_cookie "foo", {:value => "bar", :path => "/a/b"}
     response["Set-Cookie"].must_equal ["foo=bar; path=/",
-                                         "foo=bar; path=/path"].join("\n")
+                                       "foo=bar; path=/a",
+                                       "foo=bar; path=/a/b"].join("\n")
 
-    response.delete_cookie "foo", :path => "/path"
+    response.delete_cookie "foo", :path => "/a"
     response["Set-Cookie"].must_equal ["foo=bar; path=/",
-                                         "foo=; path=/path; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
+                                       "foo=bar; path=/a/b",
+                                       "foo=; path=/a; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
   end
 
   it "can do redirects" do


### PR DESCRIPTION
If you run the test without the fix you'll see the issue.

This PR fixes the following problem:

The method incorrectly replaces the cookie in the array of cookies leading to all subpath cookies being completely missing from the response when child path cookie is deleted after parent path cookie. The method's behavior is inconsistent.

rack users may incorrectly assume that 
```
Rack::Utils.delete_cookie_header!(response.headers, 'foo', path: '/a/b')
Rack::Utils.delete_cookie_header!(response.headers, 'foo', path: '/a')
```
will remove both `path=/a` and `path=/a/b` cookies when in reality only `path=/a` is removed.

without the fix the only way to correctly perform such a removal it to order from parent to child
```
Rack::Utils.delete_cookie_header!(response.headers, 'foo', path: '/a')
Rack::Utils.delete_cookie_header!(response.headers, 'foo', path: '/a/b')
```

As per RFC6265 the path in `Set-Cookie` is matched exactly when setting a cookie, the "sub-directory" rule is not applicable here (it is only applicable to `Cookie` header when sending requests). Thus the order should not matter when setting (and removing) cookies by path.
