### PR TITLE
Fix Rack::Static behavior with non-empty :urls and :index

### DIFF
--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -101,7 +101,7 @@ module Rack
     end
 
     def add_index_root?(path)
-      @index && path =~ /\/$/
+      @index && route_file(path) && path =~ /\/$/
     end
 
     def overwrite_file_path(path)

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -22,6 +22,7 @@ describe Rack::Static do
 
   OPTIONS = { urls: ["/cgi"], root: root }
   STATIC_OPTIONS = { urls: [""], root: "#{root}/static", index: 'index.html' }
+  STATIC_URLS_OPTIONS = { urls: ["/static"], root: "#{root}", index: 'index.html' }
   HASH_OPTIONS = { urls: { "/cgi/sekret" => 'cgi/test' }, root: root }
   HASH_ROOT_OPTIONS = { urls: { "/" => "static/foo.html" }, root: root }
   GZIP_OPTIONS = { urls: ["/cgi"], root: root, gzip: true }
@@ -29,6 +30,7 @@ describe Rack::Static do
   before do
   @request = Rack::MockRequest.new(static(DummyApp.new, OPTIONS))
   @static_request = Rack::MockRequest.new(static(DummyApp.new, STATIC_OPTIONS))
+  @static_urls_request = Rack::MockRequest.new(static(DummyApp.new, STATIC_URLS_OPTIONS))
   @hash_request = Rack::MockRequest.new(static(DummyApp.new, HASH_OPTIONS))
   @hash_root_request = Rack::MockRequest.new(static(DummyApp.new, HASH_ROOT_OPTIONS))
   @gzip_request = Rack::MockRequest.new(static(DummyApp.new, GZIP_OPTIONS))
@@ -63,6 +65,16 @@ describe Rack::Static do
     res = @static_request.get("/another/")
     res.must_be :ok?
     res.body.must_match(/another index!/)
+  end
+
+  it "does not call index file when requesting folder with unknown prefix" do
+    res = @static_urls_request.get("/static/another/")
+    res.must_be :ok?
+    res.body.must_match(/index!/)
+
+    res = @static_urls_request.get("/something/else/")
+    res.must_be :ok?
+    res.body.must_equal "Hello World"
   end
 
   it "doesn't call index file if :index option was omitted" do


### PR DESCRIPTION
Static behavior with empty string `urls` and `index` options is well-documented and clear:
```
  # Serve all requests normally from the folder "public" in the current
  # directory but uses index.html as default route for "/"
  #
  #     use Rack::Static, :urls => [""], :root => 'public', :index => 'index.html'
```

But there is an issue in setups where Rack::Static is to serve requests with particular prefix(es) and, for instance, proxy other requests:
```
use Rack::Static, :urls => ["/foo", "/bar"], :root => 'public', :index => 'index.html'

# GET /foo/  -> public/foo/index.html
# GET /foo/nonsense/ -> try public/foo/nonsense/index.html, return 404, which is ok
# GET /proxy/this/ -> try public/proxy/this/index.html, return 404,
#                                   which is somewhat confusing as long as /proxy is not in :urls
```