### PR TITLE
Reduce string allocations in Multipart::Parser

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -272,7 +272,9 @@ module Rack
         else
           # Save the read body part.
           if @rx_max_size < @buf.size
-            @collector.on_mime_body @mime_index, @buf.slice!(0, @buf.size - @rx_max_size)
+            chunk = @buf.slice!(0, @buf.size - @rx_max_size)
+            @collector.on_mime_body @mime_index, chunk
+            chunk.clear # deallocate chunk
           end
           :want_read
         end


### PR DESCRIPTION
This deallocates body chunks when they're not needed anymore. When testing with a 5MB request body this reduced total memory allocation from 18.3MB to 15.4MB.