### PR TITLE
ShowExceptions: fix issue when Rack env has binary data

### DIFF
--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -369,7 +369,7 @@ module Rack
                 <% env.sort_by { |k, v| k.to_s }.each { |key, val| %>
                 <tr>
                   <td><%=h key %></td>
-                  <td class="code"><div><%=h val %></div></td>
+                  <td class="code"><div><%=h val.inspect %></div></td>
                 </tr>
                 <% } %>
             </tbody>

--- a/test/spec_show_exceptions.rb
+++ b/test/spec_show_exceptions.rb
@@ -27,6 +27,24 @@ describe Rack::ShowExceptions do
     assert_match(res, /ShowExceptions/)
   end
 
+  it "works with binary data in the Rack environment" do
+    res = nil
+
+    # "\xCC" is not a valid UTF-8 string
+    req = Rack::MockRequest.new(
+      show_exceptions(
+        lambda{|env| env['foo'] = "\xCC"; raise RuntimeError }
+    ))
+
+    res = req.get("/", "HTTP_ACCEPT" => "text/html")
+
+    res.must_be :server_error?
+    res.status.must_equal 500
+
+    assert_match(res, /RuntimeError/)
+    assert_match(res, /ShowExceptions/)
+  end
+
   it "responds with HTML only to requests accepting HTML" do
     res = nil
 


### PR DESCRIPTION
Fixes an error where the exception handler itself raises an error. Other blocks in this middleware don't have this issue because they already have a `.inspect` call.