### PR TITLE
Remove needless encoding magic comments

### DIFF
--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# coding: utf-8
-
 require 'minitest/autorun'
 require 'rack'
 require 'rack/multipart'

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# -*- encoding: utf-8 -*-
 require 'minitest/autorun'
 require 'rack/utils'
 require 'rack/mock'

--- a/test/spec_version.rb
+++ b/test/spec_version.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# -*- encoding: utf-8 -*-
 require 'minitest/autorun'
 require 'rack'
 


### PR DESCRIPTION
## Summary

* Since Ruby 2.0, internal script encoding is utf-8 by default