### PR TITLE
Attempt to fix the ruby head build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 
 before_install:
   - gem env version | grep '^\(2\|1.\(8\|9\|[0-9][0-9]\)\)' || gem update --system
-  - gem list -i bundler || gem install bundler
+  - gem install bundler
 
 script: bundle exec rake ci
 


### PR DESCRIPTION
Debugging builds with this PR

---

Always install bundler so it gets updated. This will fix the ruby-head
build that's failing on master and 1-6-stable with

```
bundler: failed to load command: rake
(/home/travis/build/rack/rack/vendor/bundle/ruby/2.6.0/bin/rake)
LoadError: cannot load such file -- bundler/dep_proxy
```