### PR TITLE
Discards optional port information from X-Forwarded-For header's IP parsing

### DIFF
--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1218,6 +1218,20 @@ EOF
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '127.0.0.1, 3.4.5.6'
     res.body.must_equal '3.4.5.6'
 
+    # IPv6 format with optional port: "[2001:db8:cafe::17]:47011"
+    res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '[2001:db8:cafe::17]:47011'
+    res.body.must_equal '2001:db8:cafe::17'
+
+    res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '1.2.3.4, [2001:db8:cafe::17]:47011'
+    res.body.must_equal '2001:db8:cafe::17'
+
+    # IPv4 format with optional port: "192.0.2.43:47011"
+    res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '192.0.2.43:47011'
+    res.body.must_equal '192.0.2.43'
+
+    res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '1.2.3.4, 192.0.2.43:47011'
+    res.body.must_equal '192.0.2.43'
+
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => 'unknown,192.168.0.1'
     res.body.must_equal 'unknown'
 


### PR DESCRIPTION
Tests and documents the work from #1229 which should close #1227.

[RFC 7239](https://tools.ietf.org/html/rfc7239) describes an optional port specification in `X-Forwarded-For` that is [apparently implemented in Microsoft Azure Application Gateway](https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-faq).

The relevant examples from the RFC are in section 6:

```
             "192.0.2.43:47011"
             "[2001:db8:cafe::17]:47011"
```

This PR attempts to gently discard the port information from `X-Forwarded-For`.

Should also close #1229.