### PR TITLE
Backport pull request #1137 from unabridged/fix-eof-failure

### DIFF
--- a/lib/rack/methodoverride.rb
+++ b/lib/rack/methodoverride.rb
@@ -38,6 +38,9 @@ module Rack
     def method_override_param(req)
       req.POST[METHOD_OVERRIDE_PARAM_KEY]
     rescue Utils::InvalidParameterError, Utils::ParameterTypeError
+      req.env["rack.errors"].puts "Invalid or incomplete POST params"
+    rescue EOFError
+      req.env["rack.errors"].puts "Bad request content body"
     end
   end
 end

--- a/test/spec_methodoverride.rb
+++ b/test/spec_methodoverride.rb
@@ -65,12 +65,25 @@ EOF
                       "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size.to_s,
                       :method => "POST", :input => input)
-    begin
-      app.call env
-    rescue EOFError
-    end
+    app.call env
 
     env["REQUEST_METHOD"].should.equal "POST"
+  end
+
+  should "write error to RACK_ERRORS when given invalid multipart form data" do
+    input = <<EOF
+--AaB03x\r
+content-disposition: form-data; name="huge"; filename="huge"\r
+EOF
+    env = Rack::MockRequest.env_for("/",
+                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_LENGTH" => input.size.to_s,
+                      "rack.errors" => StringIO.new,
+                      :method => "POST", :input => input)
+    Rack::MethodOverride.new(proc { [200, {"Content-Type" => "text/plain"}, []] }).call env
+
+    env["rack.errors"].rewind
+    env["rack.errors"].read.should =~ /Bad request content body/
   end
 
   should "not modify REQUEST_METHOD for POST requests when the params are unparseable" do


### PR DESCRIPTION
Original commit message:
Fix MethodOverride EOFError failure

Converted changes from Rack 2.0 to work in Rack 1.6 which included
changing `RACK_ERRORS` to `rack.errors` and fixes to the tests (`it` to
`should` and `must_match` to `should =~`.

cc/ @rafaelfranca @tenderlove 