### PR TITLE
handle failure to upcase invalid UTF8 strings for `_method` values

### DIFF
--- a/lib/rack/methodoverride.rb
+++ b/lib/rack/methodoverride.rb
@@ -26,7 +26,11 @@ module Rack
       req = Request.new(env)
       method = method_override_param(req) ||
         env[HTTP_METHOD_OVERRIDE_HEADER]
-      method.to_s.upcase
+      begin
+        method.to_s.upcase
+      rescue ArgumentError
+        env["rack.errors"].puts "Invalid string for method"
+      end
     end
 
     private


### PR DESCRIPTION
👋  Hi folks, I recently encountered a case where a client was submitting invalid UTF8 characters in the "_method" parameter which was subsequently causing `method.to_s.upcase` to raise an `ArgumentError`.  This pull request proposes instead logging the failure to "rack.errors" in the environment and just not override `REQUEST_METHOD` with anything when this occurs.

I originally planned on raising `Rack::Utils::InvalidParameterError` but when I saw `method_override_param` uses `"rack.errors"` I switched to that:

https://github.com/mclark/rack/blob/a795740a6e071333ecc7b498fdeed24d58750da4/lib/rack/methodoverride.rb#L42-L48
```ruby
def method_override_param(req)
  req.POST[METHOD_OVERRIDE_PARAM_KEY]
rescue Utils::InvalidParameterError, Utils::ParameterTypeError
  req.env["rack.errors"].puts "Invalid or incomplete POST params"
rescue EOFError
  req.env["rack.errors"].puts "Bad request content body"
end
```

I'm happy to go either way of course, but if it raises we should probably also update the docs for [`InvalidParameterError`](https://github.com/mclark/rack/blob/a795740a6e071333ecc7b498fdeed24d58750da4/lib/rack/utils.rb#L29-L32) to be a little less specific to `parse_nested_query`.

I can open a PR on 2.0 (or master, whatever is preferred) as well if this change is desired, I was just thinking I'd let the discussion happen here first (based on `1.6-stable`) if that's cool with everyone. I guess I could have checked the process on that one first 😄 