### PR TITLE
Fix gemspec to not include test files from gem

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -23,7 +23,6 @@ EOF
   s.executables << 'rackup'
   s.require_path = 'lib'
   s.extra_rdoc_files = ['README.rdoc', 'HISTORY.md']
-  s.test_files      = Dir['test/spec_*.rb']
 
   s.author          = 'Leah Neukirchen'
   s.email           = 'leah@vuxu.org'

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -17,7 +17,7 @@ middleware) into a single method call.
 Also see https://rack.github.io/.
 EOF
 
-  s.files           = Dir['{bin/*,contrib/*,example/*,lib/**/*,test/**/*}'] +
+  s.files           = Dir['{bin/*,contrib/*,example/*,lib/**/*}'] +
                         %w(MIT-LICENSE rack.gemspec Rakefile README.rdoc SPEC)
   s.bindir          = 'bin'
   s.executables << 'rackup'


### PR DESCRIPTION
as these shouldn't be shipped.

This causes some troubles with generating RPM packages for openSUSE distribution as rpmlint is complaining.