### PR TITLE
Update URLMap Spec

### DIFF
--- a/test/spec_urlmap.rb
+++ b/test/spec_urlmap.rb
@@ -117,6 +117,14 @@ describe Rack::URLMap do
     res.must_be :ok?
     res["X-Position"].must_equal "default.org"
 
+    res = Rack::MockRequest.new(map).get("/", "HTTP_HOST" => "any-host.org")
+    res.must_be :ok?
+    res["X-Position"].must_equal "default.org"
+
+    res = Rack::MockRequest.new(map).get("/", "HTTP_HOST" => "any-host.org", "HTTP_X_FORWARDED_HOST" => "any-host.org")
+    res.must_be :ok?
+    res["X-Position"].must_equal "default.org"
+
     res = Rack::MockRequest.new(map).get("/",
                                          "HTTP_HOST" => "example.org:9292",
                                          "SERVER_PORT" => "9292")


### PR DESCRIPTION
This PR modifies URLMap's functionality to fix #990.

Currently, when using URLMap, if you request a HTTP_HOST that isn't technically valid, instead of defaulting to whatever the first route is without a specified host, it fails, returning a 404. This is mainly apparent on reverse proxies (like mod_proxy) that add the HTTP_X_FORWARDED_HOST header. 

I can't say I'm wholly sure of every URLMap use case, but it passes all existing tests, plus two extra assertions. There aren't any existing tests for regex-based routes, so I'm not sure how it will work on those.