### PR TITLE
Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,18 @@ default-steps: &default-steps
 
   # Restore bundle cache
   - type: cache-restore
-    key: rack-{{ checksum "rack.gemspec" }}
+    key: rack-{{ checksum "rack.gemspec" }}-{{ checksum "Gemfile" }}
 
   # Bundle install dependencies
   - run: bundle install --path vendor/bundle
 
   # Store bundle cache
   - type: cache-save
-    key: rack-{{ checksum "rack.gemspec" }}
+    key: rack-{{ checksum "rack.gemspec" }}-{{ checksum "Gemfile" }}
     paths:
       - vendor/bundle
+
+  - run: bundle exec rubocop
 
   - run: bundle exec rake ci
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ AllCops:
   DisabledByDefault: true
   Exclude:
     - '**/vendor/**/*'
+
+# Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
+Style/HashSyntax:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  TargetRubyVersion: 2.2
+  DisabledByDefault: true
+  Exclude:
+    - '**/vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ c_platforms = Bundler::Dsl::VALID_PLATFORMS.dup.delete_if do |platform|
   platform =~ /jruby/
 end
 
+gem "rubocop", require: false
+
 # Alternative solution that might work, but it has bad interactions with
 # Gemfile.lock if that gets committed/reused:
 # c_platforms = [:mri] if Gem.platforms.last.os == "java"

--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,9 @@ gem "rubocop", require: false
 # c_platforms = [:mri] if Gem.platforms.last.os == "java"
 
 group :extra do
-  gem 'fcgi', :platforms => c_platforms
+  gem 'fcgi', platforms: c_platforms
   gem 'memcache-client'
-  gem 'thin', :platforms => c_platforms
+  gem 'thin', platforms: c_platforms
 end
 
 group :doc do

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 # Rakefile for Rack.  -*-ruby-*-
 
 desc "Run all the tests"
-task :default => [:test]
+task default: [:test]
 
 desc "Install gem dependencies"
 task :deps do
@@ -18,7 +18,7 @@ task :deps do
 end
 
 desc "Make an archive as .tar.gz"
-task :dist => %w[chmod ChangeLog SPEC rdoc] do
+task dist: %w[chmod ChangeLog SPEC rdoc] do
   sh "git archive --format=tar --prefix=#{release}/ HEAD^{tree} >#{release}.tar"
   sh "pax -waf #{release}.tar -s ':^:#{release}/:' SPEC ChangeLog doc rack.gemspec"
   sh "gzip -f -9 #{release}.tar"
@@ -33,7 +33,7 @@ task :officialrelease do
   sh "mv stage/#{release}.tar.gz stage/#{release}.gem ."
 end
 
-task :officialrelease_really => %w[SPEC dist gem] do
+task officialrelease_really: %w[SPEC dist gem] do
   sh "shasum #{release}.tar.gz #{release}.gem"
 end
 
@@ -48,7 +48,7 @@ task :chmod do
 end
 
 desc "Generate a ChangeLog"
-task :changelog => %w[ChangeLog]
+task changelog: %w[ChangeLog]
 
 file '.git/index'
 file "ChangeLog" => '.git/index' do
@@ -83,7 +83,7 @@ file "SPEC" => 'lib/rack/lint.rb' do
 end
 
 desc "Run all the fast + platform agnostic tests"
-task :test => 'SPEC' do
+task test: 'SPEC' do
   opts     = ENV['TEST'] || ''
   specopts = ENV['TESTOPTS']
 
@@ -91,15 +91,15 @@ task :test => 'SPEC' do
 end
 
 desc "Run all the tests we run on CI"
-task :ci => :test
+task ci: :test
 
-task :gem => ["SPEC"] do
+task gem: ["SPEC"] do
   sh "gem build rack.gemspec"
 end
 
-task :doc => :rdoc
+task doc: :rdoc
 desc "Generate RDoc documentation"
-task :rdoc => %w[ChangeLog SPEC] do
+task rdoc: %w[ChangeLog SPEC] do
   sh(*%w{rdoc --line-numbers --main README.rdoc
               --title 'Rack\ Documentation' --charset utf-8 -U -o doc} +
               %w{README.rdoc KNOWN-ISSUES SPEC ChangeLog} +
@@ -107,11 +107,11 @@ task :rdoc => %w[ChangeLog SPEC] do
   cp "contrib/rdoc.css", "doc/rdoc.css"
 end
 
-task :pushdoc => %w[rdoc] do
+task pushdoc: %w[rdoc] do
   sh "rsync -avz doc/ rack.rubyforge.org:/var/www/gforge-projects/rack/doc/"
 end
 
-task :pushsite => %w[pushdoc] do
+task pushsite: %w[pushdoc] do
   sh "cd site && git gc"
   sh "rsync -avz site/ rack.rubyforge.org:/var/www/gforge-projects/rack/"
   sh "cd site && git push"

--- a/example/protectedlobster.rb
+++ b/example/protectedlobster.rb
@@ -13,4 +13,4 @@ protected_lobster.realm = 'Lobster 2.0'
 
 pretty_protected_lobster = Rack::ShowStatus.new(Rack::ShowExceptions.new(protected_lobster))
 
-Rack::Server.start :app => pretty_protected_lobster, :Port => 9292
+Rack::Server.start app: pretty_protected_lobster, Port: 9292

--- a/lib/rack/auth/digest/md5.rb
+++ b/lib/rack/auth/digest/md5.rb
@@ -49,7 +49,7 @@ module Rack
 
           if valid?(auth)
             if auth.nonce.stale?
-              return unauthorized(challenge(:stale => true))
+              return unauthorized(challenge(stale: true))
             else
               env['REMOTE_USER'] = auth.username
 

--- a/lib/rack/handler/scgi.rb
+++ b/lib/rack/handler/scgi.rb
@@ -12,10 +12,10 @@ module Rack
 
       def self.run(app, options=nil)
         options[:Socket] = UNIXServer.new(options[:File]) if options[:File]
-        new(options.merge(:app=>app,
-                          :host=>options[:Host],
-                          :port=>options[:Port],
-                          :socket=>options[:Socket])).listen
+        new(options.merge(app: app,
+                          host: options[:Host],
+                          port: options[:Port],
+                          socket: options[:Socket])).listen
       end
 
       def self.valid_options

--- a/lib/rack/lobster.rb
+++ b/lib/rack/lobster.rb
@@ -67,6 +67,6 @@ if $0 == __FILE__
   require 'rack'
   require 'rack/show_exceptions'
   Rack::Server.start(
-    :app => Rack::ShowExceptions.new(Rack::Lint.new(Rack::Lobster.new)), :Port => 9292
+    app: Rack::ShowExceptions.new(Rack::Lint.new(Rack::Lobster.new)), Port: 9292
   )
 end

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -64,7 +64,7 @@ module Rack
     def options(uri, opts={}) request(OPTIONS, uri, opts) end
 
     def request(method=GET, uri="", opts={})
-      env = self.class.env_for(uri, opts.merge(:method => method))
+      env = self.class.env_for(uri, opts.merge(method: method))
 
       if opts[:lint]
         app = Rack::Lint.new(@app)

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -94,14 +94,14 @@ module Rack
               # those which give the lone filename.
               fn = filename.split(/[\/\\]/).last
 
-              data = {:filename => fn, :type => content_type,
-                      :name => name, :tempfile => body, :head => head}
+              data = {filename: fn, type: content_type,
+                      name: name, tempfile: body, head: head}
             elsif !filename && content_type && body.is_a?(IO)
               body.rewind
 
               # Generic multipart cases, not coming from a form
-              data = {:type => content_type,
-                      :name => name, :tempfile => body, :head => head}
+              data = {type: content_type,
+                      name: name, tempfile: body, head: head}
             end
 
             yield data

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -226,12 +226,12 @@ module Rack
       default_host = environment == 'development' ? 'localhost' : '0.0.0.0'
 
       {
-        :environment => environment,
-        :pid         => nil,
-        :Port        => 9292,
-        :Host        => default_host,
-        :AccessLog   => [],
-        :config      => "config.ru"
+        environment: environment,
+        pid: nil,
+        Port: 9292,
+        Host: default_host,
+        AccessLog: [],
+        config: "config.ru"
       }
     end
 

--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -201,17 +201,17 @@ module Rack
 
       class Persisted
         DEFAULT_OPTIONS = {
-          :key =>           RACK_SESSION,
-          :path =>          '/',
-          :domain =>        nil,
-          :expire_after =>  nil,
-          :secure =>        false,
-          :httponly =>      true,
-          :defer =>         false,
-          :renew =>         false,
-          :sidbits =>       128,
-          :cookie_only =>   true,
-          :secure_random => ::SecureRandom
+          key: RACK_SESSION,
+          path: '/',
+          domain: nil,
+          expire_after: nil,
+          secure: false,
+          httponly: true,
+          defer: false,
+          renew: false,
+          sidbits: 128,
+          cookie_only: true,
+          secure_random: ::SecureRandom
         }.freeze
 
         attr_reader :key, :default_options, :sid_secure

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -119,7 +119,7 @@ module Rack
         Called from: #{caller[0]}.
         MSG
         @coder  = options[:coder] ||= Base64::Marshal.new
-        super(app, options.merge!(:cookie_only => true))
+        super(app, options.merge!(cookie_only: true))
       end
 
       private

--- a/lib/rack/session/memcache.rb
+++ b/lib/rack/session/memcache.rb
@@ -25,8 +25,8 @@ module Rack
       attr_reader :mutex, :pool
 
       DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge \
-        :namespace => 'rack:session',
-        :memcache_server => 'localhost:11211'
+        namespace: 'rack:session',
+        memcache_server: 'localhost:11211'
 
       def initialize(app, options={})
         super

--- a/lib/rack/session/pool.rb
+++ b/lib/rack/session/pool.rb
@@ -28,7 +28,7 @@ module Rack
 
     class Pool < Abstract::Persisted
       attr_reader :mutex, :pool
-      DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge :drop => false
+      DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge drop: false
 
       def initialize(app, options={})
         super

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -300,9 +300,9 @@ module Rack
       new_header = make_delete_cookie_header(header, key, value)
 
       add_cookie_to_header(new_header, key,
-                 {:value => '', :path => nil, :domain => nil,
-                   :max_age => '0',
-                   :expires => Time.at(0) }.merge(value))
+                 {value: '', path: nil, domain: nil,
+                   max_age: '0',
+                   expires: Time.at(0) }.merge(value))
 
     end
     module_function :add_remove_cookie_to_header

--- a/test/spec_auth_digest.rb
+++ b/test/spec_auth_digest.rb
@@ -18,7 +18,7 @@ describe Rack::Auth::Digest::MD5 do
   end
 
   def protected_app
-    Rack::Auth::Digest::MD5.new(unprotected_app, :realm => realm, :opaque => 'this-should-be-secret') do |username|
+    Rack::Auth::Digest::MD5.new(unprotected_app, realm: realm, opaque: 'this-should-be-secret') do |username|
       { 'Alice' => 'correct-password' }[username]
     end
   end
@@ -160,7 +160,7 @@ describe Rack::Auth::Digest::MD5 do
     begin
       Rack::Auth::Digest::Nonce.time_limit = 10
 
-      request_with_digest_auth 'GET', '/', 'Alice', 'correct-password', :wait => 1 do |response|
+      request_with_digest_auth 'GET', '/', 'Alice', 'correct-password', wait: 1 do |response|
         response.status.must_equal 200
         response.body.to_s.must_equal 'Hi Alice'
         response.headers['WWW-Authenticate'].wont_match(/\bstale=true\b/)
@@ -174,7 +174,7 @@ describe Rack::Auth::Digest::MD5 do
     begin
       Rack::Auth::Digest::Nonce.time_limit = 1
 
-      request_with_digest_auth 'GET', '/', 'Alice', 'correct-password', :wait => 2 do |response|
+      request_with_digest_auth 'GET', '/', 'Alice', 'correct-password', wait: 2 do |response|
         assert_digest_auth_challenge response
         response.headers['WWW-Authenticate'].must_match(/\bstale=true\b/)
       end
@@ -249,7 +249,7 @@ describe Rack::Auth::Digest::MD5 do
 
   it 'return application output if correct credentials given for PUT (using method override of POST)' do
     @request = Rack::MockRequest.new(protected_app_with_method_override)
-    request_with_digest_auth 'POST', '/', 'Alice', 'correct-password', :input => "_method=put" do |response|
+    request_with_digest_auth 'POST', '/', 'Alice', 'correct-password', input: "_method=put" do |response|
       response.status.must_equal 200
       response.body.to_s.must_equal 'Hi Alice'
     end

--- a/test/spec_cgi.rb
+++ b/test/spec_cgi.rb
@@ -72,7 +72,7 @@ describe Rack::Handler::CGI do
   end
 
   it "support HTTP auth" do
-    GET("/test", {:user => "ruth", :passwd => "secret"})
+    GET("/test", {user: "ruth", passwd: "secret"})
     response["HTTP_AUTHORIZATION"].must_equal "Basic cnV0aDpzZWNyZXQ="
   end
 

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -310,7 +310,7 @@ describe Rack::Deflater do
         'Content-Type' => 'text/plain'
       },
       'deflater_options' => {
-        :include => %w(text/plain)
+        include: %w(text/plain)
       }
     }
     verify(200, 'Hello World!', 'gzip', options)
@@ -322,7 +322,7 @@ describe Rack::Deflater do
         'Content-Type' => 'text/plain; charset=us-ascii'
       },
       'deflater_options' => {
-        :include => %w(text/plain)
+        include: %w(text/plain)
       }
     }
     verify(200, 'Hello World!', 'gzip', options)
@@ -331,7 +331,7 @@ describe Rack::Deflater do
   it "not deflate if content-type is not set but given in :include" do
     options = {
       'deflater_options' => {
-        :include => %w(text/plain)
+        include: %w(text/plain)
       }
     }
     verify(304, 'Hello World!', { 'gzip' => nil }, options)
@@ -343,7 +343,7 @@ describe Rack::Deflater do
         'Content-Type' => 'text/plain'
       },
       'deflater_options' => {
-        :include => %w(text/json)
+        include: %w(text/json)
       }
     }
     verify(200, 'Hello World!', { 'gzip' => nil }, options)
@@ -352,7 +352,7 @@ describe Rack::Deflater do
   it "deflate response if :if lambda evaluates to true" do
     options = {
       'deflater_options' => {
-        :if => lambda { |env, status, headers, body| true }
+        if: lambda { |env, status, headers, body| true }
       }
     }
     verify(200, 'Hello World!', deflate_or_gzip, options)
@@ -361,7 +361,7 @@ describe Rack::Deflater do
   it "not deflate if :if lambda evaluates to false" do
     options = {
       'deflater_options' => {
-        :if => lambda { |env, status, headers, body| false }
+        if: lambda { |env, status, headers, body| false }
       }
     }
     verify(200, 'Hello World!', { 'gzip' => nil }, options)
@@ -375,7 +375,7 @@ describe Rack::Deflater do
         'Content-Length' => response_len.to_s
       },
       'deflater_options' => {
-        :if => lambda { |env, status, headers, body|
+        if: lambda { |env, status, headers, body|
           headers['Content-Length'].to_i >= response_len
         }
       }
@@ -393,7 +393,7 @@ describe Rack::Deflater do
     end
 
     options = {
-      'deflater_options' => { :sync => false },
+      'deflater_options' => { sync: false },
       'app_body' => app_body,
       'skip_body_verify' => true,
     }

--- a/test/spec_fastcgi.rb
+++ b/test/spec_fastcgi.rb
@@ -73,7 +73,7 @@ describe Rack::Handler::FastCGI do
   end
 
   it "support HTTP auth" do
-    GET("/test.fcgi", {:user => "ruth", :passwd => "secret"})
+    GET("/test.fcgi", {user: "ruth", passwd: "secret"})
     response["HTTP_AUTHORIZATION"].must_equal "Basic cnV0aDpzZWNyZXQ="
   end
 

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -13,14 +13,14 @@ describe Rack::MethodOverride do
   end
 
   it "not affect GET requests" do
-    env = Rack::MockRequest.env_for("/?_method=delete", :method => "GET")
+    env = Rack::MockRequest.env_for("/?_method=delete", method: "GET")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "GET"
   end
 
   it "modify REQUEST_METHOD for POST requests when _method parameter is set" do
-    env = Rack::MockRequest.env_for("/", :method => "POST", :input => "_method=put")
+    env = Rack::MockRequest.env_for("/", method: "POST", input: "_method=put")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "PUT"
@@ -37,14 +37,14 @@ describe Rack::MethodOverride do
   end
 
   it "not modify REQUEST_METHOD if the method is unknown" do
-    env = Rack::MockRequest.env_for("/", :method => "POST", :input => "_method=foo")
+    env = Rack::MockRequest.env_for("/", method: "POST", input: "_method=foo")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "POST"
   end
 
   it "not modify REQUEST_METHOD when _method is nil" do
-    env = Rack::MockRequest.env_for("/", :method => "POST", :input => "foo=bar")
+    env = Rack::MockRequest.env_for("/", method: "POST", input: "foo=bar")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "POST"
@@ -52,8 +52,8 @@ describe Rack::MethodOverride do
 
   it "store the original REQUEST_METHOD prior to overriding" do
     env = Rack::MockRequest.env_for("/",
-            :method => "POST",
-            :input  => "_method=options")
+            method: "POST",
+            input: "_method=options")
     app.call env
 
     env["rack.methodoverride.original_method"].must_equal "POST"
@@ -90,7 +90,7 @@ EOF
   end
 
   it "not modify REQUEST_METHOD for POST requests when the params are unparseable" do
-    env = Rack::MockRequest.env_for("/", :method => "POST", :input => "(%bad-params%)")
+    env = Rack::MockRequest.env_for("/", method: "POST", input: "(%bad-params%)")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "POST"

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -56,53 +56,53 @@ describe Rack::MockRequest do
   end
 
   it "allow GET/POST/PUT/DELETE/HEAD" do
-    res = Rack::MockRequest.new(app).get("", :input => "foo")
+    res = Rack::MockRequest.new(app).get("", input: "foo")
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
 
-    res = Rack::MockRequest.new(app).post("", :input => "foo")
+    res = Rack::MockRequest.new(app).post("", input: "foo")
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
 
-    res = Rack::MockRequest.new(app).put("", :input => "foo")
+    res = Rack::MockRequest.new(app).put("", input: "foo")
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "PUT"
 
-    res = Rack::MockRequest.new(app).patch("", :input => "foo")
+    res = Rack::MockRequest.new(app).patch("", input: "foo")
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "PATCH"
 
-    res = Rack::MockRequest.new(app).delete("", :input => "foo")
+    res = Rack::MockRequest.new(app).delete("", input: "foo")
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "DELETE"
 
-    Rack::MockRequest.env_for("/", :method => "HEAD")["REQUEST_METHOD"]
+    Rack::MockRequest.env_for("/", method: "HEAD")["REQUEST_METHOD"]
      .must_equal "HEAD"
 
-    Rack::MockRequest.env_for("/", :method => "OPTIONS")["REQUEST_METHOD"]
+    Rack::MockRequest.env_for("/", method: "OPTIONS")["REQUEST_METHOD"]
      .must_equal "OPTIONS"
   end
 
   it "set content length" do
-    env = Rack::MockRequest.env_for("/", :input => "foo")
+    env = Rack::MockRequest.env_for("/", input: "foo")
     env["CONTENT_LENGTH"].must_equal "3"
 
-    env = Rack::MockRequest.env_for("/", :input => StringIO.new("foo"))
+    env = Rack::MockRequest.env_for("/", input: StringIO.new("foo"))
     env["CONTENT_LENGTH"].must_equal "3"
 
-    env = Rack::MockRequest.env_for("/", :input => Tempfile.new("name").tap { |t| t << "foo" })
+    env = Rack::MockRequest.env_for("/", input: Tempfile.new("name").tap { |t| t << "foo" })
     env["CONTENT_LENGTH"].must_equal "3"
 
-    env = Rack::MockRequest.env_for("/", :input => IO.pipe.first)
+    env = Rack::MockRequest.env_for("/", input: IO.pipe.first)
     env["CONTENT_LENGTH"].must_be_nil
   end
 
   it "allow posting" do
-    res = Rack::MockRequest.new(app).get("", :input => "foo")
+    res = Rack::MockRequest.new(app).get("", input: "foo")
     env = YAML.load(res.body)
     env["mock.postdata"].must_equal "foo"
 
-    res = Rack::MockRequest.new(app).post("", :input => StringIO.new("foo"))
+    res = Rack::MockRequest.new(app).post("", input: StringIO.new("foo"))
     env = YAML.load(res.body)
     env["mock.postdata"].must_equal "foo"
   end
@@ -157,7 +157,7 @@ describe Rack::MockRequest do
   end
 
   it "accept params and build query string for GET requests" do
-    res = Rack::MockRequest.new(app).get("/foo?baz=2", :params => {:foo => {:bar => "1"}})
+    res = Rack::MockRequest.new(app).get("/foo?baz=2", params: {foo: {bar: "1"}})
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["QUERY_STRING"].must_include "baz=2"
@@ -167,7 +167,7 @@ describe Rack::MockRequest do
   end
 
   it "accept raw input in params for GET requests" do
-    res = Rack::MockRequest.new(app).get("/foo?baz=2", :params => "foo[bar]=1")
+    res = Rack::MockRequest.new(app).get("/foo?baz=2", params: "foo[bar]=1")
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["QUERY_STRING"].must_include "baz=2"
@@ -177,7 +177,7 @@ describe Rack::MockRequest do
   end
 
   it "accept params and build url encoded params for POST requests" do
-    res = Rack::MockRequest.new(app).post("/foo", :params => {:foo => {:bar => "1"}})
+    res = Rack::MockRequest.new(app).post("/foo", params: {foo: {bar: "1"}})
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
     env["QUERY_STRING"].must_equal ""
@@ -187,7 +187,7 @@ describe Rack::MockRequest do
   end
 
   it "accept raw input in params for POST requests" do
-    res = Rack::MockRequest.new(app).post("/foo", :params => "foo[bar]=1")
+    res = Rack::MockRequest.new(app).post("/foo", params: "foo[bar]=1")
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
     env["QUERY_STRING"].must_equal ""
@@ -198,7 +198,7 @@ describe Rack::MockRequest do
 
   it "accept params and build multipart encoded params for POST requests" do
     files = Rack::Multipart::UploadedFile.new(File.join(File.dirname(__FILE__), "multipart", "file1.txt"))
-    res = Rack::MockRequest.new(app).post("/foo", :params => { "submit-name" => "Larry", "files" => files })
+    res = Rack::MockRequest.new(app).post("/foo", params: { "submit-name" => "Larry", "files" => files })
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
     env["QUERY_STRING"].must_equal ""
@@ -210,7 +210,7 @@ describe Rack::MockRequest do
 
   it "behave valid according to the Rack spec" do
     url = "https://bla.example.org:9292/meh/foo?bar"
-    Rack::MockRequest.new(app).get(url, :lint => true).
+    Rack::MockRequest.new(app).get(url, lint: true).
       must_be_kind_of Rack::MockResponse
   end
 
@@ -219,7 +219,7 @@ describe Rack::MockRequest do
     body   = Rack::BodyProxy.new(['hi']) { called = true }
     capp   = proc { |e| [200, {'Content-Type' => 'text/plain'}, body] }
     called.must_equal false
-    Rack::MockRequest.new(capp).get('/', :lint => true)
+    Rack::MockRequest.new(capp).get('/', lint: true)
     called.must_equal true
   end
 
@@ -259,7 +259,7 @@ describe Rack::MockResponse do
     res = Rack::MockRequest.new(app).get("/?status=307")
     res.must_be :redirect?
 
-    res = Rack::MockRequest.new(app).get("/?status=201", :lint => true)
+    res = Rack::MockRequest.new(app).get("/?status=201", lint: true)
     res.must_be :empty?
   end
 
@@ -281,7 +281,7 @@ describe Rack::MockResponse do
   end
 
   it "provide access to the Rack errors" do
-    res = Rack::MockRequest.new(app).get("/?error=foo", :lint => true)
+    res = Rack::MockRequest.new(app).get("/?error=foo", lint: true)
     res.must_be :ok?
     res.errors.wont_be :empty?
     res.errors.must_include "foo"
@@ -297,7 +297,7 @@ describe Rack::MockResponse do
 
   it "optionally make Rack errors fatal" do
     lambda {
-      Rack::MockRequest.new(app).get("/?error=foo", :fatal => true)
+      Rack::MockRequest.new(app).get("/?error=foo", fatal: true)
     }.must_raise Rack::MockRequest::FatalWarning
   end
 end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1337,7 +1337,7 @@ EOF
 
   class MyRequest < Rack::Request
     def params
-      {:foo => "bar"}
+      {foo: "bar"}
     end
   end
 
@@ -1350,7 +1350,7 @@ EOF
 
     req2 = MyRequest.new(env)
     req2.GET.must_equal "foo" => "bar"
-    req2.params.must_equal :foo => "bar"
+    req2.params.must_equal foo: "bar"
   end
 
   it "allow parent request to be instantiated after subclass request" do
@@ -1358,7 +1358,7 @@ EOF
 
     req1 = MyRequest.new(env)
     req1.GET.must_equal "foo" => "bar"
-    req1.params.must_equal :foo => "bar"
+    req1.params.must_equal foo: "bar"
 
     req2 = make_request(env)
     req2.GET.must_equal "foo" => "bar"

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -80,103 +80,103 @@ describe Rack::Response do
 
   it "can set cookies with the same name for multiple domains" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :domain => "sample.example.com"}
-    response.set_cookie "foo", {:value => "bar", :domain => ".example.com"}
+    response.set_cookie "foo", {value: "bar", domain: "sample.example.com"}
+    response.set_cookie "foo", {value: "bar", domain: ".example.com"}
     response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=bar; domain=.example.com"].join("\n")
   end
 
   it "formats the Cookie expiration date accordingly to RFC 6265" do
     response = Rack::Response.new
 
-    response.set_cookie "foo", {:value => "bar", :expires => Time.now+10}
+    response.set_cookie "foo", {value: "bar", expires: Time.now+10}
     response["Set-Cookie"].must_match(
       /expires=..., \d\d ... \d\d\d\d \d\d:\d\d:\d\d .../)
   end
 
   it "can set secure cookies" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :secure => true}
+    response.set_cookie "foo", {value: "bar", secure: true}
     response["Set-Cookie"].must_equal "foo=bar; secure"
   end
 
   it "can set http only cookies" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :httponly => true}
+    response.set_cookie "foo", {value: "bar", httponly: true}
     response["Set-Cookie"].must_equal "foo=bar; HttpOnly"
   end
 
   it "can set http only cookies with :http_only" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :http_only => true}
+    response.set_cookie "foo", {value: "bar", http_only: true}
     response["Set-Cookie"].must_equal "foo=bar; HttpOnly"
   end
 
   it "can set prefers :httponly for http only cookie setting when :httponly and :http_only provided" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :httponly => false, :http_only => true}
+    response.set_cookie "foo", {value: "bar", httponly: false, http_only: true}
     response["Set-Cookie"].must_equal "foo=bar"
   end
 
   it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => :lax}
+    response.set_cookie "foo", {value: "bar", same_site: :lax}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with symbol value :Lax" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => :lax}
+    response.set_cookie "foo", {value: "bar", same_site: :lax}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with string value 'Lax'" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => "Lax"}
+    response.set_cookie "foo", {value: "bar", same_site: "Lax"}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with boolean value true" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => true}
+    response.set_cookie "foo", {value: "bar", same_site: true}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with symbol value :strict" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => :strict}
+    response.set_cookie "foo", {value: "bar", same_site: :strict}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with symbol value :Strict" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => :Strict}
+    response.set_cookie "foo", {value: "bar", same_site: :Strict}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with string value 'Strict'" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => "Strict"}
+    response.set_cookie "foo", {value: "bar", same_site: "Strict"}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "validates the SameSite option value" do
     response = Rack::Response.new
     lambda {
-      response.set_cookie "foo", {:value => "bar", :same_site => "Foo"}
+      response.set_cookie "foo", {value: "bar", same_site: "Foo"}
     }.must_raise(ArgumentError).
       message.must_match(/Invalid SameSite value: "Foo"/)
   end
 
   it "can set SameSite cookies with symbol value" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => :Strict}
+    response.set_cookie "foo", {value: "bar", same_site: :Strict}
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   [ nil, false ].each do |non_truthy|
     it "omits SameSite attribute given a #{non_truthy.inspect} value" do
       response = Rack::Response.new
-      response.set_cookie "foo", {:value => "bar", :same_site => non_truthy}
+      response.set_cookie "foo", {value: "bar", same_site: non_truthy}
       response["Set-Cookie"].must_equal "foo=bar"
     end
   end
@@ -194,24 +194,24 @@ describe Rack::Response do
 
   it "can delete cookies with the same name from multiple domains" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :domain => "sample.example.com"}
-    response.set_cookie "foo", {:value => "bar", :domain => ".example.com"}
+    response.set_cookie "foo", {value: "bar", domain: "sample.example.com"}
+    response.set_cookie "foo", {value: "bar", domain: ".example.com"}
     response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=bar; domain=.example.com"].join("\n")
-    response.delete_cookie "foo", :domain => ".example.com"
+    response.delete_cookie "foo", domain: ".example.com"
     response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=; domain=.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
-    response.delete_cookie "foo", :domain => "sample.example.com"
+    response.delete_cookie "foo", domain: "sample.example.com"
     response["Set-Cookie"].must_equal ["foo=; domain=.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT",
                                          "foo=; domain=sample.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
   end
 
   it "can delete cookies with the same name with different paths" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :path => "/"}
-    response.set_cookie "foo", {:value => "bar", :path => "/path"}
+    response.set_cookie "foo", {value: "bar", path: "/"}
+    response.set_cookie "foo", {value: "bar", path: "/path"}
     response["Set-Cookie"].must_equal ["foo=bar; path=/",
                                          "foo=bar; path=/path"].join("\n")
 
-    response.delete_cookie "foo", :path => "/path"
+    response.delete_cookie "foo", path: "/path"
     response["Set-Cookie"].must_equal ["foo=bar; path=/",
                                          "foo=; path=/path; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
   end

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -28,12 +28,12 @@ describe Rack::Server do
   end
 
   it "overrides :config if :app is passed in" do
-    server = Rack::Server.new(:app => "FOO")
+    server = Rack::Server.new(app: "FOO")
     server.app.must_equal "FOO"
   end
 
   it "prefer to use :builder when it is passed in" do
-    server = Rack::Server.new(:builder => "run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['success']] }")
+    server = Rack::Server.new(builder: "run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['success']] }")
     server.app.class.must_equal Proc
     Rack::MockRequest.new(server.app).get("/").body.to_s.must_equal 'success'
   end
@@ -41,13 +41,13 @@ describe Rack::Server do
   it "allow subclasses to override middleware" do
     server = Class.new(Rack::Server).class_eval { def middleware; Hash.new [] end; self }
     server.middleware['deployment'].wont_equal []
-    server.new(:app => 'foo').middleware['deployment'].must_equal []
+    server.new(app: 'foo').middleware['deployment'].must_equal []
   end
 
   it "allow subclasses to override default middleware" do
     server = Class.new(Rack::Server).instance_eval { def default_middleware_by_environment; Hash.new [] end; self }
     server.middleware['deployment'].must_equal []
-    server.new(:app => 'foo').middleware['deployment'].must_equal []
+    server.new(app: 'foo').middleware['deployment'].must_equal []
   end
 
   it "only provide default middleware for development and deployment environments" do
@@ -55,29 +55,29 @@ describe Rack::Server do
   end
 
   it "always return an empty array for unknown environments" do
-    server = Rack::Server.new(:app => 'foo')
+    server = Rack::Server.new(app: 'foo')
     server.middleware['production'].must_equal []
   end
 
   it "not include Rack::Lint in deployment environment" do
-    server = Rack::Server.new(:app => 'foo')
+    server = Rack::Server.new(app: 'foo')
     server.middleware['deployment'].flatten.wont_include Rack::Lint
   end
 
   it "not include Rack::ShowExceptions in deployment environment" do
-    server = Rack::Server.new(:app => 'foo')
+    server = Rack::Server.new(app: 'foo')
     server.middleware['deployment'].flatten.wont_include Rack::ShowExceptions
   end
 
   it "include Rack::TempfileReaper in deployment environment" do
-    server = Rack::Server.new(:app => 'foo')
+    server = Rack::Server.new(app: 'foo')
     server.middleware['deployment'].flatten.must_include Rack::TempfileReaper
   end
 
   it "support CGI" do
     begin
       o, ENV["REQUEST_METHOD"] = ENV["REQUEST_METHOD"], 'foo'
-      server = Rack::Server.new(:app => 'foo')
+      server = Rack::Server.new(app: 'foo')
       server.server.name =~ /CGI/
       Rack::Server.logging_middleware.call(server).must_be_nil
     ensure
@@ -86,7 +86,7 @@ describe Rack::Server do
   end
 
   it "be quiet if said so" do
-    server = Rack::Server.new(:app => "FOO", :quiet => true)
+    server = Rack::Server.new(app: "FOO", quiet: true)
     Rack::Server.logging_middleware.call(server).must_be_nil
   end
 
@@ -120,15 +120,15 @@ describe Rack::Server do
     pidfile = Tempfile.open('pidfile') { |f| break f }
     FileUtils.rm pidfile.path
     server = Rack::Server.new(
-      :app         => app,
-      :environment => 'none',
-      :pid         => pidfile.path,
-      :Port        => TCPServer.open('127.0.0.1', 0){|s| s.addr[1] },
-      :Host        => '127.0.0.1',
-      :Logger      => WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
-      :AccessLog   => [],
-      :daemonize   => false,
-      :server      => 'webrick'
+      app: app,
+      environment: 'none',
+      pid: pidfile.path,
+      Port: TCPServer.open('127.0.0.1', 0){|s| s.addr[1] },
+      Host: '127.0.0.1',
+      Logger: WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
+      AccessLog: [],
+      daemonize: false,
+      server: 'webrick'
     )
     t = Thread.new { server.start { |s| Thread.current[:server] = s } }
     t.join(0.01) until t[:server] && t[:server].status != :Stop
@@ -142,34 +142,34 @@ describe Rack::Server do
 
   it "check pid file presence and running process" do
     pidfile = Tempfile.open('pidfile') { |f| f.write($$); break f }.path
-    server = Rack::Server.new(:pid => pidfile)
+    server = Rack::Server.new(pid: pidfile)
     server.send(:pidfile_process_status).must_equal :running
   end
 
   it "check pid file presence and dead process" do
     dead_pid = `echo $$`.to_i
     pidfile = Tempfile.open('pidfile') { |f| f.write(dead_pid); break f }.path
-    server = Rack::Server.new(:pid => pidfile)
+    server = Rack::Server.new(pid: pidfile)
     server.send(:pidfile_process_status).must_equal :dead
   end
 
   it "check pid file presence and exited process" do
     pidfile = Tempfile.open('pidfile') { |f| break f }.path
     ::File.delete(pidfile)
-    server = Rack::Server.new(:pid => pidfile)
+    server = Rack::Server.new(pid: pidfile)
     server.send(:pidfile_process_status).must_equal :exited
   end
 
   it "check pid file presence and not owned process" do
     pidfile = Tempfile.open('pidfile') { |f| f.write(1); break f }.path
-    server = Rack::Server.new(:pid => pidfile)
+    server = Rack::Server.new(pid: pidfile)
     server.send(:pidfile_process_status).must_equal :not_owned
   end
 
   it "not write pid file when it is created after check" do
     pidfile = Tempfile.open('pidfile') { |f| break f }.path
     ::File.delete(pidfile)
-    server = Rack::Server.new(:pid => pidfile)
+    server = Rack::Server.new(pid: pidfile)
     ::File.open(pidfile, 'w') { |f| f.write(1) }
     with_stderr do |err|
       lambda { server.send(:write_pid) }.must_raise SystemExit
@@ -182,7 +182,7 @@ describe Rack::Server do
 
   it "inform the user about existing pidfiles with running processes" do
     pidfile = Tempfile.open('pidfile') { |f| f.write(1); break f }.path
-    server = Rack::Server.new(:pid => pidfile)
+    server = Rack::Server.new(pid: pidfile)
     with_stderr do |err|
       lambda { server.start }.must_raise SystemExit
       err.rewind

--- a/test/spec_session_abstract_id.rb
+++ b/test/spec_session_abstract_id.rb
@@ -26,7 +26,7 @@ describe Rack::Session::Abstract::ID do
         'fake_hex'
       end
     end
-    id = Rack::Session::Abstract::ID.new nil, :secure_random => secure_random.new
+    id = Rack::Session::Abstract::ID.new nil, secure_random: secure_random.new
     id.send(:generate_sid).must_equal 'fake_hex'
   end
 

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -150,22 +150,22 @@ describe Rack::Session::Cookie do
     Rack::Session::Cookie.new(incrementor)
     @warnings.first.must_match(/no secret/i)
     @warnings.clear
-    Rack::Session::Cookie.new(incrementor, :secret => 'abc')
+    Rack::Session::Cookie.new(incrementor, secret: 'abc')
     @warnings.must_be :empty?
   end
 
   it "doesn't warn if coder is configured to handle encoding" do
     Rack::Session::Cookie.new(
       incrementor,
-      :coder => Object.new,
-      :let_coder_handle_secure_encoding => true)
+      coder: Object.new,
+      let_coder_handle_secure_encoding: true)
     @warnings.must_be :empty?
   end
 
   it "still warns if coder is not set" do
     Rack::Session::Cookie.new(
       incrementor,
-      :let_coder_handle_secure_encoding => true)
+      let_coder_handle_secure_encoding: true)
     @warnings.first.must_match(/no secret/i)
   end
 
@@ -180,7 +180,7 @@ describe Rack::Session::Cookie do
       def encode(str); @calls << :encode; str; end
       def decode(str); @calls << :decode; str; end
     }.new
-    response = response_for(:app => [incrementor, { :coder => identity }])
+    response = response_for(app: [incrementor, { coder: identity }])
 
     response["Set-Cookie"].must_include "rack.session="
     response.body.must_equal '{"counter"=>1}'
@@ -188,47 +188,47 @@ describe Rack::Session::Cookie do
   end
 
   it "creates a new cookie" do
-    response = response_for(:app => incrementor)
+    response = response_for(app: incrementor)
     response["Set-Cookie"].must_include "rack.session="
     response.body.must_equal '{"counter"=>1}'
   end
 
   it "loads from a cookie" do
-    response = response_for(:app => incrementor)
+    response = response_for(app: incrementor)
 
-    response = response_for(:app => incrementor, :cookie => response)
+    response = response_for(app: incrementor, cookie: response)
     response.body.must_equal '{"counter"=>2}'
 
-    response = response_for(:app => incrementor, :cookie => response)
+    response = response_for(app: incrementor, cookie: response)
     response.body.must_equal '{"counter"=>3}'
   end
 
   it "renew session id" do
-    response = response_for(:app => incrementor)
+    response = response_for(app: incrementor)
     cookie   = response['Set-Cookie']
-    response = response_for(:app => only_session_id, :cookie => cookie)
+    response = response_for(app: only_session_id, cookie: cookie)
     cookie   = response['Set-Cookie'] if response['Set-Cookie']
 
     response.body.wont_equal ""
     old_session_id = response.body
 
-    response = response_for(:app => renewer, :cookie => cookie)
+    response = response_for(app: renewer, cookie: cookie)
     cookie   = response['Set-Cookie'] if response['Set-Cookie']
-    response = response_for(:app => only_session_id, :cookie => cookie)
+    response = response_for(app: only_session_id, cookie: cookie)
 
     response.body.wont_equal ""
     response.body.wont_equal old_session_id
   end
 
   it "destroys session" do
-    response = response_for(:app => incrementor)
-    response = response_for(:app => only_session_id, :cookie => response)
+    response = response_for(app: incrementor)
+    response = response_for(app: only_session_id, cookie: response)
 
     response.body.wont_equal ""
     old_session_id = response.body
 
-    response = response_for(:app => destroy_session, :cookie => response)
-    response = response_for(:app => only_session_id, :cookie => response)
+    response = response_for(app: destroy_session, cookie: response)
+    response = response_for(app: only_session_id, cookie: response)
 
     response.body.wont_equal ""
     response.body.wont_equal old_session_id
@@ -236,104 +236,104 @@ describe Rack::Session::Cookie do
 
   it "survives broken cookies" do
     response = response_for(
-      :app => incrementor,
-      :cookie => "rack.session=blarghfasel"
+      app: incrementor,
+      cookie: "rack.session=blarghfasel"
     )
     response.body.must_equal '{"counter"=>1}'
 
     response = response_for(
-      :app => [incrementor, { :secret => "test" }],
-      :cookie => "rack.session="
+      app: [incrementor, { secret: "test" }],
+      cookie: "rack.session="
     )
     response.body.must_equal '{"counter"=>1}'
   end
 
   it "barks on too big cookies" do
     lambda{
-      response_for(:app => bigcookie, :request => { :fatal => true })
+      response_for(app: bigcookie, request: { fatal: true })
     }.must_raise Rack::MockRequest::FatalWarning
   end
 
   it "loads from a cookie with integrity hash" do
-    app = [incrementor, { :secret => "test" }]
+    app = [incrementor, { secret: "test" }]
 
-    response = response_for(:app => app)
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>2}'
 
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>3}'
 
-    app = [incrementor, { :secret => "other" }]
+    app = [incrementor, { secret: "other" }]
 
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>1}'
   end
 
   it "loads from a cookie with accept-only integrity hash for graceful key rotation" do
-    response = response_for(:app => [incrementor, { :secret => "test" }])
+    response = response_for(app: [incrementor, { secret: "test" }])
 
-    app = [incrementor, { :secret => "test2", :old_secret => "test" }]
-    response = response_for(:app => app, :cookie => response)
+    app = [incrementor, { secret: "test2", old_secret: "test" }]
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>2}'
 
-    app = [incrementor, { :secret => "test3", :old_secret => "test2" }]
-    response = response_for(:app => app, :cookie => response)
+    app = [incrementor, { secret: "test3", old_secret: "test2" }]
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>3}'
   end
 
   it "ignores tampered with session cookies" do
-    app = [incrementor, { :secret => "test" }]
-    response = response_for(:app => app)
+    app = [incrementor, { secret: "test" }]
+    response = response_for(app: app)
     response.body.must_equal '{"counter"=>1}'
 
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>2}'
 
     _, digest = response["Set-Cookie"].split("--")
     tampered_with_cookie = "hackerman-was-here" + "--" + digest
 
-    response = response_for(:app => app, :cookie => tampered_with_cookie)
+    response = response_for(app: app, cookie: tampered_with_cookie)
     response.body.must_equal '{"counter"=>1}'
   end
 
   it "supports either of secret or old_secret" do
-    app = [incrementor, { :secret => "test" }]
-    response = response_for(:app => app)
+    app = [incrementor, { secret: "test" }]
+    response = response_for(app: app)
     response.body.must_equal '{"counter"=>1}'
 
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>2}'
 
-    app = [incrementor, { :old_secret => "test" }]
-    response = response_for(:app => app)
+    app = [incrementor, { old_secret: "test" }]
+    response = response_for(app: app)
     response.body.must_equal '{"counter"=>1}'
 
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>2}'
   end
 
   it "supports custom digest class" do
-    app = [incrementor, { :secret => "test", hmac: OpenSSL::Digest::SHA256 }]
+    app = [incrementor, { secret: "test", hmac: OpenSSL::Digest::SHA256 }]
 
-    response = response_for(:app => app)
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>2}'
 
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>3}'
 
-    app = [incrementor, { :secret => "other" }]
+    app = [incrementor, { secret: "other" }]
 
-    response = response_for(:app => app, :cookie => response)
+    response = response_for(app: app, cookie: response)
     response.body.must_equal '{"counter"=>1}'
   end
 
   it "can handle Rack::Lint middleware" do
-    response = response_for(:app => incrementor)
+    response = response_for(app: incrementor)
 
     lint = Rack::Lint.new(session_id)
-    response = response_for(:app => lint, :cookie => response)
+    response = response_for(app: lint, cookie: response)
     response.body.wont_be :nil?
   end
 
@@ -348,75 +348,75 @@ describe Rack::Session::Cookie do
       end
     end
 
-    response = response_for(:app => incrementor)
+    response = response_for(app: incrementor)
 
     inspector = TestEnvInspector.new(session_id)
-    response = response_for(:app => inspector, :cookie => response)
+    response = response_for(app: inspector, cookie: response)
     response.body.wont_be :nil?
   end
 
   it "returns the session id in the session hash" do
-    response = response_for(:app => incrementor)
+    response = response_for(app: incrementor)
     response.body.must_equal '{"counter"=>1}'
 
-    response = response_for(:app => session_id, :cookie => response)
+    response = response_for(app: session_id, cookie: response)
     response.body.must_match(/"session_id"=>/)
     response.body.must_match(/"counter"=>1/)
   end
 
   it "does not return a cookie if set to secure but not using ssl" do
-    app = [incrementor, { :secure => true }]
+    app = [incrementor, { secure: true }]
 
-    response = response_for(:app => app)
+    response = response_for(app: app)
     response["Set-Cookie"].must_be_nil
 
-    response = response_for(:app => app, :request => { "HTTPS" => "on" })
+    response = response_for(app: app, request: { "HTTPS" => "on" })
     response["Set-Cookie"].wont_be :nil?
     response["Set-Cookie"].must_match(/secure/)
   end
 
   it "does not return a cookie if cookie was not read/written" do
-    response = response_for(:app => nothing)
+    response = response_for(app: nothing)
     response["Set-Cookie"].must_be_nil
   end
 
   it "does not return a cookie if cookie was not written (only read)" do
-    response = response_for(:app => session_id)
+    response = response_for(app: session_id)
     response["Set-Cookie"].must_be_nil
   end
 
   it "returns even if not read/written if :expire_after is set" do
-    app = [nothing, { :expire_after => 3600 }]
+    app = [nothing, { expire_after: 3600 }]
     request = { "rack.session" => { "not" => "empty" }}
-    response = response_for(:app => app, :request => request)
+    response = response_for(app: app, request: request)
     response["Set-Cookie"].wont_be :nil?
   end
 
   it "returns no cookie if no data was written and no session was created previously, even if :expire_after is set" do
-    app = [nothing, { :expire_after => 3600 }]
-    response = response_for(:app => app)
+    app = [nothing, { expire_after: 3600 }]
+    response = response_for(app: app)
     response["Set-Cookie"].must_be_nil
   end
 
   it "exposes :secret in env['rack.session.option']" do
-    response = response_for(:app => [session_option[:secret], { :secret => "foo" }])
+    response = response_for(app: [session_option[:secret], { secret: "foo" }])
     response.body.must_equal '"foo"'
   end
 
   it "exposes :coder in env['rack.session.option']" do
-    response = response_for(:app => session_option[:coder])
+    response = response_for(app: session_option[:coder])
     response.body.must_match(/Base64::Marshal/)
   end
 
   it "allows passing in a hash with session data from middleware in front" do
-    request = { 'rack.session' => { :foo => 'bar' }}
-    response = response_for(:app => session_id, :request => request)
+    request = { 'rack.session' => { foo: 'bar' }}
+    response = response_for(app: session_id, request: request)
     response.body.must_match(/foo/)
   end
 
   it "allows modifying session data with session data from middleware in front" do
-    request = { 'rack.session' => { :foo => 'bar' }}
-    response = response_for(:app => incrementor, :request => request)
+    request = { 'rack.session' => { foo: 'bar' }}
+    response = response_for(app: incrementor, request: request)
     response.body.must_match(/counter/)
     response.body.must_match(/foo/)
   end
@@ -435,10 +435,10 @@ describe Rack::Session::Cookie do
       def encode(hash); hash.inspect end
       def decode(str); eval(str) if str; end
     }.new
-    _app = [ app, { :secret => "test", :coder => unsafe_coder } ]
-    response = response_for(:app => _app)
+    _app = [ app, { secret: "test", coder: unsafe_coder } ]
+    response = response_for(app: _app)
     response.body.must_equal "1--"
-    response = response_for(:app => _app, :cookie => response)
+    response = response_for(app: _app, cookie: response)
     response.body.must_equal "1--2--"
   end
 end

--- a/test/spec_session_memcache.rb
+++ b/test/spec_session_memcache.rb
@@ -38,17 +38,17 @@ begin
 
     it "faults on no connection" do
       lambda {
-        Rack::Session::Memcache.new(incrementor, :memcache_server => 'nosuchserver')
+        Rack::Session::Memcache.new(incrementor, memcache_server: 'nosuchserver')
       }.must_raise(RuntimeError).message.must_equal 'No memcache servers'
     end
 
     it "connects to existing server" do
-      test_pool = MemCache.new(incrementor, :namespace => 'test:rack:session')
+      test_pool = MemCache.new(incrementor, namespace: 'test:rack:session')
       test_pool.namespace.must_equal 'test:rack:session'
     end
 
     it "passes options to MemCache" do
-      pool = Rack::Session::Memcache.new(incrementor, :namespace => 'test:rack:session')
+      pool = Rack::Session::Memcache.new(incrementor, namespace: 'test:rack:session')
       pool.pool.namespace.must_equal 'test:rack:session'
     end
 
@@ -82,7 +82,7 @@ begin
     end
 
     it "determines session from params" do
-      pool = Rack::Session::Memcache.new(incrementor, :cookie_only => false)
+      pool = Rack::Session::Memcache.new(incrementor, cookie_only: false)
       req = Rack::MockRequest.new(pool)
       res = req.get("/")
       sid = res["Set-Cookie"][session_match, 1]
@@ -103,7 +103,7 @@ begin
     end
 
     it "maintains freshness" do
-      pool = Rack::Session::Memcache.new(incrementor, :expire_after => 3)
+      pool = Rack::Session::Memcache.new(incrementor, expire_after: 3)
       res = Rack::MockRequest.new(pool).get('/')
       res.body.must_include '"counter"=>1'
       cookie = res["Set-Cookie"]
@@ -217,8 +217,8 @@ begin
       hash_check = proc do |env|
         session = env['rack.session']
         unless session.include? 'test'
-          session.update :a => :b, :c => { :d => :e },
-            :f => { :g => { :h => :i} }, 'test' => true
+          session.update :a => :b, :c => { d: :e },
+            :f => { g: { h: :i} }, 'test' => true
         else
           session[:f][:g][:h] = :j
         end

--- a/test/spec_session_pool.rb
+++ b/test/spec_session_pool.rb
@@ -199,13 +199,13 @@ describe Rack::Session::Pool do
   end
 
   it "returns even if not read/written if :expire_after is set" do
-    app = Rack::Session::Pool.new(nothing, :expire_after => 3600)
+    app = Rack::Session::Pool.new(nothing, expire_after: 3600)
     res = Rack::MockRequest.new(app).get("/", 'rack.session' => {'not' => 'empty'})
     res["Set-Cookie"].wont_be :nil?
   end
 
   it "returns no cookie if no data was written and no session was created previously, even if :expire_after is set" do
-    app = Rack::Session::Pool.new(nothing, :expire_after => 3600)
+    app = Rack::Session::Pool.new(nothing, expire_after: 3600)
     res = Rack::MockRequest.new(app).get("/")
     res["Set-Cookie"].must_be_nil
   end

--- a/test/spec_show_status.rb
+++ b/test/spec_show_status.rb
@@ -17,7 +17,7 @@ describe Rack::ShowStatus do
         [404, {"Content-Type" => "text/plain", "Content-Length" => "0"}, []]
     }))
 
-    res = req.get("/", :lint => true)
+    res = req.get("/", lint: true)
     res.must_be :not_found?
     res.wont_be_empty
 
@@ -34,7 +34,7 @@ describe Rack::ShowStatus do
           [404, {"Content-Type" => "text/plain", "Content-Length" => "0"}, []]
     }))
 
-    res = req.get("/", :lint => true)
+    res = req.get("/", lint: true)
     res.must_be :not_found?
     res.wont_be_empty
 
@@ -53,7 +53,7 @@ describe Rack::ShowStatus do
           [500, {"Content-Type" => "text/plain", "Content-Length" => "0"}, []]
     }))
 
-    res = req.get("/", :lint => true)
+    res = req.get("/", lint: true)
     res.wont_be_empty
 
     res["Content-Type"].must_equal "text/html"
@@ -69,7 +69,7 @@ describe Rack::ShowStatus do
           [404, {"Content-Type" => "text/plain", "Content-Length" => "4"}, ["foo!"]]
     }))
 
-    res = req.get("/", :lint => true)
+    res = req.get("/", lint: true)
     res.must_be :not_found?
 
     res.body.must_equal "foo!"
@@ -80,7 +80,7 @@ describe Rack::ShowStatus do
 
     req = Rack::MockRequest.new(
       show_status(lambda{|env| [401, headers, []] }))
-    res = req.get("/", :lint => true)
+    res = req.get("/", lint: true)
 
     res["WWW-Authenticate"].must_equal "Basic blah"
   end
@@ -93,7 +93,7 @@ describe Rack::ShowStatus do
           [404, {"Content-Type" => "text/plain", "Content-Length" => "4"}, ["foo!"]]
     }))
 
-    res = req.get("/", :lint => true)
+    res = req.get("/", lint: true)
     res.must_be :not_found?
     res.wont_be_empty
 

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -20,11 +20,11 @@ describe Rack::Static do
 
   root = File.expand_path(File.dirname(__FILE__))
 
-  OPTIONS = {:urls => ["/cgi"], :root => root}
-  STATIC_OPTIONS = {:urls => [""], :root => "#{root}/static", :index => 'index.html'}
-  HASH_OPTIONS = {:urls => {"/cgi/sekret" => 'cgi/test'}, :root => root}
-  HASH_ROOT_OPTIONS = {:urls => {"/" => "static/foo.html"}, :root => root}
-  GZIP_OPTIONS = {:urls => ["/cgi"], :root => root, :gzip=>true}
+  OPTIONS = {urls: ["/cgi"], root: root}
+  STATIC_OPTIONS = {urls: [""], root: "#{root}/static", index: 'index.html'}
+  HASH_OPTIONS = {urls: {"/cgi/sekret" => 'cgi/test'}, root: root}
+  HASH_ROOT_OPTIONS = {urls: {"/" => "static/foo.html"}, root: root}
+  GZIP_OPTIONS = {urls: ["/cgi"], root: root, gzip: true}
 
   before do
   @request = Rack::MockRequest.new(static(DummyApp.new, OPTIONS))
@@ -113,14 +113,14 @@ describe Rack::Static do
   end
 
   it "supports serving fixed cache-control (legacy option)" do
-    opts = OPTIONS.merge(:cache_control => 'public')
+    opts = OPTIONS.merge(cache_control: 'public')
     request = Rack::MockRequest.new(static(DummyApp.new, opts))
     res = request.get("/cgi/test")
     res.must_be :ok?
     res.headers['Cache-Control'].must_equal 'public'
   end
 
-  HEADER_OPTIONS = {:urls => ["/cgi"], :root => root, :header_rules => [
+  HEADER_OPTIONS = {urls: ["/cgi"], root: root, header_rules: [
     [:all, {'Cache-Control' => 'public, max-age=100'}],
     [:fonts, {'Cache-Control' => 'public, max-age=200'}],
     [%w(png jpg), {'Cache-Control' => 'public, max-age=300'}],
@@ -172,8 +172,8 @@ describe Rack::Static do
 
   it "prioritizes header rules over fixed cache-control setting (legacy option)" do
     opts = OPTIONS.merge(
-      :cache_control => 'public, max-age=24',
-      :header_rules => [
+      cache_control: 'public, max-age=24',
+      header_rules: [
         [:all, {'Cache-Control' => 'public, max-age=42'}]
       ])
 

--- a/test/spec_thin.rb
+++ b/test/spec_thin.rb
@@ -15,7 +15,7 @@ describe Rack::Handler::Thin do
     Thin::Logging.silent = true
 
     @thread = Thread.new do
-      Rack::Handler::Thin.run(@app, :Host => @host='127.0.0.1', :Port => @port=9204, :tag => "tag") do |server|
+      Rack::Handler::Thin.run(@app, Host: @host='127.0.0.1', Port: @port=9204, tag: "tag") do |server|
         @server = server
       end
     end
@@ -78,7 +78,7 @@ describe Rack::Handler::Thin do
   end
 
   it "support HTTP auth" do
-    GET("/test", {:user => "ruth", :passwd => "secret"})
+    GET("/test", {user: "ruth", passwd: "secret"})
     response["HTTP_AUTHORIZATION"].must_equal "Basic cnV0aDpzZWNyZXQ="
   end
 

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -11,10 +11,10 @@ describe Rack::Handler::WEBrick do
   include TestRequest::Helpers
 
   before do
-  @server = WEBrick::HTTPServer.new(:Host => @host='127.0.0.1',
-                                    :Port => @port=9202,
-                                    :Logger => WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
-                                    :AccessLog => [])
+  @server = WEBrick::HTTPServer.new(Host: @host='127.0.0.1',
+                                    Port: @port=9202,
+                                    Logger: WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
+                                    AccessLog: [])
   @server.mount "/test", Rack::Handler::WEBrick,
     Rack::Lint.new(TestRequest.new)
   @thread = Thread.new { @server.start }
@@ -94,7 +94,7 @@ describe Rack::Handler::WEBrick do
   end
 
   it "support HTTP auth" do
-    GET("/test", {:user => "ruth", :passwd => "secret"})
+    GET("/test", {user: "ruth", passwd: "secret"})
     response["HTTP_AUTHORIZATION"].must_equal "Basic cnV0aDpzZWNyZXQ="
   end
 
@@ -126,10 +126,10 @@ describe Rack::Handler::WEBrick do
     t = Thread.new do
       Rack::Handler::WEBrick.run(lambda {},
                                  {
-                                   :Host => '127.0.0.1',
-                                   :Port => 9210,
-                                   :Logger => WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
-                                   :AccessLog => []}) { |server|
+                                   Host: '127.0.0.1',
+                                   Port: 9210,
+                                   Logger: WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
+                                   AccessLog: []}) { |server|
         assert_kind_of WEBrick::HTTPServer, server
         queue.push(server)
       }


### PR DESCRIPTION
## Summary

* Required Ruby version is `>= 2.2`, so It's better to use prefer { a: :b } over { :a => :b } in hash syntax.
* It's hard to modify manufally all points, so I've installed rubocop and enabled only `Style/HashSyntax` (All cops are disabled by default)
* Executed `rubocop --auto-correct`