### PR TITLE
Correct the FCGI installation instructions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -170,9 +170,9 @@ Download and install lighttpd:
 
 Installing the FCGI libraries:
 
-    curl -O http://www.fastcgi.com/dist/fcgi-2.4.0.tar.gz
-    tar xzvf fcgi-2.4.0.tar.gz
-    cd fcgi-2.4.0
+    curl -O -k -L https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz
+    tar xvfz fcgi-2.4.1-SNAP-0910052249.tar.gz
+    cd fcgi-2.4.1-SNAP-0910052249
     ./configure --prefix=/usr/local
     make
     sudo make install


### PR DESCRIPTION



Fix the readme:

- I'm taking over #1102 since it has been open for a long time now (Thanks @yskn for opening the issue!)
- http://www.fastcgi.com is no longer available, this replaces the instruction to download the tar from a github archive
- Closes #1102

cc/ @rafaelfranca 