### PR TITLE
Add support for rfc6598 public shared networks

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -420,7 +420,7 @@ module Rack
       end
 
       def trusted_proxy?(ip)
-        ip =~ /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i
+        ip =~ /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168|100\.(6[4-9]|[7-9]\d|1[0-1]\d|12[0-7]))\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i
       end
 
       # shortcut for <tt>request.params[key]</tt>

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1310,6 +1310,7 @@ EOF
     req = make_request(Rack::MockRequest.env_for("/"))
     req.trusted_proxy?('127.0.0.1').must_equal 0
     req.trusted_proxy?('10.0.0.1').must_equal 0
+    req.trusted_proxy?('100.64.0.1').must_equal 0
     req.trusted_proxy?('172.16.0.1').must_equal 0
     req.trusted_proxy?('172.20.0.1').must_equal 0
     req.trusted_proxy?('172.30.0.1').must_equal 0
@@ -1325,6 +1326,7 @@ EOF
     req.trusted_proxy?("example.org\n127.0.0.1").must_be_nil
     req.trusted_proxy?("127.0.0.1\nexample.org").must_be_nil
     req.trusted_proxy?("11.0.0.1").must_be_nil
+    req.trusted_proxy?("100.4.0.1").must_be_nil
     req.trusted_proxy?("172.15.0.1").must_be_nil
     req.trusted_proxy?("172.32.0.1").must_be_nil
     req.trusted_proxy?("2001:470:1f0b:18f8::1").must_be_nil


### PR DESCRIPTION
Allow Request#trusted_proxy? to handle 100.64.0.0/10 network addresses as other
special networks and be ignored as the 'correct' remote ip.
https://tools.ietf.org/html/rfc6598

Kubernetes installations using CNI networking (overlay networks) are often using the 100.64/10 network for pod addresses. This causes rack apps running on those clusters to to use the REMOTE_ADDR of an upstream pod (possibly a proxy or ingress) instead of evaluating the X-Forwarded-For headers as expected. This patch expands the addresses handled by Request#ip() to include the 100.64/10 public shared network block.