### PR TITLE
Fix broken link and regenerate SPEC

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -60,9 +60,8 @@ below.
                            the presence or absence of the
                            appropriate HTTP header in the
                            request. See
-                           {https://tools.ietf.org/html/rfc3875#section-4.1.18
-                           RFC3875 section 4.1.18} for
-                           specific behavior.
+                           {RFC3875 section 4.1.18}[https://tools.ietf.org/html/rfc3875#section-4.1.18]
+                           for specific behavior.
 In addition to this, the Rack environment must include these
 Rack-specific variables:
 <tt>rack.version</tt>:: The Array representing this version of Rack
@@ -98,12 +97,13 @@ Rack-specific variables:
 Additional environment specifications have approved to
 standardized middleware APIs.  None of these are required to
 be implemented by the server.
-<tt>rack.session</tt>:: A hash like interface for storing request session data.
+<tt>rack.session</tt>:: A hash like interface for storing
+                        request session data.
                         The store must implement:
-                         store(key, value)         (aliased as []=);
-                         fetch(key, default = nil) (aliased as []);
-                         delete(key);
-                         clear;
+                        store(key, value)         (aliased as []=);
+                        fetch(key, default = nil) (aliased as []);
+                        delete(key);
+                        clear;
 <tt>rack.logger</tt>:: A common object interface for logging messages.
                        The object must implement:
                         info(message, &block)

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -125,9 +125,8 @@ module Rack
       ##                            the presence or absence of the
       ##                            appropriate HTTP header in the
       ##                            request. See
-      ##                            <a href="https://tools.ietf.org/html/rfc3875#section-4.1.18">
-      ##                            RFC3875 section 4.1.18</a> for
-      ##                            specific behavior.
+      ##                            {RFC3875 section 4.1.18}[https://tools.ietf.org/html/rfc3875#section-4.1.18]
+      ##                            for specific behavior.
 
       ## In addition to this, the Rack environment must include these
       ## Rack-specific variables:


### PR DESCRIPTION
## Summary

* I found broken link which is not RDoc style, fixed it.
* Seems SPEC is a little old, so I've regenerate it
* Executed `bundle exec rake rdoc`

## Before

![image](https://user-images.githubusercontent.com/15371677/38851722-d11d01ec-4251-11e8-81fd-130360fb85a1.png)

## After

![image](https://user-images.githubusercontent.com/15371677/38851699-b7953bfe-4251-11e8-8adb-e60eeeb00053.png)
