### PR TITLE
README: Remove outdated local gem mirror info

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -136,11 +136,6 @@ A Gem of \Rack is available at {rubygems.org}[https://rubygems.org/gems/rack]. Y
 
     gem install rack
 
-I also provide a local mirror of the gems (and development snapshots)
-at my site:
-
-    gem install rack --source http://chneukirchen.org/releases/gems/
-
 == Running the tests
 
 Testing \Rack requires the bacon testing framework:


### PR DESCRIPTION
The gem mirror in http://chneukirchen.org/releases/gems/ is not up-to-date (has Rack 1.6.0); I don't think it is still needed (if one doesn't want to depend on rubygems.org, they should anyway have a mirror for all their dependencies/gems anyway). Therefore I removed it from the README.

