### PR TITLE
Point gemspec's extra rdoc file to CHANGELOG.md (from HISTORY.md)

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -22,7 +22,7 @@ EOF
   s.bindir          = 'bin'
   s.executables << 'rackup'
   s.require_path = 'lib'
-  s.extra_rdoc_files = ['README.rdoc', 'HISTORY.md']
+  s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG.md']
 
   s.author          = 'Leah Neukirchen'
   s.email           = 'leah@vuxu.org'


### PR DESCRIPTION
Small thing I noticed while trying to run `rake gem`. Looks like `HISTORY.md` was merged into `CHANGELOG.md` at some point.

**Testing**

Before change:
```
~/code/rack(point-to-changelog-md*) » rake gem
gem build rack.gemspec
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["HISTORY.md"] are not files
rake aborted!
Command failed with status (1): [gem build rack.gemspec...]
/Users/tomer/code/rack/Rakefile:101:in `block in <top (required)>'
Tasks: TOP => gem
(See full trace by running task with --trace)
```

After change:
```
~/code/rack(point-to-changelog-md*) » rake gem
gem build rack.gemspec
WARNING:  open-ended dependency on minitest-sprint (>= 0, development) is not recommended
  if minitest-sprint is semantically versioned, use:
    add_development_dependency 'minitest-sprint', '~> 0'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: rack
  Version: 2.0.1
  File: rack-2.0.1.gem
```