### PR TITLE
✨ add_header accepts an optional delimiter

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -84,11 +84,11 @@ module Rack
       #   assert_equal 'image/png,*/*', request.get_header('Accept')
       #
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-      def add_header key, v
+      def add_header key, v, delimiter = ','
         if v.nil?
           get_header key
         elsif has_header? key
-          set_header key, "#{get_header key},#{v}"
+          set_header key, "#{get_header key}#{delimiter}#{v}"
         else
           set_header key, v
         end

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -146,11 +146,11 @@ module Rack
       #   assert_equal 'Accept-Encoding,Cookie', response.get_header('Vary')
       #
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-      def add_header key, v
+      def add_header key, v, delimiter = ','
         if v.nil?
           get_header key
         elsif has_header? key
-          set_header key, "#{get_header key},#{v}"
+          set_header key, "#{get_header key}#{delimiter}#{v}"
         else
           set_header key, v
         end

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -398,6 +398,11 @@ describe Rack::MockResponse, 'headers' do
     @res.add_header('Foo', 'yep').must_equal '1,1,2,yep'
     @res.get_header('Foo').must_equal '1,1,2,yep'
     @res.get_header('FOO').must_equal '1,1,2,yep'
+
+    # Accepts a delimiter
+    @res.add_header('BAR', '1', ' ').must_equal '1'
+    @res.add_header('BAR', '1', ' ').must_equal '1 1'
+    @res.get_header('BAR').must_equal '1 1'
   end
 
   it 'delete_header' do

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -70,14 +70,23 @@ class RackRequestTest < Minitest::Spec
   it 'can add to multivalued headers in the env' do
     req = make_request(Rack::MockRequest.env_for('http://example.com:8080/'))
 
+    # Sets on first addition
     assert_equal '1', req.add_header('FOO', '1')
     assert_equal '1', req.get_header('FOO')
 
+    # Adds more values, delimited with commas
     assert_equal '1,2', req.add_header('FOO', '2')
     assert_equal '1,2', req.get_header('FOO')
 
+    # Ignores nil additions
     assert_equal '1,2', req.add_header('FOO', nil)
     assert_equal '1,2', req.get_header('FOO')
+
+    # Add with a delimiter
+    assert_equal '1', req.add_header('BAR', '1', '; ')
+    assert_equal '1', req.get_header('BAR')
+    assert_equal '1; 2', req.add_header('BAR', '2', '; ')
+    assert_equal '1; 2', req.get_header('BAR')
   end
 
   it 'can delete env values' do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -494,6 +494,11 @@ describe Rack::Response, 'headers' do
     @response.add_header('Bar', '1').must_equal '1'
     @response.has_header?('Bar').must_equal true
     @response.get_header('Bar').must_equal '1'
+
+    # Add with a delimiter
+    @response.add_header('BAZ', '1', ', ').must_equal '1'
+    @response.add_header('BAZ', '2', ', ').must_equal '1, 2'
+    @response.get_header('BAZ').must_equal '1, 2'
   end
 
   it 'delete_header' do


### PR DESCRIPTION
Previously, `Rack::Request#add_header` and `Rack::Response#add_header` both used `','` as the delimiter between multiple values. That works great for headers like `Accept`.

But Fastly's `Surrogate-Key` uses `' '`. And Mozilla uses `'\n'` for `Set-Cookie`, `WWW-Authenticate`, and `Proxy-Authenticate` and `', '` for other headers.

This commit adds a third optional argument to both `Rack::Request#add_header` and `Rack::Response#add_header` for the delimiter. It defaults to `','`, making the change fully backwards-compatible.

See https://docs.fastly.com/guides/api-caching/purging-api-cache-with-surrogate-keys
See https://github.com/bnoordhuis/mozilla-central/blob/28b39571c584530df4b0b74bf9d929942906c081/netwerk/protocol/http/nsHttpHeaderArray.h#L176-L198

Closes #1298