### PR TITLE
Fix multipart parser for large files #1308

### DIFF
--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -6,6 +6,7 @@ require 'rack/multipart'
 require 'rack/multipart/parser'
 require 'rack/utils'
 require 'rack/mock'
+require 'timeout'
 
 describe Rack::Multipart do
   def multipart_fixture(name, boundary = "AaB03x")
@@ -144,6 +145,31 @@ describe Rack::Multipart do
     err = thr.value
     err.must_be_instance_of Errno::EPIPE
     wr.close
+  end
+
+  # see https://github.com/rack/rack/pull/1309
+  it "parse strange multipart pdf" do
+    boundary = '---------------------------932620571087722842402766118'
+
+    data = StringIO.new
+    data.write("--#{boundary}")
+    data.write("\r\n")
+    data.write('Content-Disposition: form-data; name="a"; filename="a.pdf"')
+    data.write("\r\n")
+    data.write("Content-Type:application/pdf\r\n")
+    data.write("\r\n")
+    data.write("-" * (1024 * 1024))
+    data.write("\r\n")
+    data.write("--#{boundary}--\r\n")
+
+    fixture = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+      "CONTENT_LENGTH" => data.length.to_s,
+      :input => data,
+    }
+
+    env = Rack::MockRequest.env_for '/', fixture
+    Timeout::timeout(10) { Rack::Multipart.parse_multipart(env) }
   end
 
   it 'raises an EOF error on content-length mistmatch' do


### PR DESCRIPTION
Try to avoid the lazy matching quantifier, cause it is causing serious trouble with large files.
We just use the string returned by `check_until` and remove the included boundary.
All tests pass and my problematic file uploads work as they should without performance issues.

The only problem is, that I don't know, if I should check in a large file just to demonstrate that it fails without that patch.