### PR TITLE
Add `Too Early(425)` to status codes

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -535,6 +535,7 @@ module Rack
       422 => 'Unprocessable Entity',
       423 => 'Locked',
       424 => 'Failed Dependency',
+      425 => 'Too Early',
       426 => 'Upgrade Required',
       428 => 'Precondition Required',
       429 => 'Too Many Requests',


### PR DESCRIPTION
This status code was added in RFC 8470.
Ref: https://tools.ietf.org/html/rfc8470#section-5.2