### PR TITLE
Add gem version and SemVer stability badges to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -3,7 +3,8 @@
 {<img src="https://rack.github.io/rack-logo.png" width="400" alt="rack powers web applications" />}[https://rack.github.io/]
 
 {<img src="https://secure.travis-ci.org/rack/rack.svg" alt="Build Status" />}[https://travis-ci.org/rack/rack]
-{<img src="https://gemnasium.com/rack/rack.svg" alt="Dependency Status" />}[https://gemnasium.com/rack/rack]
+{<img src="https://badge.fury.io/rb/rack.svg" alt="Gem Version" />}[http://badge.fury.io/rb/rack]
+{<img src="https://api.dependabot.com/badges/compatibility_score?dependency-name=rack&package-manager=bundler&version-scheme=semver" alt="SemVer Stability" />}[https://dependabot.com/compatibility-score.html?dependency-name=rack&package-manager=bundler&version-scheme=semver]
 
 \Rack provides a minimal, modular, and adaptable interface for developing
 web applications in Ruby. By wrapping HTTP requests and responses in


### PR DESCRIPTION
First of all, thanks for rack!

Would you be up for adding badges that show the version and how SemVer compliant / bug free new releases are? I always want to know both when adding a gem to my Gemfile. I was looking through the data we gather at Dependabot and realised we could put one together (for stability), so threw together the below:

[![Gem Version](https://badge.fury.io/rb/rack.svg)](http://badge.fury.io/rb/rack) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rack&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=rack&package-manager=bundler&version-scheme=semver)

The gem version one is pretty self explanatory. For the SemVer one, if you click through then there's a description of how it's calculated - basically it takes all of the relevant updates Dependabot has done for projects that use rack and checks what percentage of the time specs pass on the upgrade PR.

The score is slightly lower than 100% because some projects have flaky specs, but I'm working on filtering them out from the data, too :octocat:.

Finally, I removed the Gemnasium badge because it's now just an advert for GitLab 😕.