### PR TITLE
Enable Layout/Space* cops in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,28 @@ Layout/LeadingCommentSpace:
   Enabled: true
   Exclude:
     - 'test/builder/options.ru'
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+# Use `{ a: 1 }` not `{a:1}`.
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -13,7 +13,7 @@
 
 module Rack
   # The Rack protocol version number implemented.
-  VERSION = [1,3]
+  VERSION = [1, 3]
 
   # Return the Rack protocol version as a dotted string.
   def self.version

--- a/lib/rack/auth/abstract/handler.rb
+++ b/lib/rack/auth/abstract/handler.rb
@@ -10,7 +10,7 @@ module Rack
 
       attr_accessor :realm
 
-      def initialize(app, realm=nil, &authenticator)
+      def initialize(app, realm = nil, &authenticator)
         @app, @realm, @authenticator = app, realm, authenticator
       end
 

--- a/lib/rack/auth/digest/md5.rb
+++ b/lib/rack/auth/digest/md5.rb
@@ -23,7 +23,7 @@ module Rack
 
         attr_writer :passwords_hashed
 
-        def initialize(app, realm=nil, opaque=nil, &authenticator)
+        def initialize(app, realm = nil, opaque = nil, &authenticator)
           @passwords_hashed = nil
           if opaque.nil? and realm.respond_to? :values_at
             realm, opaque, @passwords_hashed = realm.values_at :realm, :opaque, :passwords_hashed

--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -8,7 +8,7 @@ module Rack
       @closed = false
     end
 
-    def respond_to?(method_name, include_all=false)
+    def respond_to?(method_name, include_all = false)
       case method_name
       when :to_ary, 'to_ary'
         return false

--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -47,7 +47,7 @@ module Rack
       return app, options
     end
 
-    def self.new_from_string(builder_script, file="(rackup)")
+    def self.new_from_string(builder_script, file = "(rackup)")
       eval "Rack::Builder.new {\n" + builder_script + "\n}.to_app",
         TOPLEVEL_BINDING, file, 0
     end
@@ -115,7 +115,7 @@ module Rack
     #
     #   use SomeMiddleware
     #   run MyApp
-    def warmup(prc=nil, &block)
+    def warmup(prc = nil, &block)
       @warmup = prc || block
     end
 
@@ -153,7 +153,7 @@ module Rack
       app = @map ? generate_map(@run, @map) : @run
       fail "missing run or map statement" unless app
       app.freeze if @freeze_app
-      app = @use.reverse.inject(app) { |a,e| e[a].tap { |x| x.freeze if @freeze_app } }
+      app = @use.reverse.inject(app) { |a, e| e[a].tap { |x| x.freeze if @freeze_app } }
       @warmup.call(app) if @warmup
       app
     end
@@ -165,8 +165,8 @@ module Rack
     private
 
     def generate_map(default_app, mapping)
-      mapped = default_app ? {'/' => default_app} : {}
-      mapping.each { |r,b| mapped[r] = self.class.new(default_app, &b).to_app }
+      mapped = default_app ? { '/' => default_app } : {}
+      mapping.each { |r, b| mapped[r] = self.class.new(default_app, &b).to_app }
       URLMap.new(mapped)
     end
   end

--- a/lib/rack/cascade.rb
+++ b/lib/rack/cascade.rb
@@ -6,11 +6,11 @@ module Rack
   # status codes).
 
   class Cascade
-    NotFound = [404, {CONTENT_TYPE => "text/plain"}, []]
+    NotFound = [404, { CONTENT_TYPE => "text/plain" }, []]
 
     attr_reader :apps
 
-    def initialize(apps, catch=[404, 405])
+    def initialize(apps, catch = [404, 405])
       @apps = []; @has_app = {}
       apps.each { |app| add app }
 

--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -25,7 +25,7 @@ module Rack
     #   %{%s - %s [%s] "%s %s%s %s" %d %s\n} %
     FORMAT = %{%s - %s [%s] "%s %s%s %s" %d %s %0.4f\n}
 
-    def initialize(app, logger=nil)
+    def initialize(app, logger = nil)
       @app = app
       @logger = logger
     end

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -68,7 +68,7 @@ module Rack
       when nil
         message = "An acceptable encoding for the requested resource #{request.fullpath} could not be found."
         bp = Rack::BodyProxy.new([message]) { body.close if body.respond_to?(:close) }
-        [406, {'Content-Type' => "text/plain", 'Content-Length' => message.length.to_s}, bp]
+        [406, { 'Content-Type' => "text/plain", 'Content-Length' => message.length.to_s }, bp]
       end
     end
 
@@ -81,7 +81,7 @@ module Rack
 
       def each(&block)
         @writer = block
-        gzip  =::Zlib::GzipWriter.new(self)
+        gzip = ::Zlib::GzipWriter.new(self)
         gzip.mtime = @mtime if @mtime
         @body.each { |part|
           gzip.write(part)

--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -43,9 +43,9 @@ table { width:100%%; }
 
     class DirectoryBody < Struct.new(:root, :path, :files)
       def each
-        show_path = Rack::Utils.escape_html(path.sub(/^#{root}/,''))
-        listings = files.map{|f| DIR_FILE % DIR_FILE_escape(*f) }*"\n"
-        page  = DIR_PAGE % [ show_path, show_path , listings ]
+        show_path = Rack::Utils.escape_html(path.sub(/^#{root}/, ''))
+        listings = files.map{|f| DIR_FILE % DIR_FILE_escape(*f) } * "\n"
+        page = DIR_PAGE % [ show_path, show_path, listings ]
         page.each_line{|l| yield l }
       end
 
@@ -58,7 +58,7 @@ table { width:100%%; }
 
     attr_reader :root, :path
 
-    def initialize(root, app=nil)
+    def initialize(root, app = nil)
       @root = ::File.expand_path(root)
       @app = app || Rack::File.new(@root)
       @head = Rack::Head.new(lambda { |env| get env })
@@ -88,9 +88,9 @@ table { width:100%%; }
 
       body = "Bad Request\n"
       size = body.bytesize
-      return [400, {CONTENT_TYPE => "text/plain",
+      return [400, { CONTENT_TYPE => "text/plain",
         CONTENT_LENGTH => size.to_s,
-        "X-Cascade" => "pass"}, [body]]
+        "X-Cascade" => "pass" }, [body]]
     end
 
     def check_forbidden(path_info)
@@ -98,13 +98,13 @@ table { width:100%%; }
 
       body = "Forbidden\n"
       size = body.bytesize
-      return [403, {CONTENT_TYPE => "text/plain",
+      return [403, { CONTENT_TYPE => "text/plain",
         CONTENT_LENGTH => size.to_s,
-        "X-Cascade" => "pass"}, [body]]
+        "X-Cascade" => "pass" }, [body]]
     end
 
     def list_directory(path_info, path, script_name)
-      files = [['../','Parent Directory','','','']]
+      files = [['../', 'Parent Directory', '', '', '']]
       glob = ::File.join(path, '*')
 
       url_head = (script_name.split('/') + path_info.split('/')).map do |part|
@@ -128,7 +128,7 @@ table { width:100%%; }
         files << [ url, basename, size, type, mtime ]
       end
 
-      return [ 200, { CONTENT_TYPE =>'text/html; charset=utf-8'}, DirectoryBody.new(@root, path, files) ]
+      return [ 200, { CONTENT_TYPE => 'text/html; charset=utf-8' }, DirectoryBody.new(@root, path, files) ]
     end
 
     def stat(node)
@@ -156,9 +156,9 @@ table { width:100%%; }
     def entity_not_found(path_info)
       body = "Entity not found: #{path_info}\n"
       size = body.bytesize
-      return [404, {CONTENT_TYPE => "text/plain",
+      return [404, { CONTENT_TYPE => "text/plain",
         CONTENT_LENGTH => size.to_s,
-        "X-Cascade" => "pass"}, [body]]
+        "X-Cascade" => "pass" }, [body]]
     end
 
     # Stolen from Ramaze

--- a/lib/rack/file.rb
+++ b/lib/rack/file.rb
@@ -21,7 +21,7 @@ module Rack
 
     attr_reader :root
 
-    def initialize(root, headers={}, default_mime = 'text/plain')
+    def initialize(root, headers = {}, default_mime = 'text/plain')
       @root = root
       @headers = headers
       @default_mime = default_mime
@@ -36,7 +36,7 @@ module Rack
     def get(env)
       request = Rack::Request.new env
       unless ALLOWED_VERBS.include? request.request_method
-        return fail(405, "Method Not Allowed", {'Allow' => ALLOW_HEADER})
+        return fail(405, "Method Not Allowed", { 'Allow' => ALLOW_HEADER })
       end
 
       path_info = Utils.unescape_path request.path_info
@@ -60,7 +60,7 @@ module Rack
 
     def serving(request, path)
       if request.options?
-        return [200, {'Allow' => ALLOW_HEADER, CONTENT_LENGTH => '0'}, []]
+        return [200, { 'Allow' => ALLOW_HEADER, CONTENT_LENGTH => '0' }, []]
       end
       last_modified = ::File.mtime(path).httpdate
       return [304, {}, []] if request.get_header('HTTP_IF_MODIFIED_SINCE') == last_modified
@@ -82,7 +82,7 @@ module Rack
         # No ranges, or multiple ranges (which we don't support):
         # TODO: Support multiple byte-ranges
         response[0] = 200
-        range = 0..size-1
+        range = 0..size - 1
       elsif ranges.empty?
         # Unsatisfiable. Return error, and file size:
         response = fail(416, "Byte range unsatisfiable")
@@ -115,7 +115,7 @@ module Rack
       def each
         ::File.open(path, "rb") do |file|
           file.seek(range.begin)
-          remaining_len = range.end-range.begin+1
+          remaining_len = range.end - range.begin + 1
           while remaining_len > 0
             part = file.read([8192, remaining_len].min)
             break unless part

--- a/lib/rack/handler/cgi.rb
+++ b/lib/rack/handler/cgi.rb
@@ -6,7 +6,7 @@ require 'rack/rewindable_input'
 module Rack
   module Handler
     class CGI
-      def self.run(app, options=nil)
+      def self.run(app, options = nil)
         $stdin.binmode
         serve app
       end

--- a/lib/rack/handler/fastcgi.rb
+++ b/lib/rack/handler/fastcgi.rb
@@ -9,7 +9,7 @@ if defined? FCGI::Stream
   class FCGI::Stream
     alias _rack_read_without_buffer read
 
-    def read(n, buffer=nil)
+    def read(n, buffer = nil)
       buf = _rack_read_without_buffer n
       buffer.replace(buf.to_s)  if buffer
       buf
@@ -20,7 +20,7 @@ end
 module Rack
   module Handler
     class FastCGI
-      def self.run(app, options={})
+      def self.run(app, options = {})
         if options[:File]
           STDIN.reopen(UNIXServer.new(options[:File]))
         elsif options[:Port]

--- a/lib/rack/handler/lsws.rb
+++ b/lib/rack/handler/lsws.rb
@@ -7,7 +7,7 @@ require 'rack/rewindable_input'
 module Rack
   module Handler
     class LSWS
-      def self.run(app, options=nil)
+      def self.run(app, options = nil)
         while LSAPI.accept != nil
           serve app
         end

--- a/lib/rack/handler/scgi.rb
+++ b/lib/rack/handler/scgi.rb
@@ -10,7 +10,7 @@ module Rack
     class SCGI < ::SCGI::Processor
       attr_accessor :app
 
-      def self.run(app, options=nil)
+      def self.run(app, options = nil)
         options[:Socket] = UNIXServer.new(options[:File]) if options[:File]
         new(options.merge(app: app,
                           host: options[:Host],

--- a/lib/rack/handler/thin.rb
+++ b/lib/rack/handler/thin.rb
@@ -10,7 +10,7 @@ require "rack/chunked"
 module Rack
   module Handler
     class Thin
-      def self.run(app, options={})
+      def self.run(app, options = {})
         environment  = ENV['RACK_ENV'] || 'development'
         default_host = environment == 'development' ? 'localhost' : '0.0.0.0'
 

--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -24,7 +24,7 @@ end
 module Rack
   module Handler
     class WEBrick < ::WEBrick::HTTPServlet::AbstractServlet
-      def self.run(app, options={})
+      def self.run(app, options = {})
         environment  = ENV['RACK_ENV'] || 'development'
         default_host = environment == 'development' ? 'localhost' : nil
 
@@ -81,7 +81,7 @@ module Rack
         env[QUERY_STRING] ||= ""
         unless env[PATH_INFO] == ""
           path, n = req.request_uri.path, env[SCRIPT_NAME].length
-          env[PATH_INFO] = path[n, path.length-n]
+          env[PATH_INFO] = path[n, path.length - n]
         end
         env[REQUEST_PATH] ||= [env[SCRIPT_NAME], env[PATH_INFO]].join
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -35,7 +35,7 @@ module Rack
 
     ## A Rack application is a Ruby object (not a class) that
     ## responds to +call+.
-    def call(env=nil)
+    def call(env = nil)
       dup._call(env)
     end
 
@@ -265,7 +265,7 @@ module Rack
       ## <tt>HTTP_CONTENT_TYPE</tt> or <tt>HTTP_CONTENT_LENGTH</tt>
       ## (use the versions without <tt>HTTP_</tt>).
       %w[HTTP_CONTENT_TYPE HTTP_CONTENT_LENGTH].each { |header|
-        assert("env contains #{header}, must use #{header[5,-1]}") {
+        assert("env contains #{header}, must use #{header[5, -1]}") {
           not env.include? header
         }
       }

--- a/lib/rack/lobster.rb
+++ b/lib/rack/lobster.rb
@@ -27,8 +27,8 @@ module Rack
       content = ["<title>Lobstericious!</title>",
                  "<pre>", lobster, "</pre>",
                  "<a href='#{href}'>flip!</a>"]
-      length = content.inject(0) { |a,e| a+e.size }.to_s
-      [200, {CONTENT_TYPE => "text/html", CONTENT_LENGTH => length}, content]
+      length = content.inject(0) { |a, e| a + e.size }.to_s
+      [200, { CONTENT_TYPE => "text/html", CONTENT_LENGTH => length }, content]
     }
 
     def call(env)
@@ -39,8 +39,8 @@ module Rack
             gsub('\\', 'TEMP').
             gsub('/', '\\').
             gsub('TEMP', '/').
-            gsub('{','}').
-            gsub('(',')')
+            gsub('{', '}').
+            gsub('(', ')')
         end.join("\n")
         href = "?flip=right"
       elsif req.GET["flip"] == "crash"

--- a/lib/rack/media_type.rb
+++ b/lib/rack/media_type.rb
@@ -27,7 +27,7 @@ module Rack
         return {} if content_type.nil?
         Hash[*content_type.split(SPLIT_PATTERN)[1..-1].
           collect { |s| s.split('=', 2) }.
-          map { |k,v| [k.downcase, strip_doublequotes(v)] }.flatten]
+          map { |k, v| [k.downcase, strip_doublequotes(v)] }.flatten]
       end
 
       private

--- a/lib/rack/mime.rb
+++ b/lib/rack/mime.rb
@@ -15,7 +15,7 @@ module Rack
     # This is a shortcut for:
     #     Rack::Mime::MIME_TYPES.fetch('.foo', 'application/octet-stream')
 
-    def mime_type(ext, fallback='application/octet-stream')
+    def mime_type(ext, fallback = 'application/octet-stream')
       MIME_TYPES.fetch(ext.to_s.downcase, fallback)
     end
     module_function :mime_type

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -55,15 +55,15 @@ module Rack
       @app = app
     end
 
-    def get(uri, opts={})     request(GET, uri, opts)     end
-    def post(uri, opts={})    request(POST, uri, opts)    end
-    def put(uri, opts={})     request(PUT, uri, opts)     end
-    def patch(uri, opts={})   request(PATCH, uri, opts)   end
-    def delete(uri, opts={})  request(DELETE, uri, opts)  end
-    def head(uri, opts={})    request(HEAD, uri, opts)    end
-    def options(uri, opts={}) request(OPTIONS, uri, opts) end
+    def get(uri, opts = {})     request(GET, uri, opts)     end
+    def post(uri, opts = {})    request(POST, uri, opts)    end
+    def put(uri, opts = {})     request(PUT, uri, opts)     end
+    def patch(uri, opts = {})   request(PATCH, uri, opts)   end
+    def delete(uri, opts = {})  request(DELETE, uri, opts)  end
+    def head(uri, opts = {})    request(HEAD, uri, opts)    end
+    def options(uri, opts = {}) request(OPTIONS, uri, opts) end
 
-    def request(method=GET, uri="", opts={})
+    def request(method = GET, uri = "", opts = {})
       env = self.class.env_for(uri, opts.merge(method: method))
 
       if opts[:lint]
@@ -73,7 +73,7 @@ module Rack
       end
 
       errors = env[RACK_ERRORS]
-      status, headers, body  = app.call(env)
+      status, headers, body = app.call(env)
       MockResponse.new(status, headers, body, errors)
     ensure
       body.close if body.respond_to?(:close)
@@ -87,7 +87,7 @@ module Rack
     end
 
     # Return the Rack environment used for a request to +uri+.
-    def self.env_for(uri="", opts={})
+    def self.env_for(uri = "", opts = {})
       uri = parse_uri_rfc2396(uri)
       uri.path = "/#{uri.path}" unless uri.path[0] == ?/
 
@@ -162,7 +162,7 @@ module Rack
     # Errors
     attr_accessor :errors
 
-    def initialize(status, headers, body, errors=StringIO.new(""))
+    def initialize(status, headers, body, errors = StringIO.new(""))
       @original_headers = headers
       @errors           = errors.string if errors.respond_to?(:string)
 

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -94,14 +94,14 @@ module Rack
               # those which give the lone filename.
               fn = filename.split(/[\/\\]/).last
 
-              data = {filename: fn, type: content_type,
-                      name: name, tempfile: body, head: head}
+              data = { filename: fn, type: content_type,
+                      name: name, tempfile: body, head: head }
             elsif !filename && content_type && body.is_a?(IO)
               body.rewind
 
               # Generic multipart cases, not coming from a form
-              data = {type: content_type,
-                      name: name, tempfile: body, head: head}
+              data = { type: content_type,
+                      name: name, tempfile: body, head: head }
             end
 
             yield data
@@ -240,8 +240,8 @@ module Rack
 
       def handle_mime_head
         if @buf.index(EOL + EOL)
-          i = @buf.index(EOL+EOL)
-          head = @buf.slice!(0, i+2) # First \r\n
+          i = @buf.index(EOL + EOL)
+          head = @buf.slice!(0, i + 2) # First \r\n
           @buf.slice!(0, 2)          # Second \r\n
 
           content_type = head[MULTIPART_CONTENT_TYPE, 1]
@@ -329,7 +329,7 @@ module Rack
         filename
       end
 
-      CHARSET   = "charset"
+      CHARSET = "charset"
 
       def tag_multipart_encoding(filename, content_type, name, body)
         name = name.to_s
@@ -346,7 +346,7 @@ module Rack
           if TEXT_PLAIN == type_subtype
             rest         = list.drop 1
             rest.each do |param|
-              k,v = param.split('=', 2)
+              k, v = param.split('=', 2)
               k.strip!
               v.strip!
               v = v[1..-2] if v[0] == '"' && v[-1] == '"'

--- a/lib/rack/recursive.rb
+++ b/lib/rack/recursive.rb
@@ -12,14 +12,14 @@ module Rack
   class ForwardRequest < Exception
     attr_reader :url, :env
 
-    def initialize(url, env={})
+    def initialize(url, env = {})
       @url = URI(url)
       @env = env
 
       @env[PATH_INFO] =       @url.path
-      @env[QUERY_STRING] =    @url.query  if @url.query
-      @env[HTTP_HOST] =       @url.host   if @url.host
-      @env["HTTP_PORT"] =     @url.port   if @url.port
+      @env[QUERY_STRING] = @url.query  if @url.query
+      @env[HTTP_HOST] = @url.host   if @url.host
+      @env["HTTP_PORT"] = @url.port   if @url.port
       @env[RACK_URL_SCHEME] = @url.scheme if @url.scheme
 
       super "forwarding to #{url}"

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -467,7 +467,7 @@ module Rack
         Utils.default_query_parser
       end
 
-      def parse_query(qs, d='&')
+      def parse_query(qs, d = '&')
         query_parser.parse_nested_query(qs, d)
       end
 

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -27,7 +27,7 @@ module Rack
 
     CHUNKED = 'chunked'.freeze
 
-    def initialize(body=[], status=200, header={})
+    def initialize(body = [], status = 200, header = {})
       @status = status.to_i
       @header = Utils::HeaderHash.new.merge(header)
 
@@ -50,7 +50,7 @@ module Rack
       yield self  if block_given?
     end
 
-    def redirect(target, status=302)
+    def redirect(target, status = 302)
       self.status = status
       self.location = target
     end
@@ -186,7 +186,7 @@ module Rack
         set_header SET_COOKIE, ::Rack::Utils.add_cookie_to_header(cookie_header, key, value)
       end
 
-      def delete_cookie(key, value={})
+      def delete_cookie(key, value = {})
         set_header SET_COOKIE, ::Rack::Utils.add_remove_cookie_to_header(get_header(SET_COOKIE), key, value)
       end
 

--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -101,7 +101,7 @@ module Rack
   # will be matched with case indifference.
 
   class Sendfile
-    def initialize(app, variation=nil, mappings=[])
+    def initialize(app, variation = nil, mappings = [])
       @app = app
       @variation = variation
       @mappings = mappings.map do |internal, external|
@@ -149,7 +149,7 @@ module Rack
     end
 
     def map_accel_path(env, path)
-      if mapping = @mappings.find { |internal,_| internal =~ path }
+      if mapping = @mappings.find { |internal, _| internal =~ path }
         path.sub(*mapping)
       elsif mapping = env['HTTP_X_ACCEL_MAPPING']
         mapping.split(',').map(&:strip).each do |m|

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -247,7 +247,7 @@ module Rack
       end
 
       def default_middleware_by_environment
-        m = Hash.new {|h,k| h[k] = []}
+        m = Hash.new {|h, k| h[k] = []}
         m["deployment"] = [
           [Rack::ContentLength],
           [Rack::Chunked],

--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -59,7 +59,7 @@ module Rack
           @data[key.to_s]
         end
 
-        def fetch(key, default=Unspecified, &block)
+        def fetch(key, default = Unspecified, &block)
           load_for_read!
           if default == Unspecified
             @data.fetch(key.to_s, &block)
@@ -216,7 +216,7 @@ module Rack
 
         attr_reader :key, :default_options, :sid_secure
 
-        def initialize(app, options={})
+        def initialize(app, options = {})
           @app = app
           @default_options = self.class::DEFAULT_OPTIONS.merge(options)
           @key = @default_options.delete(:key)
@@ -228,7 +228,7 @@ module Rack
           context(env)
         end
 
-        def context(env, app=@app)
+        def context(env, app = @app)
           req = make_request env
           prepare_session(req)
           status, headers, body = app.call(req.env)
@@ -351,7 +351,7 @@ module Rack
 
           session.send(:load!) unless loaded_session?(session)
           session_id ||= session.id
-          session_data = session.to_hash.delete_if { |k,v| v.nil? }
+          session_data = session.to_hash.delete_if { |k, v| v.nil? }
 
           if not data = write_session(req, session_id, session_data, options)
             req.get_header(RACK_ERRORS).puts("Warning! #{self.class.name} failed to save session. Content dropped.")

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -105,7 +105,7 @@ module Rack
 
       attr_reader :coder
 
-      def initialize(app, options={})
+      def initialize(app, options = {})
         @secrets = options.values_at(:secret, :old_secret).compact
         @hmac = options.fetch(:hmac, OpenSSL::Digest::SHA1)
 
@@ -118,7 +118,7 @@ module Rack
 
         Called from: #{caller[0]}.
         MSG
-        @coder  = options[:coder] ||= Base64::Marshal.new
+        @coder = options[:coder] ||= Base64::Marshal.new
         super(app, options.merge!(cookie_only: true))
       end
 
@@ -149,7 +149,7 @@ module Rack
         end
       end
 
-      def persistent_session_id!(data, sid=nil)
+      def persistent_session_id!(data, sid = nil)
         data ||= {}
         data["session_id"] ||= sid || generate_sid
         data

--- a/lib/rack/session/memcache.rb
+++ b/lib/rack/session/memcache.rb
@@ -28,12 +28,12 @@ module Rack
         namespace: 'rack:session',
         memcache_server: 'localhost:11211'
 
-      def initialize(app, options={})
+      def initialize(app, options = {})
         super
 
         @mutex = Mutex.new
         mserv = @default_options[:memcache_server]
-        mopts = @default_options.reject{|k,v| !MemCache::DEFAULT_OPTIONS.include? k }
+        mopts = @default_options.reject{|k, v| !MemCache::DEFAULT_OPTIONS.include? k }
 
         @pool = options[:cache] || MemCache.new(mserv, mopts)
         unless @pool.active? and @pool.servers.any?(&:alive?)

--- a/lib/rack/session/pool.rb
+++ b/lib/rack/session/pool.rb
@@ -30,7 +30,7 @@ module Rack
       attr_reader :mutex, :pool
       DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge drop: false
 
-      def initialize(app, options={})
+      def initialize(app, options = {})
         super
         @pool = Hash.new
         @mutex = Mutex.new

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -79,13 +79,13 @@ module Rack
           frame.function = $4
 
           begin
-            lineno = frame.lineno-1
+            lineno = frame.lineno - 1
             lines = ::File.readlines(frame.filename)
-            frame.pre_context_lineno = [lineno-CONTEXT, 0].max
+            frame.pre_context_lineno = [lineno - CONTEXT, 0].max
             frame.pre_context = lines[frame.pre_context_lineno...lineno]
             frame.context_line = lines[lineno].chomp
-            frame.post_context_lineno = [lineno+CONTEXT, lines.size].min
-            frame.post_context = lines[lineno+1..frame.post_context_lineno]
+            frame.post_context_lineno = [lineno + CONTEXT, lines.size].min
+            frame.post_context = lines[lineno + 1..frame.post_context_lineno]
           rescue
           end
 

--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -85,7 +85,7 @@ module Rack
   #
   class Static
 
-    def initialize(app, options={})
+    def initialize(app, options = {})
       @app = app
       @urls = options[:urls] || ["/favicon.ico"]
       @index = options[:index]
@@ -95,7 +95,7 @@ module Rack
       # HTTP Headers
       @header_rules = options[:header_rules] || []
       # Allow for legacy :cache_control option while prioritizing global header_rules setting
-      @header_rules.unshift([:all, {CACHE_CONTROL => options[:cache_control]}]) if options[:cache_control]
+      @header_rules.unshift([:all, { CACHE_CONTROL => options[:cache_control] }]) if options[:cache_control]
 
       @file_server = Rack::File.new(root)
     end

--- a/lib/rack/urlmap.rb
+++ b/lib/rack/urlmap.rb
@@ -77,7 +77,7 @@ module Rack
         return app.call(env)
       end
 
-      [404, {CONTENT_TYPE => "text/plain", "X-Cascade" => "pass"}, ["Not Found: #{path}"]]
+      [404, { CONTENT_TYPE => "text/plain", "X-Cascade" => "pass" }, ["Not Found: #{path}"]]
 
     ensure
       env[PATH_INFO]   = path

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -213,7 +213,7 @@ module Rack
       #   precede those with less specific.  Ordering with respect to other
       #   attributes (e.g., Domain) is unspecified.
       cookies = parse_query(header, ';,') { |s| unescape(s) rescue s }
-      cookies.each_with_object({}) { |(k,v), hash| hash[k] = Array === v ? v.first : v }
+      cookies.each_with_object({}) { |(k, v), hash| hash[k] = Array === v ? v.first : v }
     end
     module_function :parse_cookies_header
 
@@ -299,7 +299,7 @@ module Rack
       new_header = make_delete_cookie_header(header, key, value)
 
       add_cookie_to_header(new_header, key,
-                 {value: '', path: nil, domain: nil,
+                 { value: '', path: nil, domain: nil,
                    max_age: '0',
                    expires: Time.at(0) }.merge(value))
 
@@ -342,7 +342,7 @@ module Rack
       ranges = []
       $1.split(/,\s*/).each do |range_spec|
         return nil  unless range_spec =~ /(\d*)-(\d*)/
-        r0,r1 = $1, $2
+        r0, r1 = $1, $2
         if r0.empty?
           return nil  if r1.empty?
           # suffix-byte-range-spec, represents trailing suffix of file
@@ -356,7 +356,7 @@ module Rack
           else
             r1 = r1.to_i
             return nil  if r1 < r0  # backwards range is syntactically invalid
-            r1 = size-1  if r1 >= size
+            r1 = size - 1  if r1 >= size
           end
         end
         ranges << (r0..r1)  if r0 <= r1
@@ -377,7 +377,7 @@ module Rack
       l = a.unpack("C*")
 
       r, i = 0, -1
-      b.each_byte { |v| r |= v ^ l[i+=1] }
+      b.each_byte { |v| r |= v ^ l[i += 1] }
       r == 0
     end
     module_function :secure_compare
@@ -403,7 +403,7 @@ module Rack
         self.class.new(@for, app)
       end
 
-      def context(env, app=@app)
+      def context(env, app = @app)
         recontext(app).call(env)
       end
     end
@@ -411,11 +411,11 @@ module Rack
     # A case-insensitive Hash that preserves the original case of a
     # header when set.
     class HeaderHash < Hash
-      def self.new(hash={})
+      def self.new(hash = {})
         HeaderHash === hash ? hash : super(hash)
       end
 
-      def initialize(hash={})
+      def initialize(hash = {})
         super()
         @names = {}
         hash.each { |k, v| self[k] = v }
@@ -435,7 +435,7 @@ module Rack
 
       def to_hash
         hash = {}
-        each { |k,v| hash[k] = v }
+        each { |k, v| hash[k] = v }
         hash
       end
 

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |s|
-  s.name            = "rack"
+  s.name = "rack"
   s.version = File.read('lib/rack.rb')[/RELEASE += +([\"\'])([\d][\w\.]+)\1/, 2]
   s.platform        = Gem::Platform::RUBY
   s.summary         = "a modular Ruby webserver interface"
@@ -20,8 +20,8 @@ EOF
   s.files           = Dir['{bin/*,contrib/*,example/*,lib/**/*,test/**/*}'] +
                         %w(COPYING rack.gemspec Rakefile README.rdoc SPEC)
   s.bindir          = 'bin'
-  s.executables     << 'rackup'
-  s.require_path    = 'lib'
+  s.executables << 'rackup'
+  s.require_path = 'lib'
   s.extra_rdoc_files = ['README.rdoc', 'HISTORY.md']
   s.test_files      = Dir['test/spec_*.rb']
 

--- a/test/builder/an_underscore_app.rb
+++ b/test/builder/an_underscore_app.rb
@@ -2,6 +2,6 @@
 
 class AnUnderscoreApp
   def self.call(env)
-    [200, {'Content-Type' => 'text/plain'}, ['OK']]
+    [200, { 'Content-Type' => 'text/plain' }, ['OK']]
   end
 end

--- a/test/builder/anything.rb
+++ b/test/builder/anything.rb
@@ -2,6 +2,6 @@
 
 class Anything
   def self.call(env)
-    [200, {'Content-Type' => 'text/plain'}, ['OK']]
+    [200, { 'Content-Type' => 'text/plain' }, ['OK']]
   end
 end

--- a/test/builder/comment.ru
+++ b/test/builder/comment.ru
@@ -3,4 +3,4 @@
 =begin
 
 =end
-run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ['OK']] }

--- a/test/builder/end.ru
+++ b/test/builder/end.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
 __END__
 Should not be evaluated
 Neither should

--- a/test/builder/line.ru
+++ b/test/builder/line.ru
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-run lambda{ |env| [200, {'Content-Type' => 'text/plain'}, [__LINE__.to_s]] }
+run lambda{ |env| [200, { 'Content-Type' => 'text/plain' }, [__LINE__.to_s]] }

--- a/test/builder/options.ru
+++ b/test/builder/options.ru
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 #\ -d -p 2929 --env test
-run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }
+run lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ['OK']] }

--- a/test/spec_auth_basic.rb
+++ b/test/spec_auth_basic.rb
@@ -12,7 +12,7 @@ describe Rack::Auth::Basic do
 
   def unprotected_app
     Rack::Lint.new lambda { |env|
-      [ 200, {'Content-Type' => 'text/plain'}, ["Hi #{env['REMOTE_USER']}"] ]
+      [ 200, { 'Content-Type' => 'text/plain' }, ["Hi #{env['REMOTE_USER']}"] ]
     }
   end
 

--- a/test/spec_auth_digest.rb
+++ b/test/spec_auth_digest.rb
@@ -13,7 +13,7 @@ describe Rack::Auth::Digest::MD5 do
   def unprotected_app
     Rack::Lint.new lambda { |env|
       friend = Rack::Utils.parse_query(env["QUERY_STRING"])["friend"]
-      [ 200, {'Content-Type' => 'text/plain'}, ["Hi #{env['REMOTE_USER']}#{friend ? " and #{friend}" : ''}"] ]
+      [ 200, { 'Content-Type' => 'text/plain' }, ["Hi #{env['REMOTE_USER']}#{friend ? " and #{friend}" : ''}"] ]
     }
   end
 

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -42,7 +42,7 @@ describe Rack::BodyProxy do
     called = false
 
     begin
-      proxy  = Rack::BodyProxy.new(object) { called = true }
+      proxy = Rack::BodyProxy.new(object) { called = true }
       called.must_equal false
       proxy.close
     rescue RuntimeError => e

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -33,10 +33,10 @@ describe Rack::Builder do
   it "supports mapping" do
     app = builder_to_app do
       map '/' do |outer_env|
-        run lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, ['root']] }
+        run lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, ['root']] }
       end
       map '/sub' do
-        run lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, ['sub']] }
+        run lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, ['sub']] }
       end
     end
     Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'root'
@@ -49,7 +49,7 @@ describe Rack::Builder do
       map '/' do |outer_env|
         run lambda { |inner_env|
           inner_env['new_key'] = 'new_value'
-          [200, {"Content-Type" => "text/plain"}, ['root']]
+          [200, { "Content-Type" => "text/plain" }, ['root']]
         }
       end
     end
@@ -60,7 +60,7 @@ describe Rack::Builder do
   it "dupe #to_app when mapping so Rack::Reloader can reload the application on each request" do
     app = builder do
       map '/' do |outer_env|
-        run lambda { |env|  [200, {"Content-Type" => "text/plain"}, [object_id.to_s]] }
+        run lambda { |env|  [200, { "Content-Type" => "text/plain" }, [object_id.to_s]] }
       end
     end
 
@@ -99,7 +99,7 @@ describe Rack::Builder do
         'secret' == password
       end
 
-      run lambda { |env| [200, {"Content-Type" => "text/plain"}, ['Hi Boss']] }
+      run lambda { |env| [200, { "Content-Type" => "text/plain" }, ['Hi Boss']] }
     end
 
     response = Rack::MockRequest.new(app).get("/")
@@ -127,9 +127,9 @@ describe Rack::Builder do
   it "can mix map and run for endpoints" do
     app = builder do
       map '/sub' do
-        run lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, ['sub']] }
+        run lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, ['sub']] }
       end
-      run lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, ['root']] }
+      run lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, ['root']] }
     end
 
     Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'root'
@@ -166,7 +166,7 @@ describe Rack::Builder do
         def call(env)
           raise "bzzzt"  if @called > 0
         @called += 1
-          [200, {'Content-Type' => 'text/plain'}, ['OK']]
+          [200, { 'Content-Type' => 'text/plain' }, ['OK']]
         end
       end
 

--- a/test/spec_cascade.rb
+++ b/test/spec_cascade.rb
@@ -19,7 +19,7 @@ describe Rack::Cascade do
   app2 = Rack::URLMap.new("/crash" => lambda { |env| raise "boom" })
 
   app3 = Rack::URLMap.new("/foo" => lambda { |env|
-                            [200, { "Content-Type" => "text/plain"}, [""]]})
+                            [200, { "Content-Type" => "text/plain" }, [""]]})
 
   it "dispatch onward on 404 and 405 by default" do
     cascade = cascade([app1, app2, app3])

--- a/test/spec_cgi.rb
+++ b/test/spec_cgi.rb
@@ -37,7 +37,7 @@ describe Rack::Handler::CGI do
 
   it "have rack headers" do
     GET("/test")
-    response["rack.version"].must_equal [1,3]
+    response["rack.version"].must_equal [1, 3]
     assert_equal false, response["rack.multithread"]
     assert_equal true, response["rack.multiprocess"]
     assert_equal true, response["rack.run_once"]
@@ -61,7 +61,7 @@ describe Rack::Handler::CGI do
   end
 
   it "have CGI headers on POST" do
-    POST("/test", {"rack-form-data" => "23"}, {'X-test-header' => '42'})
+    POST("/test", { "rack-form-data" => "23" }, { 'X-test-header' => '42' })
     status.must_equal 200
     response["REQUEST_METHOD"].must_equal "POST"
     response["SCRIPT_NAME"].must_equal "/test"
@@ -72,7 +72,7 @@ describe Rack::Handler::CGI do
   end
 
   it "support HTTP auth" do
-    GET("/test", {user: "ruth", passwd: "secret"})
+    GET("/test", { user: "ruth", passwd: "secret" })
     response["HTTP_AUTHORIZATION"].must_equal "Basic cnV0aDpzZWNyZXQ="
   end
 

--- a/test/spec_chunked.rb
+++ b/test/spec_chunked.rb
@@ -22,7 +22,7 @@ describe Rack::Chunked do
   end
 
   it 'chunk responses with no Content-Length' do
-    app = lambda { |env| [200, {"Content-Type" => "text/plain"}, ['Hello', ' ', 'World!']] }
+    app = lambda { |env| [200, { "Content-Type" => "text/plain" }, ['Hello', ' ', 'World!']] }
     response = Rack::MockResponse.new(*chunked(app).call(@env))
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
@@ -30,7 +30,7 @@ describe Rack::Chunked do
   end
 
   it 'chunks empty bodies properly' do
-    app = lambda { |env| [200, {"Content-Type" => "text/plain"}, []] }
+    app = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
     response = Rack::MockResponse.new(*chunked(app).call(@env))
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
@@ -39,7 +39,7 @@ describe Rack::Chunked do
 
   it 'chunks encoded bodies properly' do
     body = ["\uFFFEHello", " ", "World"].map {|t| t.encode("UTF-16LE") }
-    app  = lambda { |env| [200, {"Content-Type" => "text/plain"}, body] }
+    app  = lambda { |env| [200, { "Content-Type" => "text/plain" }, body] }
     response = Rack::MockResponse.new(*chunked(app).call(@env))
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
@@ -50,7 +50,7 @@ describe Rack::Chunked do
 
   it 'not modify response when Content-Length header present' do
     app = lambda { |env|
-      [200, {"Content-Type" => "text/plain", 'Content-Length'=>'12'}, ['Hello', ' ', 'World!']]
+      [200, { "Content-Type" => "text/plain", 'Content-Length' => '12' }, ['Hello', ' ', 'World!']]
     }
     status, headers, body = chunked(app).call(@env)
     status.must_equal 200
@@ -60,7 +60,7 @@ describe Rack::Chunked do
   end
 
   it 'not modify response when client is HTTP/1.0' do
-    app = lambda { |env| [200, {"Content-Type" => "text/plain"}, ['Hello', ' ', 'World!']] }
+    app = lambda { |env| [200, { "Content-Type" => "text/plain" }, ['Hello', ' ', 'World!']] }
     @env['HTTP_VERSION'] = 'HTTP/1.0'
     status, headers, body = chunked(app).call(@env)
     status.must_equal 200
@@ -69,7 +69,7 @@ describe Rack::Chunked do
   end
 
   it 'not modify response when client is ancient, pre-HTTP/1.0' do
-    app = lambda { |env| [200, {"Content-Type" => "text/plain"}, ['Hello', ' ', 'World!']] }
+    app = lambda { |env| [200, { "Content-Type" => "text/plain" }, ['Hello', ' ', 'World!']] }
     check = lambda do
       status, headers, body = chunked(app).call(@env.dup)
       status.must_equal 200
@@ -86,7 +86,7 @@ describe Rack::Chunked do
 
   it 'not modify response when Transfer-Encoding header already present' do
     app = lambda { |env|
-      [200, {"Content-Type" => "text/plain", 'Transfer-Encoding' => 'identity'}, ['Hello', ' ', 'World!']]
+      [200, { "Content-Type" => "text/plain", 'Transfer-Encoding' => 'identity' }, ['Hello', ' ', 'World!']]
     }
     status, headers, body = chunked(app).call(@env)
     status.must_equal 200

--- a/test/spec_common_logger.rb
+++ b/test/spec_common_logger.rb
@@ -13,15 +13,15 @@ describe Rack::CommonLogger do
 
   app = Rack::Lint.new lambda { |env|
     [200,
-     {"Content-Type" => "text/html", "Content-Length" => length.to_s},
+     { "Content-Type" => "text/html", "Content-Length" => length.to_s },
      [obj]]}
   app_without_length = Rack::Lint.new lambda { |env|
     [200,
-     {"Content-Type" => "text/html"},
+     { "Content-Type" => "text/html" },
      []]}
   app_with_zero_length = Rack::Lint.new lambda { |env|
     [200,
-     {"Content-Type" => "text/html", "Content-Length" => "0"},
+     { "Content-Type" => "text/html", "Content-Length" => "0" },
      []]}
 
   it "log to rack.errors by default" do

--- a/test/spec_conditional_get.rb
+++ b/test/spec_conditional_get.rb
@@ -13,7 +13,7 @@ describe Rack::ConditionalGet do
   it "set a 304 status and truncate body when If-Modified-Since hits" do
     timestamp = Time.now.httpdate
     app = conditional_get(lambda { |env|
-      [200, {'Last-Modified'=>timestamp}, ['TEST']] })
+      [200, { 'Last-Modified' => timestamp }, ['TEST']] })
 
     response = Rack::MockRequest.new(app).
       get("/", 'HTTP_IF_MODIFIED_SINCE' => timestamp)
@@ -24,7 +24,7 @@ describe Rack::ConditionalGet do
 
   it "set a 304 status and truncate body when If-Modified-Since hits and is higher than current time" do
     app = conditional_get(lambda { |env|
-      [200, {'Last-Modified'=>(Time.now - 3600).httpdate}, ['TEST']] })
+      [200, { 'Last-Modified' => (Time.now - 3600).httpdate }, ['TEST']] })
 
     response = Rack::MockRequest.new(app).
       get("/", 'HTTP_IF_MODIFIED_SINCE' => Time.now.httpdate)
@@ -35,7 +35,7 @@ describe Rack::ConditionalGet do
 
   it "set a 304 status and truncate body when If-None-Match hits" do
     app = conditional_get(lambda { |env|
-      [200, {'ETag'=>'1234'}, ['TEST']] })
+      [200, { 'ETag' => '1234' }, ['TEST']] })
 
     response = Rack::MockRequest.new(app).
       get("/", 'HTTP_IF_NONE_MATCH' => '1234')
@@ -47,7 +47,7 @@ describe Rack::ConditionalGet do
   it "not set a 304 status if If-Modified-Since hits but Etag does not" do
     timestamp = Time.now.httpdate
     app = conditional_get(lambda { |env|
-      [200, {'Last-Modified'=>timestamp, 'Etag'=>'1234', 'Content-Type' => 'text/plain'}, ['TEST']] })
+      [200, { 'Last-Modified' => timestamp, 'Etag' => '1234', 'Content-Type' => 'text/plain' }, ['TEST']] })
 
     response = Rack::MockRequest.new(app).
       get("/", 'HTTP_IF_MODIFIED_SINCE' => timestamp, 'HTTP_IF_NONE_MATCH' => '4321')
@@ -59,7 +59,7 @@ describe Rack::ConditionalGet do
   it "set a 304 status and truncate body when both If-None-Match and If-Modified-Since hits" do
     timestamp = Time.now.httpdate
     app = conditional_get(lambda { |env|
-      [200, {'Last-Modified'=>timestamp, 'ETag'=>'1234'}, ['TEST']] })
+      [200, { 'Last-Modified' => timestamp, 'ETag' => '1234' }, ['TEST']] })
 
     response = Rack::MockRequest.new(app).
       get("/", 'HTTP_IF_MODIFIED_SINCE' => timestamp, 'HTTP_IF_NONE_MATCH' => '1234')
@@ -70,7 +70,7 @@ describe Rack::ConditionalGet do
 
   it "not affect non-GET/HEAD requests" do
     app = conditional_get(lambda { |env|
-      [200, {'Etag'=>'1234', 'Content-Type' => 'text/plain'}, ['TEST']] })
+      [200, { 'Etag' => '1234', 'Content-Type' => 'text/plain' }, ['TEST']] })
 
     response = Rack::MockRequest.new(app).
       post("/", 'HTTP_IF_NONE_MATCH' => '1234')
@@ -81,7 +81,7 @@ describe Rack::ConditionalGet do
 
   it "not affect non-200 requests" do
     app = conditional_get(lambda { |env|
-      [302, {'Etag'=>'1234', 'Content-Type' => 'text/plain'}, ['TEST']] })
+      [302, { 'Etag' => '1234', 'Content-Type' => 'text/plain' }, ['TEST']] })
 
     response = Rack::MockRequest.new(app).
       get("/", 'HTTP_IF_NONE_MATCH' => '1234')
@@ -93,7 +93,7 @@ describe Rack::ConditionalGet do
   it "not affect requests with malformed HTTP_IF_NONE_MATCH" do
     bad_timestamp = Time.now.strftime('%Y-%m-%d %H:%M:%S %z')
     app = conditional_get(lambda { |env|
-      [200,{'Last-Modified'=>(Time.now - 3600).httpdate, 'Content-Type' => 'text/plain'}, ['TEST']] })
+      [200, { 'Last-Modified' => (Time.now - 3600).httpdate, 'Content-Type' => 'text/plain' }, ['TEST']] })
 
     response = Rack::MockRequest.new(app).
       get("/", 'HTTP_IF_MODIFIED_SINCE' => bad_timestamp)

--- a/test/spec_config.rb
+++ b/test/spec_config.rb
@@ -15,7 +15,7 @@ describe Rack::Config do
         env['greeting'] = 'hello'
       end
       run lambda { |env|
-        [200, {'Content-Type' => 'text/plain'}, [env['greeting'] || '']]
+        [200, { 'Content-Type' => 'text/plain' }, [env['greeting'] || '']]
       }
     end
 

--- a/test/spec_content_length.rb
+++ b/test/spec_content_length.rb
@@ -15,7 +15,7 @@ describe Rack::ContentLength do
   end
 
   it "set Content-Length on Array bodies if none is set" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ["Hello, World!"]] }
     response = content_length(app).call(request)
     response[1]['Content-Length'].must_equal '13'
   end
@@ -24,13 +24,13 @@ describe Rack::ContentLength do
     body = lambda { "Hello World!" }
     def body.each ; yield call ; end
 
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, body] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, body] }
     response = content_length(app).call(request)
     response[1]['Content-Length'].must_be_nil
   end
 
   it "not change Content-Length if it is already set" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain', 'Content-Length' => '1'}, "Hello, World!"] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Content-Length' => '1' }, "Hello, World!"] }
     response = content_length(app).call(request)
     response[1]['Content-Length'].must_equal '1'
   end
@@ -42,7 +42,7 @@ describe Rack::ContentLength do
   end
 
   it "not set Content-Length when Transfer-Encoding is chunked" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain', 'Transfer-Encoding' => 'chunked'}, []] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Transfer-Encoding' => 'chunked' }, []] }
     response = content_length(app).call(request)
     response[1]['Content-Length'].must_be_nil
   end
@@ -64,7 +64,7 @@ describe Rack::ContentLength do
       def to_ary; end
     end.new(%w[one two three])
 
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, body] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, body] }
     response = content_length(app).call(request)
     body.closed.must_be_nil
     response[2].close
@@ -79,7 +79,7 @@ describe Rack::ContentLength do
       def to_ary; end
     end.new(%w[one two three])
 
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, body] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, body] }
     response = content_length(app).call(request)
     expected = %w[one two three]
     response[1]['Content-Length'].must_equal expected.join.size.to_s

--- a/test/spec_content_type.rb
+++ b/test/spec_content_type.rb
@@ -28,16 +28,16 @@ describe Rack::ContentType do
   end
 
   it "not change Content-Type if it is already set" do
-    app = lambda { |env| [200, {'Content-Type' => 'foo/bar'}, "Hello, World!"] }
+    app = lambda { |env| [200, { 'Content-Type' => 'foo/bar' }, "Hello, World!"] }
     headers = content_type(app).call(request)[1]
     headers['Content-Type'].must_equal 'foo/bar'
   end
 
   it "detect Content-Type case insensitive" do
-    app = lambda { |env| [200, {'CONTENT-Type' => 'foo/bar'}, "Hello, World!"] }
+    app = lambda { |env| [200, { 'CONTENT-Type' => 'foo/bar' }, "Hello, World!"] }
     headers = content_type(app).call(request)[1]
-    headers.to_a.select { |k,v| k.downcase == "content-type" }.
-      must_equal [["CONTENT-Type","foo/bar"]]
+    headers.to_a.select { |k, v| k.downcase == "content-type" }.
+      must_equal [["CONTENT-Type", "foo/bar"]]
   end
 
   it "not set Content-Type on 304 responses" do

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -98,7 +98,7 @@ describe Rack::Deflater do
   end
 
   def deflate_or_gzip
-    {'deflate, gzip' => 'gzip'}
+    { 'deflate, gzip' => 'gzip' }
   end
 
   it 'be able to deflate bodies that respond to each' do

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 
 describe Rack::Directory do
   DOCROOT = File.expand_path(File.dirname(__FILE__)) unless defined? DOCROOT
-  FILE_CATCH = proc{|env| [200, {'Content-Type'=>'text/plain', "Content-Length" => "7"}, ['passed!']] }
+  FILE_CATCH = proc{|env| [200, { 'Content-Type' => 'text/plain', "Content-Length" => "7" }, ['passed!']] }
 
   attr_reader :app
 
@@ -25,7 +25,7 @@ describe Rack::Directory do
       FileUtils.touch File.join(full_dir, "omg.txt")
       app = Rack::Directory.new(dir, FILE_CATCH)
       env = Rack::MockRequest.env_for("/#{plus_dir}/")
-      status,_,body = app.call env
+      status, _, body = app.call env
 
       assert_equal 200, status
 
@@ -111,7 +111,7 @@ describe Rack::Directory do
       FileUtils.touch File.join(full_dir, "omg omg.txt")
       app = Rack::Directory.new(dir, FILE_CATCH)
       env = Rack::MockRequest.env_for(Rack::Utils.escape_path("/#{space_dir}/"))
-      status,_,body = app.call env
+      status, _, body = app.call env
 
       assert_equal 200, status
 

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -22,79 +22,79 @@ describe Rack::ETag do
   end
 
   it "set ETag if none is set if status is 200" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ["Hello, World!"]] }
     response = etag(app).call(request)
     response[1]['ETag'].must_equal "W/\"dffd6021bb2bd5b0af676290809ec3a5\""
   end
 
   it "set ETag if none is set if status is 201" do
-    app = lambda { |env| [201, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+    app = lambda { |env| [201, { 'Content-Type' => 'text/plain' }, ["Hello, World!"]] }
     response = etag(app).call(request)
     response[1]['ETag'].must_equal "W/\"dffd6021bb2bd5b0af676290809ec3a5\""
   end
 
   it "set Cache-Control to 'max-age=0, private, must-revalidate' (default) if none is set" do
-    app = lambda { |env| [201, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+    app = lambda { |env| [201, { 'Content-Type' => 'text/plain' }, ["Hello, World!"]] }
     response = etag(app).call(request)
     response[1]['Cache-Control'].must_equal 'max-age=0, private, must-revalidate'
   end
 
   it "set Cache-Control to chosen one if none is set" do
-    app = lambda { |env| [201, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+    app = lambda { |env| [201, { 'Content-Type' => 'text/plain' }, ["Hello, World!"]] }
     response = etag(app, nil, 'public').call(request)
     response[1]['Cache-Control'].must_equal 'public'
   end
 
   it "set a given Cache-Control even if digest could not be calculated" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, []] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, []] }
     response = etag(app, 'no-cache').call(request)
     response[1]['Cache-Control'].must_equal 'no-cache'
   end
 
   it "not set Cache-Control if it is already set" do
-    app = lambda { |env| [201, {'Content-Type' => 'text/plain', 'Cache-Control' => 'public'}, ["Hello, World!"]] }
+    app = lambda { |env| [201, { 'Content-Type' => 'text/plain', 'Cache-Control' => 'public' }, ["Hello, World!"]] }
     response = etag(app).call(request)
     response[1]['Cache-Control'].must_equal 'public'
   end
 
   it "not set Cache-Control if directive isn't present" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ["Hello, World!"]] }
     response = etag(app, nil, nil).call(request)
     response[1]['Cache-Control'].must_be_nil
   end
 
   it "not change ETag if it is already set" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain', 'ETag' => '"abc"'}, ["Hello, World!"]] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'ETag' => '"abc"' }, ["Hello, World!"]] }
     response = etag(app).call(request)
     response[1]['ETag'].must_equal "\"abc\""
   end
 
   it "not set ETag if body is empty" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain', 'Last-Modified' => Time.now.httpdate}, []] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Last-Modified' => Time.now.httpdate }, []] }
     response = etag(app).call(request)
     response[1]['ETag'].must_be_nil
   end
 
   it "not set ETag if Last-Modified is set" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain', 'Last-Modified' => Time.now.httpdate}, ["Hello, World!"]] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Last-Modified' => Time.now.httpdate }, ["Hello, World!"]] }
     response = etag(app).call(request)
     response[1]['ETag'].must_be_nil
   end
 
   it "not set ETag if a sendfile_body is given" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, sendfile_body] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, sendfile_body] }
     response = etag(app).call(request)
     response[1]['ETag'].must_be_nil
   end
 
   it "not set ETag if a status is not 200 or 201" do
-    app = lambda { |env| [401, {'Content-Type' => 'text/plain'}, ['Access denied.']] }
+    app = lambda { |env| [401, { 'Content-Type' => 'text/plain' }, ['Access denied.']] }
     response = etag(app).call(request)
     response[1]['ETag'].must_be_nil
   end
 
   it "not set ETag if no-cache is given" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain', 'Cache-Control' => 'no-cache, must-revalidate'}, ['Hello, World!']] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Cache-Control' => 'no-cache, must-revalidate' }, ['Hello, World!']] }
     response = etag(app).call(request)
     response[1]['ETag'].must_be_nil
   end

--- a/test/spec_fastcgi.rb
+++ b/test/spec_fastcgi.rb
@@ -38,7 +38,7 @@ describe Rack::Handler::FastCGI do
 
   it "have rack headers" do
     GET("/test.fcgi")
-    response["rack.version"].must_equal [1,3]
+    response["rack.version"].must_equal [1, 3]
     assert_equal false, response["rack.multithread"]
     assert_equal true, response["rack.multiprocess"]
     assert_equal false, response["rack.run_once"]
@@ -62,7 +62,7 @@ describe Rack::Handler::FastCGI do
   end
 
   it "have CGI headers on POST" do
-    POST("/test.fcgi", {"rack-form-data" => "23"}, {'X-test-header' => '42'})
+    POST("/test.fcgi", { "rack-form-data" => "23" }, { 'X-test-header' => '42' })
     status.must_equal 200
     response["REQUEST_METHOD"].must_equal "POST"
     response["SCRIPT_NAME"].must_equal "/test.fcgi"
@@ -73,7 +73,7 @@ describe Rack::Handler::FastCGI do
   end
 
   it "support HTTP auth" do
-    GET("/test.fcgi", {user: "ruth", passwd: "secret"})
+    GET("/test.fcgi", { user: "ruth", passwd: "secret" })
     response["HTTP_AUTHORIZATION"].must_equal "Basic cnV0aDpzZWNyZXQ="
   end
 

--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -17,7 +17,7 @@ describe Rack::File do
       File.write File.join(dir, "you+me.txt"), "hello world"
       app = file(dir)
       env = Rack::MockRequest.env_for("/you+me.txt")
-      status,_,body = app.call env
+      status, _, body = app.call env
 
       assert_equal 200, status
 

--- a/test/spec_head.rb
+++ b/test/spec_head.rb
@@ -10,7 +10,7 @@ describe Rack::Head do
   def test_response(headers = {})
     body = StringIO.new "foo"
     app = lambda do |env|
-      [200, {"Content-type" => "test/plain", "Content-length" => "3"}, body]
+      [200, { "Content-type" => "test/plain", "Content-length" => "3" }, body]
     end
     request = Rack::MockRequest.env_for("/", headers)
     response = Rack::Lint.new(Rack::Head.new(app)).call(request)

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -13,7 +13,7 @@ describe Rack::Lint do
 
   it "pass valid request" do
     Rack::Lint.new(lambda { |env|
-                     [200, {"Content-type" => "test/plain", "Content-length" => "3"}, ["foo"]]
+                     [200, { "Content-type" => "test/plain", "Content-length" => "3" }, ["foo"]]
                    }).call(env({})).first.must_equal 200
   end
 
@@ -189,14 +189,14 @@ describe Rack::Lint do
 
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, {true=>false}, []]
+                       [200, { true => false }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_equal "header key must be a string, was TrueClass"
 
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, {"Status" => "404"}, []]
+                       [200, { "Status" => "404" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/must not contain Status/)
@@ -218,7 +218,7 @@ describe Rack::Lint do
     invalid_headers.each do |invalid_header|
       lambda {
         Rack::Lint.new(lambda { |env|
-          [200, {invalid_header => "text/plain"}, []]
+          [200, { invalid_header => "text/plain" }, []]
         }).call(env({}))
       }.must_raise(Rack::Lint::LintError, "on invalid header: #{invalid_header}").
       message.must_equal("invalid header name: #{invalid_header}")
@@ -226,20 +226,20 @@ describe Rack::Lint do
     valid_headers = 0.upto(127).map(&:chr) - invalid_headers
     valid_headers.each do |valid_header|
       Rack::Lint.new(lambda { |env|
-                       [200, {valid_header => "text/plain"}, []]
+                       [200, { valid_header => "text/plain" }, []]
                      }).call(env({})).first.must_equal 200
     end
 
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, {"Foo" => Object.new}, []]
+                       [200, { "Foo" => Object.new }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_equal "a header value must be a String, but the value of 'Foo' is a Object"
 
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, {"Foo" => [1, 2, 3]}, []]
+                       [200, { "Foo" => [1, 2, 3] }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_equal "a header value must be a String, but the value of 'Foo' is a Array"
@@ -247,14 +247,14 @@ describe Rack::Lint do
 
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, {"Foo-Bar" => "text\000plain"}, []]
+                       [200, { "Foo-Bar" => "text\000plain" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/invalid header/)
 
     # line ends (010).must_be :allowed in header values.?
     Rack::Lint.new(lambda { |env|
-                     [200, {"Foo-Bar" => "one\ntwo\nthree", "Content-Length" => "0", "Content-Type" => "text/plain" }, []]
+                     [200, { "Foo-Bar" => "one\ntwo\nthree", "Content-Length" => "0", "Content-Type" => "text/plain" }, []]
                    }).call(env({})).first.must_equal 200
 
     # non-Hash header responses.must_be :allowed?
@@ -274,7 +274,7 @@ describe Rack::Lint do
     [100, 101, 204, 304].each do |status|
       lambda {
         Rack::Lint.new(lambda { |env|
-                         [status, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                         [status, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                        }).call(env({}))
       }.must_raise(Rack::Lint::LintError).
         message.must_match(/Content-Type header found/)
@@ -285,7 +285,7 @@ describe Rack::Lint do
     [100, 101, 204, 304].each do |status|
       lambda {
         Rack::Lint.new(lambda { |env|
-                         [status, {"Content-length" => "0"}, []]
+                         [status, { "Content-length" => "0" }, []]
                        }).call(env({}))
       }.must_raise(Rack::Lint::LintError).
         message.must_match(/Content-Length header found/)
@@ -293,7 +293,7 @@ describe Rack::Lint do
 
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, {"Content-type" => "text/plain", "Content-Length" => "1"}, []]
+                       [200, { "Content-type" => "text/plain", "Content-Length" => "1" }, []]
                      }).call(env({}))[2].each { }
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/Content-Length header was 1, but should be 0/)
@@ -302,7 +302,7 @@ describe Rack::Lint do
   it "notice body errors" do
     lambda {
       body = Rack::Lint.new(lambda { |env|
-                               [200, {"Content-type" => "text/plain","Content-length" => "3"}, [1,2,3]]
+                               [200, { "Content-type" => "text/plain", "Content-length" => "3" }, [1, 2, 3]]
                              }).call(env({}))[2]
       body.each { |part| }
     }.must_raise(Rack::Lint::LintError).
@@ -313,7 +313,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].gets("\r\n")
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/gets called with arguments/)
@@ -321,7 +321,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].read(1, 2, 3)
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/read called with too many arguments/)
@@ -329,7 +329,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].read("foo")
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/read called with non-integer and non-nil length/)
@@ -337,7 +337,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].read(-1)
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/read called with a negative length/)
@@ -345,7 +345,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].read(nil, nil)
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/read called with non-String buffer/)
@@ -353,7 +353,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].read(nil, 1)
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/read called with non-String buffer/)
@@ -361,7 +361,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].rewind(0)
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/rewind called with arguments/)
@@ -406,7 +406,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].gets
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env("rack.input" => weirdio))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/gets didn't return a String/)
@@ -414,7 +414,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].each { |x| }
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env("rack.input" => weirdio))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/each didn't yield a String/)
@@ -422,7 +422,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].read
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env("rack.input" => weirdio))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/read didn't return nil or a String/)
@@ -430,7 +430,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].read
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env("rack.input" => eof_weirdio))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/read\(nil\) returned nil on EOF/)
@@ -438,7 +438,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].rewind
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env("rack.input" => weirdio))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/rewind raised Errno::ESPIPE/)
@@ -447,7 +447,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.input"].close
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/close must not be called/)
@@ -457,7 +457,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.errors"].write(42)
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/write not called with a String/)
@@ -465,7 +465,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(lambda { |env|
                        env["rack.errors"].close
-                       [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
+                       [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/close must not be called/)
@@ -473,13 +473,13 @@ describe Rack::Lint do
 
   it "notice HEAD errors" do
     Rack::Lint.new(lambda { |env|
-                     [200, {"Content-type" => "test/plain", "Content-length" => "3"}, []]
-                   }).call(env({"REQUEST_METHOD" => "HEAD"})).first.must_equal 200
+                     [200, { "Content-type" => "test/plain", "Content-length" => "3" }, []]
+                   }).call(env({ "REQUEST_METHOD" => "HEAD" })).first.must_equal 200
 
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, {"Content-type" => "test/plain", "Content-length" => "3"}, ["foo"]]
-                     }).call(env({"REQUEST_METHOD" => "HEAD"}))[2].each { }
+                       [200, { "Content-type" => "test/plain", "Content-length" => "3" }, ["foo"]]
+                     }).call(env({ "REQUEST_METHOD" => "HEAD" }))[2].each { }
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/body was given for HEAD/)
   end
@@ -490,8 +490,8 @@ describe Rack::Lint do
 
     Rack::Lint.new(lambda { |env|
                      env["rack.input"].send(:read, *args)
-                     [201, {"Content-type" => "text/plain", "Content-length" => "0"}, []]
-                   }).call(env({"rack.input" => StringIO.new(hello_str)})).
+                     [201, { "Content-type" => "text/plain", "Content-length" => "0" }, []]
+                   }).call(env({ "rack.input" => StringIO.new(hello_str) })).
       first.must_equal 201
   end
 

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -46,7 +46,7 @@ describe Rack::Lock do
         def each; %w{ hi mom }.each { |x| yield x }; end
       }.new
 
-      app = lock_app(lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, response] })
+      app = lock_app(lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, response] })
       response = app.call(env)[2]
       list = []
       response.each { |x| list << x }
@@ -60,7 +60,7 @@ describe Rack::Lock do
       res = ['Hello World']
       def res.to_path ; "/tmp/hello.txt" ; end
 
-      app = Rack::Lock.new(lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, res] }, lock)
+      app = Rack::Lock.new(lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, res] }, lock)
       body = app.call(env)[2]
 
       body.must_respond_to :to_path
@@ -68,11 +68,11 @@ describe Rack::Lock do
     end
 
     it 'not delegate to_path if body does not implement it' do
-      env  = Rack::MockRequest.env_for("/")
+      env = Rack::MockRequest.env_for("/")
 
       res = ['Hello World']
 
-      app = lock_app(lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, res] })
+      app = lock_app(lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, res] })
       body = app.call(env)[2]
 
       body.wont_respond_to :to_path
@@ -87,7 +87,7 @@ describe Rack::Lock do
       def close; @close_called = true; end
     }.new
 
-    app = lock_app(lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, response] })
+    app = lock_app(lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, response] })
     app.call(env)
     response.close_called.must_equal false
     response.close
@@ -98,7 +98,7 @@ describe Rack::Lock do
     lock     = Lock.new
     env      = Rack::MockRequest.env_for("/")
     response = Object.new
-    app      = lock_app(lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, response] }, lock)
+    app      = lock_app(lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, response] }, lock)
     lock.synchronized.must_equal false
     response = app.call(env)[2]
     lock.synchronized.must_equal true
@@ -108,7 +108,7 @@ describe Rack::Lock do
 
   it "return value from app" do
     env  = Rack::MockRequest.env_for("/")
-    body = [200, {"Content-Type" => "text/plain"}, %w{ hi mom }]
+    body = [200, { "Content-Type" => "text/plain" }, %w{ hi mom }]
     app  = lock_app(lambda { |inner_env| body })
 
     res = app.call(env)
@@ -120,7 +120,7 @@ describe Rack::Lock do
   it "call synchronize on lock" do
     lock = Lock.new
     env = Rack::MockRequest.env_for("/")
-    app = lock_app(lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, %w{ a b c }] }, lock)
+    app = lock_app(lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, %w{ a b c }] }, lock)
     lock.synchronized.must_equal false
     app.call(env)
     lock.synchronized.must_equal true
@@ -145,7 +145,7 @@ describe Rack::Lock do
   it "set multithread flag to false" do
     app = lock_app(lambda { |env|
       env['rack.multithread'].must_equal false
-      [200, {"Content-Type" => "text/plain"}, %w{ a b c }]
+      [200, { "Content-Type" => "text/plain" }, %w{ a b c }]
     }, false)
     env = Rack::MockRequest.env_for("/")
     env['rack.multithread'].must_equal true
@@ -160,7 +160,7 @@ describe Rack::Lock do
         env['rack.multithread'].must_equal true
         super
       end
-    }.new(lambda { |env| [200, {"Content-Type" => "text/plain"}, %w{ a b c }] })
+    }.new(lambda { |env| [200, { "Content-Type" => "text/plain" }, %w{ a b c }] })
     Rack::Lint.new(app).call(Rack::MockRequest.env_for("/"))
   end
 
@@ -172,7 +172,7 @@ describe Rack::Lock do
       def unlock() @unlocked = true end
     end.new
     env = Rack::MockRequest.env_for("/")
-    app = lock_app(proc { [200, {"Content-Type" => "text/plain"}, []] }, lock)
+    app = lock_app(proc { [200, { "Content-Type" => "text/plain" }, []] }, lock)
     lambda { app.call(env) }.must_raise Exception
     lock.unlocked?.must_equal false
   end
@@ -182,7 +182,7 @@ describe Rack::Lock do
       attr_reader :env
       def initialize(env) @env = env end
     end
-    app = Rack::Lock.new lambda { |env| [200, {"Content-Type" => "text/plain"}, proxy.new(env)] }
+    app = Rack::Lock.new lambda { |env| [200, { "Content-Type" => "text/plain" }, proxy.new(env)] }
     response = app.call(Rack::MockRequest.env_for("/"))[2]
     response.env['rack.multithread'].must_equal false
   end
@@ -197,7 +197,7 @@ describe Rack::Lock do
 
   it "not replace the environment" do
     env  = Rack::MockRequest.env_for("/")
-    app  = lock_app(lambda { |inner_env| [200, {"Content-Type" => "text/plain"}, [inner_env.object_id.to_s]] })
+    app  = lock_app(lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, [inner_env.object_id.to_s]] })
 
     _, _, body = app.call(env)
 

--- a/test/spec_logger.rb
+++ b/test/spec_logger.rb
@@ -13,7 +13,7 @@ describe Rack::Logger do
     log.info("Program started")
     log.warn("Nothing to do!")
 
-    [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]]
+    [200, { 'Content-Type' => 'text/plain' }, ["Hello, World!"]]
   }
 
   it "conform to Rack::Lint" do

--- a/test/spec_media_type.rb
+++ b/test/spec_media_type.rb
@@ -25,7 +25,7 @@ describe Rack::MediaType do
       Rack::MediaType.type(@content_type).must_equal 'application/text'
     end
 
-    it  '#params is empty' do
+    it '#params is empty' do
       Rack::MediaType.params(@content_type).must_equal @empty_hash
     end
   end

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -8,7 +8,7 @@ require 'rack/mock'
 describe Rack::MethodOverride do
   def app
     Rack::Lint.new(Rack::MethodOverride.new(lambda {|e|
-      [200, {"Content-Type" => "text/plain"}, []]
+      [200, { "Content-Type" => "text/plain" }, []]
     }))
   end
 
@@ -83,7 +83,7 @@ EOF
                       "CONTENT_LENGTH" => input.size.to_s,
                       Rack::RACK_ERRORS => StringIO.new,
                       :method => "POST", :input => input)
-    Rack::MethodOverride.new(proc { [200, {"Content-Type" => "text/plain"}, []] }).call env
+    Rack::MethodOverride.new(proc { [200, { "Content-Type" => "text/plain" }, []] }).call env
 
     env[Rack::RACK_ERRORS].rewind
     env[Rack::RACK_ERRORS].read.must_match /Bad request content body/

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -157,7 +157,7 @@ describe Rack::MockRequest do
   end
 
   it "accept params and build query string for GET requests" do
-    res = Rack::MockRequest.new(app).get("/foo?baz=2", params: {foo: {bar: "1"}})
+    res = Rack::MockRequest.new(app).get("/foo?baz=2", params: { foo: { bar: "1" } })
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["QUERY_STRING"].must_include "baz=2"
@@ -177,7 +177,7 @@ describe Rack::MockRequest do
   end
 
   it "accept params and build url encoded params for POST requests" do
-    res = Rack::MockRequest.new(app).post("/foo", params: {foo: {bar: "1"}})
+    res = Rack::MockRequest.new(app).post("/foo", params: { foo: { bar: "1" } })
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
     env["QUERY_STRING"].must_equal ""
@@ -217,7 +217,7 @@ describe Rack::MockRequest do
   it "call close on the original body object" do
     called = false
     body   = Rack::BodyProxy.new(['hi']) { called = true }
-    capp   = proc { |e| [200, {'Content-Type' => 'text/plain'}, body] }
+    capp   = proc { |e| [200, { 'Content-Type' => 'text/plain' }, body] }
     called.must_equal false
     Rack::MockRequest.new(capp).get('/', lint: true)
     called.must_equal true

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -172,7 +172,7 @@ describe Rack::Multipart do
     c = Class.new(Rack::QueryParser::Params) do
       def initialize(*)
         super
-        @params = Hash.new{|h,k| h[k.to_s] if k.is_a?(Symbol)}
+        @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
     query_parser = Rack::QueryParser.new c, 65536, 100
@@ -477,7 +477,7 @@ Content-Type: image/jpeg\r
 
   it "builds nested multipart body" do
     files = Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"))
-    data  = Rack::Multipart.build_multipart("people" => [{"submit-name" => "Larry", "files" => files}])
+    data  = Rack::Multipart.build_multipart("people" => [{ "submit-name" => "Larry", "files" => files }])
 
     options = {
       "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
@@ -557,7 +557,7 @@ Content-Type: image/jpeg\r
   end
 
   it "return nil if no UploadedFiles were used" do
-    data = Rack::Multipart.build_multipart("people" => [{"submit-name" => "Larry", "files" => "contents"}])
+    data = Rack::Multipart.build_multipart("people" => [{ "submit-name" => "Larry", "files" => "contents" }])
     data.must_be_nil
   end
 
@@ -584,7 +584,7 @@ EOF
     env = Rack::MockRequest.env_for("/", options)
     params = Rack::Multipart.parse_multipart(env)
 
-    params.must_equal "description"=>"Very very blue"
+    params.must_equal "description" => "Very very blue"
   end
 
   it "parse multipart upload with no content-length header" do

--- a/test/spec_null_logger.rb
+++ b/test/spec_null_logger.rb
@@ -9,14 +9,14 @@ describe Rack::NullLogger do
   it "act as a noop logger" do
     app = lambda { |env|
       env['rack.logger'].warn "b00m"
-      [200, {'Content-Type' => 'text/plain'}, ["Hello, World!"]]
+      [200, { 'Content-Type' => 'text/plain' }, ["Hello, World!"]]
     }
 
     logger = Rack::Lint.new(Rack::NullLogger.new(app))
 
     res = logger.call(Rack::MockRequest.env_for)
     res[0..1].must_equal [
-      200, {'Content-Type' => 'text/plain'}
+      200, { 'Content-Type' => 'text/plain' }
     ]
     res[2].to_enum.to_a.must_equal ["Hello, World!"]
   end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -55,7 +55,7 @@ class RackRequestTest < Minitest::Spec
     req = make_request(Rack::MockRequest.env_for("http://example.com:8080/"))
     req.set_header 'foo', 'bar'
     hash = {}
-    req.each_header do |k,v|
+    req.each_header do |k, v|
       hash[k] = v
     end
     assert_equal 'bar', hash['foo']
@@ -232,7 +232,7 @@ class RackRequestTest < Minitest::Spec
     c = Class.new(Rack::QueryParser::Params) do
       def initialize(*)
         super
-        @params = Hash.new{|h,k| h[k.to_s] if k.is_a?(Symbol)}
+        @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
     parser = Rack::QueryParser.new(c, 65536, 100)
@@ -274,7 +274,7 @@ class RackRequestTest < Minitest::Spec
 
     old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 3
     begin
-      exp = {"foo"=>{"bar"=>{"baz"=>{"qux"=>"1"}}}}
+      exp = { "foo" => { "bar" => { "baz" => { "qux" => "1" } } } }
       make_request(nested_query).GET.must_equal exp
       lambda { make_request(plain_query).GET  }.must_raise RangeError
     ensure
@@ -300,7 +300,7 @@ class RackRequestTest < Minitest::Spec
     c = Class.new(Rack::QueryParser::Params) do
       def initialize(*)
         super
-        @params = Hash.new{|h,k| h[k.to_s] if k.is_a?(Symbol)}
+        @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
     parser = Rack::QueryParser.new(c, 65536, 100)
@@ -724,7 +724,7 @@ class RackRequestTest < Minitest::Spec
   end
 
   it "provide setters" do
-    req = make_request(e=Rack::MockRequest.env_for(""))
+    req = make_request(e = Rack::MockRequest.env_for(""))
     req.script_name.must_equal ""
     req.script_name = "/foo"
     req.script_name.must_equal "/foo"
@@ -955,7 +955,7 @@ EOF
 --AaB03x\r
 content-disposition: form-data; name="huge"; filename="huge"\r
 \r
-#{"x"*32768}\r
+#{"x" * 32768}\r
 --AaB03x\r
 content-disposition: form-data; name="mean"; filename="mean"\r
 \r
@@ -1074,7 +1074,7 @@ EOF
 content-disposition: form-data; name="fileupload"; filename="junk.a"\r
 content-type: application/octet-stream\r
 \r
-#{[0x36,0xCF,0x0A,0xF8].pack('c*')}\r
+#{[0x36, 0xCF, 0x0A, 0xF8].pack('c*')}\r
 --AaB03x--\r
 EOF
 
@@ -1094,7 +1094,7 @@ EOF
     rack_input.rewind
 
     req = make_request Rack::MockRequest.env_for("/",
-                      "rack.request.form_hash" => {'foo' => 'bar'},
+                      "rack.request.form_hash" => { 'foo' => 'bar' },
                       "rack.request.form_input" => rack_input,
                       :input => rack_input)
 
@@ -1105,7 +1105,7 @@ EOF
     app = lambda { |env|
       content = make_request(env).POST["file"].inspect
       size = content.bytesize
-      [200, {"Content-Type" => "text/html", "Content-Length" => size.to_s}, [content]]
+      [200, { "Content-Type" => "text/html", "Content-Length" => size.to_s }, [content]]
     }
 
     input = <<EOF.dup
@@ -1337,7 +1337,7 @@ EOF
 
   class MyRequest < Rack::Request
     def params
-      {foo: "bar"}
+      { foo: "bar" }
     end
   end
 

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -80,103 +80,103 @@ describe Rack::Response do
 
   it "can set cookies with the same name for multiple domains" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", domain: "sample.example.com"}
-    response.set_cookie "foo", {value: "bar", domain: ".example.com"}
+    response.set_cookie "foo", { value: "bar", domain: "sample.example.com" }
+    response.set_cookie "foo", { value: "bar", domain: ".example.com" }
     response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=bar; domain=.example.com"].join("\n")
   end
 
   it "formats the Cookie expiration date accordingly to RFC 6265" do
     response = Rack::Response.new
 
-    response.set_cookie "foo", {value: "bar", expires: Time.now+10}
+    response.set_cookie "foo", { value: "bar", expires: Time.now + 10 }
     response["Set-Cookie"].must_match(
       /expires=..., \d\d ... \d\d\d\d \d\d:\d\d:\d\d .../)
   end
 
   it "can set secure cookies" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", secure: true}
+    response.set_cookie "foo", { value: "bar", secure: true }
     response["Set-Cookie"].must_equal "foo=bar; secure"
   end
 
   it "can set http only cookies" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", httponly: true}
+    response.set_cookie "foo", { value: "bar", httponly: true }
     response["Set-Cookie"].must_equal "foo=bar; HttpOnly"
   end
 
   it "can set http only cookies with :http_only" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", http_only: true}
+    response.set_cookie "foo", { value: "bar", http_only: true }
     response["Set-Cookie"].must_equal "foo=bar; HttpOnly"
   end
 
   it "can set prefers :httponly for http only cookie setting when :httponly and :http_only provided" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", httponly: false, http_only: true}
+    response.set_cookie "foo", { value: "bar", httponly: false, http_only: true }
     response["Set-Cookie"].must_equal "foo=bar"
   end
 
   it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", same_site: :lax}
+    response.set_cookie "foo", { value: "bar", same_site: :lax }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with symbol value :Lax" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", same_site: :lax}
+    response.set_cookie "foo", { value: "bar", same_site: :lax }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with string value 'Lax'" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", same_site: "Lax"}
+    response.set_cookie "foo", { value: "bar", same_site: "Lax" }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with boolean value true" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", same_site: true}
+    response.set_cookie "foo", { value: "bar", same_site: true }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with symbol value :strict" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", same_site: :strict}
+    response.set_cookie "foo", { value: "bar", same_site: :strict }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with symbol value :Strict" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", same_site: :Strict}
+    response.set_cookie "foo", { value: "bar", same_site: :Strict }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with string value 'Strict'" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", same_site: "Strict"}
+    response.set_cookie "foo", { value: "bar", same_site: "Strict" }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   it "validates the SameSite option value" do
     response = Rack::Response.new
     lambda {
-      response.set_cookie "foo", {value: "bar", same_site: "Foo"}
+      response.set_cookie "foo", { value: "bar", same_site: "Foo" }
     }.must_raise(ArgumentError).
       message.must_match(/Invalid SameSite value: "Foo"/)
   end
 
   it "can set SameSite cookies with symbol value" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", same_site: :Strict}
+    response.set_cookie "foo", { value: "bar", same_site: :Strict }
     response["Set-Cookie"].must_equal "foo=bar; SameSite=Strict"
   end
 
   [ nil, false ].each do |non_truthy|
     it "omits SameSite attribute given a #{non_truthy.inspect} value" do
       response = Rack::Response.new
-      response.set_cookie "foo", {value: "bar", same_site: non_truthy}
+      response.set_cookie "foo", { value: "bar", same_site: non_truthy }
       response["Set-Cookie"].must_equal "foo=bar"
     end
   end
@@ -194,8 +194,8 @@ describe Rack::Response do
 
   it "can delete cookies with the same name from multiple domains" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", domain: "sample.example.com"}
-    response.set_cookie "foo", {value: "bar", domain: ".example.com"}
+    response.set_cookie "foo", { value: "bar", domain: "sample.example.com" }
+    response.set_cookie "foo", { value: "bar", domain: ".example.com" }
     response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=bar; domain=.example.com"].join("\n")
     response.delete_cookie "foo", domain: ".example.com"
     response["Set-Cookie"].must_equal ["foo=bar; domain=sample.example.com", "foo=; domain=.example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"].join("\n")
@@ -206,8 +206,8 @@ describe Rack::Response do
 
   it "can delete cookies with the same name with different paths" do
     response = Rack::Response.new
-    response.set_cookie "foo", {value: "bar", path: "/"}
-    response.set_cookie "foo", {value: "bar", path: "/path"}
+    response.set_cookie "foo", { value: "bar", path: "/" }
+    response.set_cookie "foo", { value: "bar", path: "/path" }
     response["Set-Cookie"].must_equal ["foo=bar; path=/",
                                          "foo=bar; path=/path"].join("\n")
 

--- a/test/spec_runtime.rb
+++ b/test/spec_runtime.rb
@@ -15,25 +15,25 @@ describe Rack::Runtime do
   end
 
   it "sets X-Runtime is none is set" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, "Hello, World!"] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, "Hello, World!"] }
     response = runtime_app(app).call(request)
     response[1]['X-Runtime'].must_match(/[\d\.]+/)
   end
 
   it "doesn't set the X-Runtime if it is already set" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain', "X-Runtime" => "foobar"}, "Hello, World!"] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', "X-Runtime" => "foobar" }, "Hello, World!"] }
     response = runtime_app(app).call(request)
     response[1]['X-Runtime'].must_equal "foobar"
   end
 
   it "allow a suffix to be set" do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, "Hello, World!"] }
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, "Hello, World!"] }
     response = runtime_app(app, "Test").call(request)
     response[1]['X-Runtime-Test'].must_match(/[\d\.]+/)
   end
 
   it "allow multiple timers to be set" do
-    app = lambda { |env| sleep 0.1; [200, {'Content-Type' => 'text/plain'}, "Hello, World!"] }
+    app = lambda { |env| sleep 0.1; [200, { 'Content-Type' => 'text/plain' }, "Hello, World!"] }
     runtime = runtime_app(app, "App")
 
     # wrap many times to guarantee a measurable difference

--- a/test/spec_sendfile.rb
+++ b/test/spec_sendfile.rb
@@ -15,15 +15,15 @@ describe Rack::Sendfile do
     res
   end
 
-  def simple_app(body=sendfile_body)
-    lambda { |env| [200, {'Content-Type' => 'text/plain'}, body] }
+  def simple_app(body = sendfile_body)
+    lambda { |env| [200, { 'Content-Type' => 'text/plain' }, body] }
   end
 
   def sendfile_app(body, mappings = [])
     Rack::Lint.new Rack::Sendfile.new(simple_app(body), nil, mappings)
   end
 
-  def request(headers={}, body=sendfile_body, mappings=[])
+  def request(headers = {}, body = sendfile_body, mappings = [])
     yield Rack::MockRequest.new(sendfile_app(body, mappings)).get('/', headers)
   end
 
@@ -84,7 +84,7 @@ describe Rack::Sendfile do
   end
 
   it 'does nothing when body does not respond to #to_path' do
-    request({'HTTP_X_SENDFILE_TYPE' => 'X-Sendfile'}, ['Not a file...']) do |response|
+    request({ 'HTTP_X_SENDFILE_TYPE' => 'X-Sendfile' }, ['Not a file...']) do |response|
       response.body.must_equal 'Not a file...'
       response.headers.wont_include 'X-Sendfile'
     end
@@ -106,14 +106,14 @@ describe Rack::Sendfile do
         ["#{dir2}/", '/wibble/']
       ]
 
-      request({'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect'}, first_body, mappings) do |response|
+      request({ 'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect' }, first_body, mappings) do |response|
         response.must_be :ok?
         response.body.must_be :empty?
         response.headers['Content-Length'].must_equal '0'
         response.headers['X-Accel-Redirect'].must_equal '/foo/bar/rack_sendfile'
       end
 
-      request({'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect'}, second_body, mappings) do |response|
+      request({ 'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect' }, second_body, mappings) do |response|
         response.must_be :ok?
         response.body.must_be :empty?
         response.headers['Content-Length'].must_equal '0'

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -17,7 +17,7 @@ describe Rack::Server do
   before { SPEC_ARGV[0..-1] = [] }
 
   def app
-    lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['success']] }
+    lambda { |env| [200, { 'Content-Type' => 'text/plain' }, ['success']] }
   end
 
   def with_stderr

--- a/test/spec_session_abstract_session_hash.rb
+++ b/test/spec_session_abstract_session_hash.rb
@@ -10,7 +10,7 @@ describe Rack::Session::Abstract::SessionHash do
     super
     store = Class.new do
       def load_session(req)
-        ["id", {foo: :bar, baz: :qux}]
+        ["id", { foo: :bar, baz: :qux }]
       end
       def session_exists?(req)
         true

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -47,7 +47,7 @@ describe Rack::Session::Cookie do
     Rack::Response.new("Nothing").to_a
   end
 
-  def response_for(options={})
+  def response_for(options = {})
     request_options = options.fetch(:request, {})
     cookie = if options[:cookie].is_a?(Rack::Response)
       options[:cookie]["Set-Cookie"]
@@ -387,7 +387,7 @@ describe Rack::Session::Cookie do
 
   it "returns even if not read/written if :expire_after is set" do
     app = [nothing, { expire_after: 3600 }]
-    request = { "rack.session" => { "not" => "empty" }}
+    request = { "rack.session" => { "not" => "empty" } }
     response = response_for(app: app, request: request)
     response["Set-Cookie"].wont_be :nil?
   end
@@ -409,13 +409,13 @@ describe Rack::Session::Cookie do
   end
 
   it "allows passing in a hash with session data from middleware in front" do
-    request = { 'rack.session' => { foo: 'bar' }}
+    request = { 'rack.session' => { foo: 'bar' } }
     response = response_for(app: session_id, request: request)
     response.body.must_match(/foo/)
   end
 
   it "allows modifying session data with session data from middleware in front" do
-    request = { 'rack.session' => { foo: 'bar' }}
+    request = { 'rack.session' => { foo: 'bar' } }
     response = response_for(app: incrementor, request: request)
     response.body.must_match(/counter/)
     response.body.must_match(/foo/)

--- a/test/spec_session_memcache.rb
+++ b/test/spec_session_memcache.rb
@@ -218,7 +218,7 @@ begin
         session = env['rack.session']
         unless session.include? 'test'
           session.update :a => :b, :c => { d: :e },
-            :f => { g: { h: :i} }, 'test' => true
+            :f => { g: { h: :i } }, 'test' => true
         else
           session[:f][:g][:h] = :j
         end
@@ -254,12 +254,12 @@ begin
         # emulate disconjoinment of threading
         env['rack.session'] = env['rack.session'].dup
         Thread.stop
-        env['rack.session'][(Time.now.usec*rand).to_i] = true
+        env['rack.session'][(Time.now.usec * rand).to_i] = true
         incrementor.call(env)
       end
       tses = Rack::Utils::Context.new pool, delta_incrementor
       treq = Rack::MockRequest.new(tses)
-      tnum = rand(7).to_i+5
+      tnum = rand(7).to_i + 5
       r = Array.new(tnum) do
         Thread.new(treq) do |run|
           run.get('/', "HTTP_COOKIE" => cookie, 'rack.multithread' => true)
@@ -271,10 +271,10 @@ begin
       end
 
       session = pool.pool.get(session_id)
-      session.size.must_equal tnum+1 # counter
+      session.size.must_equal tnum + 1 # counter
       session['counter'].must_equal 2 # meeeh
 
-      tnum = rand(7).to_i+5
+      tnum = rand(7).to_i + 5
       r = Array.new(tnum) do
         app = Rack::Utils::Context.new pool, time_delta
         req = Rack::MockRequest.new app
@@ -288,17 +288,17 @@ begin
       end
 
       session = pool.pool.get(session_id)
-      session.size.must_equal tnum+1
+      session.size.must_equal tnum + 1
       session['counter'].must_equal 3
 
       drop_counter = proc do |env|
         env['rack.session'].delete 'counter'
         env['rack.session']['foo'] = 'bar'
-        [200, {'Content-Type'=>'text/plain'}, env['rack.session'].inspect]
+        [200, { 'Content-Type' => 'text/plain' }, env['rack.session'].inspect]
       end
       tses = Rack::Utils::Context.new pool, drop_counter
       treq = Rack::MockRequest.new(tses)
-      tnum = rand(7).to_i+5
+      tnum = rand(7).to_i + 5
       r = Array.new(tnum) do
         Thread.new(treq) do |run|
           run.get('/', "HTTP_COOKIE" => cookie, 'rack.multithread' => true)
@@ -310,7 +310,7 @@ begin
       end
 
       session = pool.pool.get(session_id)
-      session.size.must_equal r.size+1
+      session.size.must_equal r.size + 1
       session['counter'].must_be_nil?
       session['foo'].must_equal 'bar'
     end

--- a/test/spec_session_pool.rb
+++ b/test/spec_session_pool.rb
@@ -159,18 +159,18 @@ describe Rack::Session::Pool do
     res = req.get('/')
     res.body.must_equal '{"counter"=>1}'
     cookie = res["Set-Cookie"]
-    sess_id = cookie[/#{pool.key}=([^,;]+)/,1]
+    sess_id = cookie[/#{pool.key}=([^,;]+)/, 1]
 
     delta_incrementor = lambda do |env|
       # emulate disconjoinment of threading
       env['rack.session'] = env['rack.session'].dup
       Thread.stop
-      env['rack.session'][(Time.now.usec*rand).to_i] = true
+      env['rack.session'][(Time.now.usec * rand).to_i] = true
       incrementor.call(env)
     end
     tses = Rack::Utils::Context.new pool, delta_incrementor
     treq = Rack::MockRequest.new(tses)
-    tnum = rand(7).to_i+5
+    tnum = rand(7).to_i + 5
     r = Array.new(tnum) do
       Thread.new(treq) do |run|
         run.get('/', "HTTP_COOKIE" => cookie, 'rack.multithread' => true)
@@ -182,7 +182,7 @@ describe Rack::Session::Pool do
     end
 
     session = pool.pool[sess_id]
-    session.size.must_equal tnum+1 # counter
+    session.size.must_equal tnum + 1 # counter
     session['counter'].must_equal 2 # meeeh
   end
 
@@ -200,7 +200,7 @@ describe Rack::Session::Pool do
 
   it "returns even if not read/written if :expire_after is set" do
     app = Rack::Session::Pool.new(nothing, expire_after: 3600)
-    res = Rack::MockRequest.new(app).get("/", 'rack.session' => {'not' => 'empty'})
+    res = Rack::MockRequest.new(app).get("/", 'rack.session' => { 'not' => 'empty' })
     res["Set-Cookie"].wont_be :nil?
   end
 

--- a/test/spec_show_exceptions.rb
+++ b/test/spec_show_exceptions.rb
@@ -37,11 +37,11 @@ describe Rack::ShowExceptions do
 
     [
       # Serve text/html when the client accepts text/html
-      ["text/html", ["/", {"HTTP_ACCEPT" => "text/html"}]],
-      ["text/html", ["/", {"HTTP_ACCEPT" => "*/*"}]],
+      ["text/html", ["/", { "HTTP_ACCEPT" => "text/html" }]],
+      ["text/html", ["/", { "HTTP_ACCEPT" => "*/*" }]],
       # Serve text/plain when the client does not accept text/html
       ["text/plain", ["/"]],
-      ["text/plain", ["/", {"HTTP_ACCEPT" => "application/json"}]]
+      ["text/plain", ["/", { "HTTP_ACCEPT" => "application/json" }]]
     ].each do |exmime, rargs|
       res = req.get(*rargs)
 

--- a/test/spec_show_status.rb
+++ b/test/spec_show_status.rb
@@ -14,7 +14,7 @@ describe Rack::ShowStatus do
   it "provide a default status message" do
     req = Rack::MockRequest.new(
       show_status(lambda{|env|
-        [404, {"Content-Type" => "text/plain", "Content-Length" => "0"}, []]
+        [404, { "Content-Type" => "text/plain", "Content-Length" => "0" }, []]
     }))
 
     res = req.get("/", lint: true)
@@ -31,7 +31,7 @@ describe Rack::ShowStatus do
       show_status(
         lambda{|env|
           env["rack.showstatus.detail"] = "gone too meta."
-          [404, {"Content-Type" => "text/plain", "Content-Length" => "0"}, []]
+          [404, { "Content-Type" => "text/plain", "Content-Length" => "0" }, []]
     }))
 
     res = req.get("/", lint: true)
@@ -50,7 +50,7 @@ describe Rack::ShowStatus do
       show_status(
         lambda{|env|
           env["rack.showstatus.detail"] = detail
-          [500, {"Content-Type" => "text/plain", "Content-Length" => "0"}, []]
+          [500, { "Content-Type" => "text/plain", "Content-Length" => "0" }, []]
     }))
 
     res = req.get("/", lint: true)
@@ -66,7 +66,7 @@ describe Rack::ShowStatus do
     req = Rack::MockRequest.new(
       show_status(
         lambda{|env|
-          [404, {"Content-Type" => "text/plain", "Content-Length" => "4"}, ["foo!"]]
+          [404, { "Content-Type" => "text/plain", "Content-Length" => "4" }, ["foo!"]]
     }))
 
     res = req.get("/", lint: true)
@@ -76,7 +76,7 @@ describe Rack::ShowStatus do
   end
 
   it "pass on original headers" do
-    headers = {"WWW-Authenticate" => "Basic blah"}
+    headers = { "WWW-Authenticate" => "Basic blah" }
 
     req = Rack::MockRequest.new(
       show_status(lambda{|env| [401, headers, []] }))
@@ -90,7 +90,7 @@ describe Rack::ShowStatus do
       show_status(
         lambda{|env|
           env["rack.showstatus.detail"] = "gone too meta."
-          [404, {"Content-Type" => "text/plain", "Content-Length" => "4"}, ["foo!"]]
+          [404, { "Content-Type" => "text/plain", "Content-Length" => "4" }, ["foo!"]]
     }))
 
     res = req.get("/", lint: true)

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -9,7 +9,7 @@ require 'stringio'
 
 class DummyApp
   def call(env)
-    [200, {"Content-Type" => "text/plain"}, ["Hello World"]]
+    [200, { "Content-Type" => "text/plain" }, ["Hello World"]]
   end
 end
 
@@ -20,11 +20,11 @@ describe Rack::Static do
 
   root = File.expand_path(File.dirname(__FILE__))
 
-  OPTIONS = {urls: ["/cgi"], root: root}
-  STATIC_OPTIONS = {urls: [""], root: "#{root}/static", index: 'index.html'}
-  HASH_OPTIONS = {urls: {"/cgi/sekret" => 'cgi/test'}, root: root}
-  HASH_ROOT_OPTIONS = {urls: {"/" => "static/foo.html"}, root: root}
-  GZIP_OPTIONS = {urls: ["/cgi"], root: root, gzip: true}
+  OPTIONS = { urls: ["/cgi"], root: root }
+  STATIC_OPTIONS = { urls: [""], root: "#{root}/static", index: 'index.html' }
+  HASH_OPTIONS = { urls: { "/cgi/sekret" => 'cgi/test' }, root: root }
+  HASH_ROOT_OPTIONS = { urls: { "/" => "static/foo.html" }, root: root }
+  GZIP_OPTIONS = { urls: ["/cgi"], root: root, gzip: true }
 
   before do
   @request = Rack::MockRequest.new(static(DummyApp.new, OPTIONS))
@@ -89,7 +89,7 @@ describe Rack::Static do
   end
 
   it "serves gzipped files if client accepts gzip encoding and gzip files are present" do
-    res = @gzip_request.get("/cgi/test", 'HTTP_ACCEPT_ENCODING'=>'deflate, gzip')
+    res = @gzip_request.get("/cgi/test", 'HTTP_ACCEPT_ENCODING' => 'deflate, gzip')
     res.must_be :ok?
     res.headers['Content-Encoding'].must_equal 'gzip'
     res.headers['Content-Type'].must_equal 'text/plain'
@@ -97,7 +97,7 @@ describe Rack::Static do
   end
 
   it "serves regular files if client accepts gzip encoding and gzip files are not present" do
-    res = @gzip_request.get("/cgi/rackup_stub.rb", 'HTTP_ACCEPT_ENCODING'=>'deflate, gzip')
+    res = @gzip_request.get("/cgi/rackup_stub.rb", 'HTTP_ACCEPT_ENCODING' => 'deflate, gzip')
     res.must_be :ok?
     res.headers['Content-Encoding'].must_be_nil
     res.headers['Content-Type'].must_equal 'text/x-script.ruby'
@@ -120,14 +120,14 @@ describe Rack::Static do
     res.headers['Cache-Control'].must_equal 'public'
   end
 
-  HEADER_OPTIONS = {urls: ["/cgi"], root: root, header_rules: [
-    [:all, {'Cache-Control' => 'public, max-age=100'}],
-    [:fonts, {'Cache-Control' => 'public, max-age=200'}],
-    [%w(png jpg), {'Cache-Control' => 'public, max-age=300'}],
-    ['/cgi/assets/folder/', {'Cache-Control' => 'public, max-age=400'}],
-    ['cgi/assets/javascripts', {'Cache-Control' => 'public, max-age=500'}],
-    [/\.(css|erb)\z/, {'Cache-Control' => 'public, max-age=600'}]
-  ]}
+  HEADER_OPTIONS = { urls: ["/cgi"], root: root, header_rules: [
+    [:all, { 'Cache-Control' => 'public, max-age=100' }],
+    [:fonts, { 'Cache-Control' => 'public, max-age=200' }],
+    [%w(png jpg), { 'Cache-Control' => 'public, max-age=300' }],
+    ['/cgi/assets/folder/', { 'Cache-Control' => 'public, max-age=400' }],
+    ['cgi/assets/javascripts', { 'Cache-Control' => 'public, max-age=500' }],
+    [/\.(css|erb)\z/, { 'Cache-Control' => 'public, max-age=600' }]
+  ] }
 
   it "supports header rule :all" do
     # Headers for all files via :all shortcut
@@ -174,7 +174,7 @@ describe Rack::Static do
     opts = OPTIONS.merge(
       cache_control: 'public, max-age=24',
       header_rules: [
-        [:all, {'Cache-Control' => 'public, max-age=42'}]
+        [:all, { 'Cache-Control' => 'public, max-age=42' }]
       ])
 
     request = Rack::MockRequest.new(static(DummyApp.new, opts))

--- a/test/spec_thin.rb
+++ b/test/spec_thin.rb
@@ -15,7 +15,7 @@ describe Rack::Handler::Thin do
     Thin::Logging.silent = true
 
     @thread = Thread.new do
-      Rack::Handler::Thin.run(@app, Host: @host='127.0.0.1', Port: @port=9204, tag: "tag") do |server|
+      Rack::Handler::Thin.run(@app, Host: @host = '127.0.0.1', Port: @port = 9204, tag: "tag") do |server|
         @server = server
       end
     end
@@ -46,7 +46,7 @@ describe Rack::Handler::Thin do
 
   it "have rack headers" do
     GET("/")
-    response["rack.version"].must_equal [1,0]
+    response["rack.version"].must_equal [1, 0]
     response["rack.multithread"].must_equal false
     response["rack.multiprocess"].must_equal false
     response["rack.run_once"].must_equal false
@@ -68,7 +68,7 @@ describe Rack::Handler::Thin do
   end
 
   it "have CGI headers on POST" do
-    POST("/", {"rack-form-data" => "23"}, {'X-test-header' => '42'})
+    POST("/", { "rack-form-data" => "23" }, { 'X-test-header' => '42' })
     status.must_equal 200
     response["REQUEST_METHOD"].must_equal "POST"
     response["REQUEST_PATH"].must_equal "/"
@@ -78,7 +78,7 @@ describe Rack::Handler::Thin do
   end
 
   it "support HTTP auth" do
-    GET("/test", {user: "ruth", passwd: "secret"})
+    GET("/test", { user: "ruth", passwd: "secret" })
     response["HTTP_AUTHORIZATION"].must_equal "Basic cnV0aDpzZWNyZXQ="
   end
 

--- a/test/spec_urlmap.rb
+++ b/test/spec_urlmap.rb
@@ -137,7 +137,7 @@ describe Rack::URLMap do
   it "be nestable" do
     map = Rack::Lint.new(Rack::URLMap.new("/foo" =>
       Rack::URLMap.new("/bar" =>
-        Rack::URLMap.new("/quux" =>  lambda { |env|
+        Rack::URLMap.new("/quux" => lambda { |env|
                            [200,
                             { "Content-Type" => "text/plain",
                               "X-Position" => "/foo/bar/quux",

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -73,7 +73,7 @@ describe Rack::Utils do
   end
 
   it "escape path spaces with %20" do
-    Rack::Utils.escape_path("foo bar").must_equal  "foo%20bar"
+    Rack::Utils.escape_path("foo bar").must_equal "foo%20bar"
   end
 
   it "unescape correctly" do
@@ -182,38 +182,38 @@ describe Rack::Utils do
       must_equal "foo" => ["bar"], "baz" => ["1", "2", "3"]
 
     Rack::Utils.parse_nested_query("x[y][z]=1").
-      must_equal "x" => {"y" => {"z" => "1"}}
+      must_equal "x" => { "y" => { "z" => "1" } }
     Rack::Utils.parse_nested_query("x[y][z][]=1").
-      must_equal "x" => {"y" => {"z" => ["1"]}}
+      must_equal "x" => { "y" => { "z" => ["1"] } }
     Rack::Utils.parse_nested_query("x[y][z]=1&x[y][z]=2").
-      must_equal "x" => {"y" => {"z" => "2"}}
+      must_equal "x" => { "y" => { "z" => "2" } }
     Rack::Utils.parse_nested_query("x[y][z][]=1&x[y][z][]=2").
-      must_equal "x" => {"y" => {"z" => ["1", "2"]}}
+      must_equal "x" => { "y" => { "z" => ["1", "2"] } }
 
     Rack::Utils.parse_nested_query("x[y][][z]=1").
-      must_equal "x" => {"y" => [{"z" => "1"}]}
+      must_equal "x" => { "y" => [{ "z" => "1" }] }
     Rack::Utils.parse_nested_query("x[y][][z][]=1").
-      must_equal "x" => {"y" => [{"z" => ["1"]}]}
+      must_equal "x" => { "y" => [{ "z" => ["1"] }] }
     Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][w]=2").
-      must_equal "x" => {"y" => [{"z" => "1", "w" => "2"}]}
+      must_equal "x" => { "y" => [{ "z" => "1", "w" => "2" }] }
 
     Rack::Utils.parse_nested_query("x[y][][v][w]=1").
-      must_equal "x" => {"y" => [{"v" => {"w" => "1"}}]}
+      must_equal "x" => { "y" => [{ "v" => { "w" => "1" } }] }
     Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][v][w]=2").
-      must_equal "x" => {"y" => [{"z" => "1", "v" => {"w" => "2"}}]}
+      must_equal "x" => { "y" => [{ "z" => "1", "v" => { "w" => "2" } }] }
 
     Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][z]=2").
-      must_equal "x" => {"y" => [{"z" => "1"}, {"z" => "2"}]}
+      must_equal "x" => { "y" => [{ "z" => "1" }, { "z" => "2" }] }
     Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][w]=a&x[y][][z]=2&x[y][][w]=3").
-      must_equal "x" => {"y" => [{"z" => "1", "w" => "a"}, {"z" => "2", "w" => "3"}]}
+      must_equal "x" => { "y" => [{ "z" => "1", "w" => "a" }, { "z" => "2", "w" => "3" }] }
 
     Rack::Utils.parse_nested_query("x[][y]=1&x[][z][w]=a&x[][y]=2&x[][z][w]=b").
-      must_equal "x" => [{"y" => "1", "z" => {"w" => "a"}}, {"y" => "2", "z" => {"w" => "b"}}]
+      must_equal "x" => [{ "y" => "1", "z" => { "w" => "a" } }, { "y" => "2", "z" => { "w" => "b" } }]
     Rack::Utils.parse_nested_query("x[][z][w]=a&x[][y]=1&x[][z][w]=b&x[][y]=2").
-      must_equal "x" => [{"y" => "1", "z" => {"w" => "a"}}, {"y" => "2", "z" => {"w" => "b"}}]
+      must_equal "x" => [{ "y" => "1", "z" => { "w" => "a" } }, { "y" => "2", "z" => { "w" => "b" } }]
 
     Rack::Utils.parse_nested_query("data[books][][data][page]=1&data[books][][data][page]=2").
-      must_equal "data" => { "books" => [{ "data" => { "page" => "1"}}, { "data" => { "page" => "2"}}] }
+      must_equal "data" => { "books" => [{ "data" => { "page" => "1" } }, { "data" => { "page" => "2" } }] }
 
     lambda { Rack::Utils.parse_nested_query("x[y]=1&x[y]z=2") }.
       must_raise(Rack::Utils::ParameterTypeError).
@@ -234,13 +234,13 @@ describe Rack::Utils do
 
   it "only moves to a new array when the full key has been seen" do
     Rack::Utils.parse_nested_query("x[][y][][z]=1&x[][y][][w]=2").
-      must_equal "x" => [{"y" => [{"z" => "1", "w" => "2"}]}]
+      must_equal "x" => [{ "y" => [{ "z" => "1", "w" => "2" }] }]
 
     Rack::Utils.parse_nested_query(
       "x[][id]=1&x[][y][a]=5&x[][y][b]=7&x[][z][id]=3&x[][z][w]=0&x[][id]=2&x[][y][a]=6&x[][y][b]=8&x[][z][id]=4&x[][z][w]=0"
     ).must_equal "x" => [
-        {"id" => "1", "y" => {"a" => "5", "b" => "7"}, "z" => {"id" => "3", "w" => "0"}},
-        {"id" => "2", "y" => {"a" => "6", "b" => "8"}, "z" => {"id" => "4", "w" => "0"}},
+        { "id" => "1", "y" => { "a" => "5", "b" => "7" }, "z" => { "id" => "3", "w" => "0" } },
+        { "id" => "2", "y" => { "a" => "6", "b" => "8" }, "z" => { "id" => "4", "w" => "0" } },
       ]
   end
 
@@ -250,7 +250,7 @@ describe Rack::Utils do
       param_parser_class = Class.new(Rack::QueryParser::Params) do
         def initialize(*)
           super
-          @params = Hash.new{|h,k| h[k.to_s] if k.is_a?(Symbol)}
+          @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
         end
       end
       Rack::Utils.default_query_parser = Rack::QueryParser.new(param_parser_class, 65536, 100)
@@ -321,7 +321,7 @@ describe Rack::Utils do
       must_equal 'x[y][][z]=1&x[y][][z]=2'
     Rack::Utils.build_nested_query('x' => { 'y' => [{ 'z' => '1', 'w' => 'a' }, { 'z' => '2', 'w' => '3' }] }).
       must_equal 'x[y][][z]=1&x[y][][w]=a&x[y][][z]=2&x[y][][w]=3'
-    Rack::Utils.build_nested_query({"foo" => ["1", ["2"]]}).
+    Rack::Utils.build_nested_query({ "foo" => ["1", ["2"]] }).
       must_equal 'foo[]=1&foo[][]=2'
 
     lambda { Rack::Utils.build_nested_query("foo=bar") }.
@@ -330,24 +330,24 @@ describe Rack::Utils do
   end
 
   it 'performs the inverse function of #parse_nested_query' do
-    [{"foo" => nil, "bar" => ""},
-      {"foo" => "bar", "baz" => ""},
-      {"foo" => ["1", "2"]},
-      {"foo" => "bar", "baz" => ["1", "2", "3"]},
-      {"foo" => ["bar"], "baz" => ["1", "2", "3"]},
-      {"foo" => ["1", "2"]},
-      {"foo" => "bar", "baz" => ["1", "2", "3"]},
-      {"x" => {"y" => {"z" => "1"}}},
-      {"x" => {"y" => {"z" => ["1"]}}},
-      {"x" => {"y" => {"z" => ["1", "2"]}}},
-      {"x" => {"y" => [{"z" => "1"}]}},
-      {"x" => {"y" => [{"z" => ["1"]}]}},
-      {"x" => {"y" => [{"z" => "1", "w" => "2"}]}},
-      {"x" => {"y" => [{"v" => {"w" => "1"}}]}},
-      {"x" => {"y" => [{"z" => "1", "v" => {"w" => "2"}}]}},
-      {"x" => {"y" => [{"z" => "1"}, {"z" => "2"}]}},
-      {"x" => {"y" => [{"z" => "1", "w" => "a"}, {"z" => "2", "w" => "3"}]}},
-      {"foo" => ["1", ["2"]]},
+    [{ "foo" => nil, "bar" => "" },
+      { "foo" => "bar", "baz" => "" },
+      { "foo" => ["1", "2"] },
+      { "foo" => "bar", "baz" => ["1", "2", "3"] },
+      { "foo" => ["bar"], "baz" => ["1", "2", "3"] },
+      { "foo" => ["1", "2"] },
+      { "foo" => "bar", "baz" => ["1", "2", "3"] },
+      { "x" => { "y" => { "z" => "1" } } },
+      { "x" => { "y" => { "z" => ["1"] } } },
+      { "x" => { "y" => { "z" => ["1", "2"] } } },
+      { "x" => { "y" => [{ "z" => "1" }] } },
+      { "x" => { "y" => [{ "z" => ["1"] }] } },
+      { "x" => { "y" => [{ "z" => "1", "w" => "2" }] } },
+      { "x" => { "y" => [{ "v" => { "w" => "1" } }] } },
+      { "x" => { "y" => [{ "z" => "1", "v" => { "w" => "2" } }] } },
+      { "x" => { "y" => [{ "z" => "1" }, { "z" => "2" }] } },
+      { "x" => { "y" => [{ "z" => "1", "w" => "a" }, { "z" => "2", "w" => "3" }] } },
+      { "foo" => ["1", ["2"]] },
     ].each { |params|
       qs = Rack::Utils.build_nested_query(params)
       Rack::Utils.parse_nested_query(qs).must_equal params
@@ -493,19 +493,19 @@ end
 describe Rack::Utils, "cookies" do
   it "parses cookies" do
     env = Rack::MockRequest.env_for("", "HTTP_COOKIE" => "zoo=m")
-    Rack::Utils.parse_cookies(env).must_equal({"zoo" => "m"})
+    Rack::Utils.parse_cookies(env).must_equal({ "zoo" => "m" })
 
     env = Rack::MockRequest.env_for("", "HTTP_COOKIE" => "foo=%")
-    Rack::Utils.parse_cookies(env).must_equal({"foo" => "%"})
+    Rack::Utils.parse_cookies(env).must_equal({ "foo" => "%" })
 
     env = Rack::MockRequest.env_for("", "HTTP_COOKIE" => "foo=bar;foo=car")
-    Rack::Utils.parse_cookies(env).must_equal({"foo" => "bar"})
+    Rack::Utils.parse_cookies(env).must_equal({ "foo" => "bar" })
 
     env = Rack::MockRequest.env_for("", "HTTP_COOKIE" => "foo=bar;quux=h&m")
-    Rack::Utils.parse_cookies(env).must_equal({"foo" => "bar", "quux" => "h&m"})
+    Rack::Utils.parse_cookies(env).must_equal({ "foo" => "bar", "quux" => "h&m" })
 
     env = Rack::MockRequest.env_for("", "HTTP_COOKIE" => "foo=bar").freeze
-    Rack::Utils.parse_cookies(env).must_equal({"foo" => "bar"})
+    Rack::Utils.parse_cookies(env).must_equal({ "foo" => "bar" })
   end
 
   it "adds new cookies to nil header" do
@@ -539,48 +539,48 @@ end
 
 describe Rack::Utils, "byte_range" do
   it "ignore missing or syntactically invalid byte ranges" do
-    Rack::Utils.byte_ranges({},500).must_be_nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "foobar"},500).must_be_nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "furlongs=123-456"},500).must_be_nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes="},500).must_be_nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=-"},500).must_be_nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=123,456"},500).must_be_nil
+    Rack::Utils.byte_ranges({}, 500).must_be_nil
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "foobar" }, 500).must_be_nil
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "furlongs=123-456" }, 500).must_be_nil
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=" }, 500).must_be_nil
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-" }, 500).must_be_nil
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123,456" }, 500).must_be_nil
     # A range of non-positive length is syntactically invalid and ignored:
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=456-123"},500).must_be_nil
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=456-455"},500).must_be_nil
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=456-123" }, 500).must_be_nil
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=456-455" }, 500).must_be_nil
   end
 
   it "parse simple byte ranges" do
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=123-456"},500).must_equal [(123..456)]
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=123-"},500).must_equal [(123..499)]
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=-100"},500).must_equal [(400..499)]
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=0-0"},500).must_equal [(0..0)]
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=499-499"},500).must_equal [(499..499)]
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123-456" }, 500).must_equal [(123..456)]
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123-" }, 500).must_equal [(123..499)]
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-100" }, 500).must_equal [(400..499)]
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=0-0" }, 500).must_equal [(0..0)]
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=499-499" }, 500).must_equal [(499..499)]
   end
 
   it "parse several byte ranges" do
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=500-600,601-999"},1000).must_equal [(500..600),(601..999)]
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=500-600,601-999" }, 1000).must_equal [(500..600), (601..999)]
   end
 
   it "truncate byte ranges" do
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=123-999"},500).must_equal [(123..499)]
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=600-999"},500).must_equal []
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=-999"},500).must_equal [(0..499)]
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123-999" }, 500).must_equal [(123..499)]
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=600-999" }, 500).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-999" }, 500).must_equal [(0..499)]
   end
 
   it "ignore unsatisfiable byte ranges" do
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=500-501"},500).must_equal []
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=500-"},500).must_equal []
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=999-"},500).must_equal []
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=-0"},500).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=500-501" }, 500).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=500-" }, 500).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=999-" }, 500).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-0" }, 500).must_equal []
   end
 
   it "handle byte ranges of empty files" do
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=123-456"},0).must_equal []
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=0-"},0).must_equal []
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=-100"},0).must_equal []
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=0-0"},0).must_equal []
-    Rack::Utils.byte_ranges({"HTTP_RANGE" => "bytes=-0"},0).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123-456" }, 0).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=0-" }, 0).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-100" }, 0).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=0-0" }, 0).must_equal []
+    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-0" }, 0).must_equal []
   end
 end
 
@@ -613,7 +613,7 @@ describe Rack::Utils::HeaderHash do
   it "merge case-insensitively" do
     h = Rack::Utils::HeaderHash.new("ETag" => 'HELLO', "content-length" => '123')
     merged = h.merge("Etag" => 'WORLD', 'Content-Length' => '321', "Foo" => 'BAR')
-    merged.must_equal "Etag"=>'WORLD', "Content-Length"=>'321', "Foo"=>'BAR'
+    merged.must_equal "Etag" => 'WORLD', "Content-Length" => '321', "Foo" => 'BAR'
   end
 
   it "overwrite case insensitively and assume the new key's case" do
@@ -636,7 +636,7 @@ describe Rack::Utils::HeaderHash do
 
   it "replace hashes correctly" do
     h = Rack::Utils::HeaderHash.new("Foo-Bar" => "baz")
-    j = {"foo" => "bar"}
+    j = { "foo" => "bar" }
     h.replace(j)
     h["foo"].must_equal "bar"
   end
@@ -674,7 +674,7 @@ describe Rack::Utils::HeaderHash do
 
   it "convert Array values to Strings when responding to #each" do
     h = Rack::Utils::HeaderHash.new("foo" => ["bar", "baz"])
-    h.each do |k,v|
+    h.each do |k, v|
       k.must_equal "foo"
       v.must_equal "bar\nbaz"
     end
@@ -691,14 +691,14 @@ end
 describe Rack::Utils::Context do
   class ContextTest
     attr_reader :app
-    def initialize app; @app=app; end
+    def initialize app; @app = app; end
     def call env; context env; end
-    def context env, app=@app; app.call(env); end
+    def context env, app = @app; app.call(env); end
   end
-  test_target1 = proc{|e| e.to_s+' world' }
-  test_target2 = proc{|e| e.to_i+2 }
+  test_target1 = proc{|e| e.to_s + ' world' }
+  test_target2 = proc{|e| e.to_i + 2 }
   test_target3 = proc{|e| nil }
-  test_target4 = proc{|e| [200,{'Content-Type'=>'text/plain', 'Content-Length'=>'0'},['']] }
+  test_target4 = proc{|e| [200, { 'Content-Type' => 'text/plain', 'Content-Length' => '0' }, ['']] }
   test_app = ContextTest.new test_target4
 
   it "set context correctly" do

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -11,8 +11,8 @@ describe Rack::Handler::WEBrick do
   include TestRequest::Helpers
 
   before do
-  @server = WEBrick::HTTPServer.new(Host: @host='127.0.0.1',
-                                    Port: @port=9202,
+  @server = WEBrick::HTTPServer.new(Host: @host = '127.0.0.1',
+                                    Port: @port = 9202,
                                     Logger: WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
                                     AccessLog: [])
   @server.mount "/test", Rack::Handler::WEBrick,
@@ -51,7 +51,7 @@ describe Rack::Handler::WEBrick do
 
   it "have rack headers" do
     GET("/test")
-    response["rack.version"].must_equal [1,3]
+    response["rack.version"].must_equal [1, 3]
     response["rack.multithread"].must_equal true
     assert_equal false, response["rack.multiprocess"]
     assert_equal false, response["rack.run_once"]
@@ -82,7 +82,7 @@ describe Rack::Handler::WEBrick do
   end
 
   it "have CGI headers on POST" do
-    POST("/test", {"rack-form-data" => "23"}, {'X-test-header' => '42'})
+    POST("/test", { "rack-form-data" => "23" }, { 'X-test-header' => '42' })
     status.must_equal 200
     response["REQUEST_METHOD"].must_equal "POST"
     response["SCRIPT_NAME"].must_equal "/test"
@@ -94,7 +94,7 @@ describe Rack::Handler::WEBrick do
   end
 
   it "support HTTP auth" do
-    GET("/test", {user: "ruth", passwd: "secret"})
+    GET("/test", { user: "ruth", passwd: "secret" })
     response["HTTP_AUTHORIZATION"].must_equal "Basic cnV0aDpzZWNyZXQ="
   end
 
@@ -129,7 +129,7 @@ describe Rack::Handler::WEBrick do
                                    Host: '127.0.0.1',
                                    Port: 9210,
                                    Logger: WEBrick::Log.new(nil, WEBrick::BasicLog::WARN),
-                                   AccessLog: []}) { |server|
+                                   AccessLog: [] }) { |server|
         assert_kind_of WEBrick::HTTPServer, server
         queue.push(server)
       }
@@ -186,7 +186,7 @@ describe Rack::Handler::WEBrick do
     Rack::Lint.new(lambda{ |req|
       [
         200,
-        {"Transfer-Encoding" => "chunked"},
+        { "Transfer-Encoding" => "chunked" },
         ["7\r\nchunked\r\n0\r\n\r\n"]
       ]
     })

--- a/test/testrequest.rb
+++ b/test/testrequest.rb
@@ -12,10 +12,10 @@ class TestRequest
     env["test.postdata"] = env["rack.input"].read
     minienv = env.dup
     # This may in the future want to replace with a dummy value instead.
-    minienv.delete_if { |k,v| NOSERIALIZE.any? { |c| v.kind_of?(c) } }
+    minienv.delete_if { |k, v| NOSERIALIZE.any? { |c| v.kind_of?(c) } }
     body = minienv.to_yaml
     size = body.bytesize
-    [status, {"Content-Type" => "text/yaml", "Content-Length" => size.to_s}, [body]]
+    [status, { "Content-Type" => "text/yaml", "Content-Length" => size.to_s }, [body]]
   end
 
   module Helpers
@@ -32,7 +32,7 @@ class TestRequest
       "#{ROOT}/bin/rackup"
     end
 
-    def GET(path, header={})
+    def GET(path, header = {})
       Net::HTTP.start(@host, @port) { |http|
         user = header.delete(:user)
         passwd = header.delete(:passwd)
@@ -50,7 +50,7 @@ class TestRequest
       }
     end
 
-    def POST(path, formdata={}, header={})
+    def POST(path, formdata = {}, header = {})
       Net::HTTP.start(@host, @port) { |http|
         user = header.delete(:user)
         passwd = header.delete(:passwd)
@@ -69,7 +69,7 @@ end
 
 class StreamingRequest
   def self.call(env)
-    [200, {"Content-Type" => "text/plain"}, new]
+    [200, { "Content-Type" => "text/plain" }, new]
   end
 
   def each


### PR DESCRIPTION
## Summary

* For become easy to read codes, enabled `Layout/Space*` cops (which are adopted in rails repo)
* Execute `rubocop --auto-correct`