### PR TITLE
Disable duplicated tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ before_install:
 script: bundle exec rake ci
 
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - ruby-head
   - rbx-2
   - jruby-9.0.4.0
   - jruby-head


### PR DESCRIPTION
## Summary

* Currently, tests for CRuby runs in CircleCI
* Stopped running useless test patterns in travis CI