### PR TITLE
Update LICENSE

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (C) 2007-present Christian Neukirchen <http://chneukirchen.org/infopage.html>
+Copyright (C) 2007-2018 Christian Neukirchen <http://chneukirchen.org/infopage.html>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2007-2016 Christian Neukirchen <purl.org/net/chneukirchen>
+The MIT License (MIT)
+
+Copyright (C) 2007-present Christian Neukirchen <http://chneukirchen.org/infopage.html>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -13,6 +15,6 @@ all copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.rdoc
+++ b/README.rdoc
@@ -220,7 +220,7 @@ that we manage timing in order to provide viable patches at the time of
 disclosure. Your assistance in this matter is greatly appreciated.
 
 Mailing list archives are available at
-<https://groups.google.com/group/rack-devel>.
+<https://groups.google.com/forum/#!forum/rack-devel>.
 
 Git repository (send Git patches to the mailing list):
 * https://github.com/rack/rack
@@ -276,27 +276,6 @@ would like to thank:
   Rack builds up on.
 * All bug reporters and patch contributors not mentioned above.
 
-== Copyright
-
-Copyright (C) 2007, 2008, 2009, 2010 Christian Neukirchen <http://purl.org/net/chneukirchen>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to
-deal in the Software without restriction, including without limitation the
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 == Links
 
 Rack:: <https://rack.github.io/>
@@ -304,3 +283,7 @@ Official Rack repositories:: <https://github.com/rack>
 Rack Bug Tracking:: <https://github.com/rack/rack/issues>
 rack-devel mailing list:: <https://groups.google.com/group/rack-devel>
 Rack's Rubyforge project:: <http://rubyforge.org/projects/rack>
+
+== License
+
+Rack is released under the {MIT License}[https://opensource.org/licenses/MIT].

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# Copyright (C) 2007, 2008, 2009, 2010 Christian Neukirchen <purl.org/net/chneukirchen>
+# Copyright (C) 2007-present Christian Neukirchen <http://chneukirchen.org/infopage.html>
 #
 # Rack is freely distributable under the terms of an MIT-style license.
-# See COPYING or http://www.opensource.org/licenses/mit-license.php.
+# See MIT-LICENSE or https://opensource.org/licenses/MIT.
 
 # The Rack main module, serving as a namespace for all core Rack
 # modules and classes.

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (C) 2007-present Christian Neukirchen <http://chneukirchen.org/infopage.html>
+# Copyright (C) 2007-2018 Christian Neukirchen <http://chneukirchen.org/infopage.html>
 #
 # Rack is freely distributable under the terms of an MIT-style license.
 # See MIT-LICENSE or https://opensource.org/licenses/MIT.

--- a/lib/rack/reloader.rb
+++ b/lib/rack/reloader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (C) 2009-present Michael Fellinger <m.fellinger@gmail.com>
+# Copyright (C) 2009-2018 Michael Fellinger <m.fellinger@gmail.com>
 # Rack::Reloader is subject to the terms of an MIT-style license.
 # See MIT-LICENSE or https://opensource.org/licenses/MIT.
 

--- a/lib/rack/reloader.rb
+++ b/lib/rack/reloader.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-#          Copyright (c) 2009 Michael Fellinger m.fellinger@gmail.com
-#       Rack::Reloader is subject to the terms of an MIT-style license.
-#      See COPYING or http://www.opensource.org/licenses/mit-license.php.
+# Copyright (C) 2009-present Michael Fellinger <m.fellinger@gmail.com>
+# Rack::Reloader is subject to the terms of an MIT-style license.
+# See MIT-LICENSE or https://opensource.org/licenses/MIT.
 
 require 'pathname'
 

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -113,8 +113,8 @@ module Rack
 
     # :stopdoc:
 
-    # adapted from Django <djangoproject.com>
-    # Copyright (c) 2005, the Lawrence Journal-World
+    # adapted from Django <www.djangoproject.com>
+    # Copyright (c) Django Software Foundation and individual contributors.
     # Used under the modified BSD license:
     # http://www.xfree86.org/3.3.6/COPYRIGHT2.html#5
     TEMPLATE = ERB.new(<<-'HTML'.gsub(/^      /, ''))

--- a/lib/rack/show_status.rb
+++ b/lib/rack/show_status.rb
@@ -54,8 +54,8 @@ module Rack
 
     # :stopdoc:
 
-# adapted from Django <djangoproject.com>
-# Copyright (c) 2005, the Lawrence Journal-World
+# adapted from Django <www.djangoproject.com>
+# Copyright (c) Django Software Foundation and individual contributors.
 # Used under the modified BSD license:
 # http://www.xfree86.org/3.3.6/COPYRIGHT2.html#5
 TEMPLATE = <<'HTML'

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -18,7 +18,7 @@ Also see https://rack.github.io/.
 EOF
 
   s.files           = Dir['{bin/*,contrib/*,example/*,lib/**/*,test/**/*}'] +
-                        %w(COPYING rack.gemspec Rakefile README.rdoc SPEC)
+                        %w(MIT-LICENSE rack.gemspec Rakefile README.rdoc SPEC)
   s.bindir          = 'bin'
   s.executables << 'rackup'
   s.require_path = 'lib'


### PR DESCRIPTION
## Summary

* Renamed COPYING to MIT-LICENSE. Because currently MIT-LICESE is used in almost gems.
* Updated README, and added license section instead of copyright section.
* Updated author url.
* Updated copyright's end of the term be ~"present"~ 2018.
* Updated Django license ([link](https://github.com/django/django))