### PR TITLE
Support multipart filename with + in the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Changed
 - `Rack::Utils.status_code` now raises an error when the status symbol is invalid instead of `500`.
 - `Rack::Request::SCHEME_WHITELIST` has been renamed to `Rack::Request::ALLOWED_SCHEMES`
+- `Rack::Multipart::Parser.get_filename` now accepts file that contains `+` in its name, avoiding the replacement of `+` to space character since filenames with `+` are valid.
 
 ### Removed
 - HISTORY.md by @twitnithegirl

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -312,7 +312,7 @@ module Rack
         return unless filename
 
         if filename.scan(/%.?.?/).all? { |s| s =~ /%[0-9a-fA-F]{2}/ }
-          filename = Utils.unescape(filename)
+          filename = Utils.unescape_path(filename)
         end
 
         filename.scrub!

--- a/test/multipart/filename_with_plus
+++ b/test/multipart/filename_with_plus
@@ -1,0 +1,6 @@
+--AaB03x
+Content-Disposition: form-data; name="files"; filename="foo+bar"
+Content-Type: application/octet-stream
+
+contents
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -363,6 +363,19 @@ describe Rack::Multipart do
     params["files"][:tempfile].read.must_equal "contents"
   end
 
+  it "parse filename with plus character" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:filename_with_plus))
+    params = Rack::Multipart.parse_multipart(env)
+    params["files"][:type].must_equal "application/octet-stream"
+    params["files"][:filename].must_equal "foo+bar"
+    params["files"][:head].must_equal "Content-Disposition: form-data; " +
+      "name=\"files\"; " +
+      "filename=\"foo+bar\"\r\n" +
+      "Content-Type: application/octet-stream\r\n"
+    params["files"][:name].must_equal "files"
+    params["files"][:tempfile].read.must_equal "contents"
+  end
+
   it "parse filename with percent escaped quotes" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:filename_with_percent_escaped_quotes))
     params = Rack::Multipart.parse_multipart(env)


### PR DESCRIPTION
Use Utils.unescape_path in Rack::Multipart::Parser.get_name
in order to not translate + to space in the filename, since
filenames with + are valid.  This commit should fix #755