### PR TITLE
fix String status check failed at STATUS_WITH_NO_ENTITY_BODY

### DIFF
--- a/lib/rack/chunked.rb
+++ b/lib/rack/chunked.rb
@@ -57,7 +57,7 @@ module Rack
       headers = HeaderHash.new(headers)
 
       if ! chunkable_version?(env[HTTP_VERSION]) ||
-         STATUS_WITH_NO_ENTITY_BODY.include?(status) ||
+         STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i) ||
          headers[CONTENT_LENGTH] ||
          headers[TRANSFER_ENCODING]
         [status, headers, body]

--- a/lib/rack/content_type.rb
+++ b/lib/rack/content_type.rb
@@ -21,7 +21,7 @@ module Rack
       status, headers, body = @app.call(env)
       headers = Utils::HeaderHash.new(headers)
 
-      unless STATUS_WITH_NO_ENTITY_BODY.include?(status)
+      unless STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i)
         headers[CONTENT_TYPE] ||= @content_type
       end
 

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -107,7 +107,7 @@ module Rack
     def should_deflate?(env, status, headers, body)
       # Skip compressing empty entity body responses and responses with
       # no-transform set.
-      if Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status) ||
+      if Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i) ||
           headers['Cache-Control'].to_s =~ /\bno-transform\b/ ||
          (headers['Content-Encoding'] && headers['Content-Encoding'] !~ /\bidentity\b/)
         return false

--- a/test/spec_content_type.rb
+++ b/test/spec_content_type.rb
@@ -40,9 +40,19 @@ describe Rack::ContentType do
       must_equal [["CONTENT-Type", "foo/bar"]]
   end
 
-  it "not set Content-Type on 304 responses" do
-    app = lambda { |env| [304, {}, []] }
-    response = content_type(app, "text/html").call(request)
-    response[1]['Content-Type'].must_be_nil
+  [100, 204, 304].each do |code|
+    it "not set Content-Type on #{code} responses" do
+      app = lambda { |env| [code, {}, []] }
+      response = content_type(app, "text/html").call(request)
+      response[1]['Content-Type'].must_be_nil
+    end
+  end
+
+  ['100', '204', '304'].each do |code|
+    it "not set Content-Type on #{code} responses if status is a string" do
+      app = lambda { |env| [code, {}, []] }
+      response = content_type(app, "text/html").call(request)
+      response[1]['Content-Type'].must_be_nil
+    end
   end
 end


### PR DESCRIPTION
Since the `STATUS_WITH_NO_ENTITY_BODY` is an array of Integer, the check at lib/rack/lint.rb and lib/rack/content_length.rb allows to check the String status by calling `to_i`, but other places do not.

For example:
https://github.com/rack/rack/blob/ab008307cbb805585449145966989d5274fbe1e4/lib/rack/content_type.rb#L22-L24

Fixed to allow String status for:
- lib/rack/content_type.rb
- lib/rack/chunked.rb
- lib/rack/deflater.rb

Resolves #1218 