### PR TITLE
change unescape to URI.unescape

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -64,7 +64,7 @@ module Rack
       params = make_params
 
       (qs || '').split(d ? (COMMON_SEP[d] || /[#{d}] */n) : DEFAULT_SEP).each do |p|
-        k, v = p.split('=', 2).map! { |s| unescape(s) }
+        k, v = p.split('=', 2).map! { |s| URI.unescape(s) }
 
         normalize_params(params, k, v, param_depth_limit)
       end


### PR DESCRIPTION
```
http://localhost:3000?foo=%9g
http://localhost:3000?%9g
http://localhost:3000?%
```

errors:

```
Puma caught this error: Invalid query parameters: invalid %-encoding (%9g) (ActionController::BadRequest)
/usr/local/ruby/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/query_parser.rb:72:in `rescue in parse_nested_query'
/usr/local/ruby/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/query_parser.rb:60:in `parse_nested_query'
/usr/local/ruby/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/request.rb:468:in `parse_query'
/usr/local/ruby/lib/ruby/gems/2.5.0/gems/rack-2.0.5/lib/rack/request.rb:319:in `GET'
```