### PR TITLE
Call the correct accepts_html? method for prefer_plaintext

### DIFF
--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -48,7 +48,7 @@ module Rack
     end
 
     def prefers_plaintext?(env)
-      !accepts_html(env)
+      !accepts_html?(env)
     end
 
     def accepts_html?(env)

--- a/test/spec_show_exceptions.rb
+++ b/test/spec_show_exceptions.rb
@@ -101,4 +101,17 @@ describe Rack::ShowExceptions do
     res.status.must_equal 500
     res.body.must_equal "foo"
   end
+
+  it "knows to prefer plaintext for non-html" do
+    # We don't need an app for this
+    exc = Rack::ShowExceptions.new(nil)
+
+    [
+      [{ "HTTP_ACCEPT" => "text/plain" }, true],
+      [{ "HTTP_ACCEPT" => "text/foo" }, true],
+      [{ "HTTP_ACCEPT" => "text/html" }, false]
+    ].each do |env, expected|
+      assert_equal(expected, exc.prefers_plaintext?(env))
+    end
+  end
 end


### PR DESCRIPTION
I noticed that `prefers_plaintext?` is calling a non-existent `accepts-html` method. This was working in 1.5.x and looks like it changed starting in 1.6.x. We use `prefers_plaintext?`so we need this to make upgrading possible.

Would it be possible to get this added into a 1.6.x release too? This PR is forked off of master so I'm happy to open another PR with a similar fix that's forked off of 1-6-stable (I wasn't sure the preferred way to do that).