### PR TITLE
Introduce Request.scheme_allowlist and deprecate existing constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Changed
 - `Rack::Utils.status_code` now raises an error when the status symbol is invalid instead of `500`.
+- `Rack::Request::SCHEME_WHITELIST` has been renamed to `Rack::Request::ALLOWED_SCHEMES`
 
 ### Removed
 - HISTORY.md by @twitnithegirl
@@ -16,7 +17,7 @@ All notable changes to this project will be documented in this file. For info on
 #
 #
 # History/News Archive
-Items below this line are from the previously maintained HISTORY.md and NEWS.md files. 
+Items below this line are from the previously maintained HISTORY.md and NEWS.md files.
 #
 
 ## [2.0.0]
@@ -65,13 +66,13 @@ Items below this line are from the previously maintained HISTORY.md and NEWS.md 
 - Prevent extremely deep parameters from being parsed. CVE-2015-3225
 
 ## [1.6.1] 2015-05-06
-  - Fix CVE-2014-9490, denial of service attack in OkJson 
-  - Use a monotonic time for Rack::Runtime, if available 
+  - Fix CVE-2014-9490, denial of service attack in OkJson
+  - Use a monotonic time for Rack::Runtime, if available
   - RACK_MULTIPART_LIMIT changed to RACK_MULTIPART_PART_LIMIT (RACK_MULTIPART_LIMIT is deprecated and will be removed in 1.7.0)
 
 ## [1.5.3] 2015-05-06
   - Fix CVE-2014-9490, denial of service attack in OkJson
-  - Backport bug fixes to 1.5 series 
+  - Backport bug fixes to 1.5 series
 
 ## [1.6.0] 2014-01-18
   - Response#unauthorized? helper

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -18,7 +18,11 @@ module Rack
     end
 
     self.ip_filter = lambda { |ip| ip =~ /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i }
-    SCHEME_WHITELIST = %w(https http).freeze
+    ALLOWED_SCHEMES = %w(https http).freeze
+    SCHEME_WHITELIST = ALLOWED_SCHEMES
+    if Object.respond_to?(:deprecate_constant)
+      deprecate_constant :SCHEME_WHITELIST
+    end
 
     def initialize(env)
       @params = nil
@@ -507,7 +511,7 @@ module Rack
         ]
 
         scheme_headers.each do |header|
-          return header if SCHEME_WHITELIST.include?(header)
+          return header if ALLOWED_SCHEMES.include?(header)
         end
 
         nil


### PR DESCRIPTION
## Problem 

Update the constant to use clearer terminology. 

## Description:

Deprecates the constant, provide a new class method `Request.scheme_allowlist` for anyone who still needs it.

[Original motivation](https://github.com/rails/rails/issues/33677), other community efforts examples:

- https://github.com/rails/rails/pull/33681
- https://github.com/graphiti-api/graphiti/pull/10
- https://github.com/rails/rails/pull/33718
- https://github.com/ruby/psych/pull/378
- https://github.com/ruby/ruby/pull/2008
- https://github.com/ruby/ruby/pull/2009
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/dtao/safe_yaml/pull/93
- https://github.com/rubocop-hq/rubocop/pull/6466
- https://github.com/rubocop-hq/rubocop/pull/6467
- https://github.com/rspec/rspec-core/pull/2576
- https://github.com/rspec/rspec-expectations/pull/1083
- https://github.com/rspec/rspec-mocks/pull/1246
- https://github.com/rspec/rspec-support/pull/356
- https://github.com/flavorjones/loofah/pull/158
- https://github.com/pry/pry/pull/1874
- https://github.com/pry/pry/pull/1875
