### PR TITLE
Performance: remove useless header merge from Response

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -29,7 +29,7 @@ module Rack
 
     def initialize(body = [], status = 200, header = {})
       @status = status.to_i
-      @header = Utils::HeaderHash.new.merge(header)
+      @header = Utils::HeaderHash.new(header)
 
       @writer  = lambda { |x| @body << x }
       @block   = nil

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -29,7 +29,7 @@ module Rack
 
     def initialize(body = [], status = 200, header = {})
       @status = status.to_i
-      @header = Utils::HeaderHash.build(header)
+      @header = Utils::HeaderHash.new(header)
 
       @writer  = lambda { |x| @body << x }
       @block   = nil

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -29,7 +29,7 @@ module Rack
 
     def initialize(body = [], status = 200, header = {})
       @status = status.to_i
-      @header = Utils::HeaderHash.new(header)
+      @header = Utils::HeaderHash.build(header)
 
       @writer  = lambda { |x| @body << x }
       @block   = nil

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -410,15 +410,9 @@ module Rack
 
     # A case-insensitive Hash that preserves the original case of a
     # header when set.
-    class HeaderHash < Hash
-      def self.build(hash)
-        HeaderHash === hash ? hash.dup : new(hash)
-      end
-
-      def self.new(hash = {})
-        HeaderHash === hash ? hash : super(hash)
-      end
-
+    #
+    # @api private
+    class HeaderHash < Hash # :nodoc:
       def initialize(hash = {})
         super()
         @names = {}

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -411,6 +411,10 @@ module Rack
     # A case-insensitive Hash that preserves the original case of a
     # header when set.
     class HeaderHash < Hash
+      def self.build(hash)
+        HeaderHash === hash ? hash.dup : new(hash)
+      end
+
       def self.new(hash = {})
         HeaderHash === hash ? hash : super(hash)
       end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -62,6 +62,16 @@ describe Rack::Response do
     response["Content-Type"].must_equal "text/plain"
   end
 
+  it "doesn't mutate given headers" do
+    [{}, Rack::Utils::HeaderHash.new].each do |header|
+      response = Rack::Response.new([], 200, header)
+      response.header["Content-Type"] = "text/plain"
+      response.header["Content-Type"].must_equal "text/plain"
+
+      header.wont_include("Content-Type")
+    end
+  end
+
   it "can override the initial Content-Type with a different case" do
     response = Rack::Response.new("", 200, "content-type" => "text/plain")
     response["Content-Type"].must_equal "text/plain"

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -671,10 +671,10 @@ describe Rack::Utils::HeaderHash do
     h.delete("Hello").must_be_nil
   end
 
-  it "avoid unnecessary object creation if possible" do
+  it "dups given HeaderHash" do
     a = Rack::Utils::HeaderHash.new("foo" => "bar")
     b = Rack::Utils::HeaderHash.new(a)
-    b.object_id.must_equal a.object_id
+    b.object_id.wont_equal a.object_id
     b.must_equal a
   end
 


### PR DESCRIPTION
## Change

There is no need to instantiate and merge headers, as `HeaderHash` already sets the given values from `header`.

By looking at the code of `HeaderHash#merge` we see that it duplicates itself:

```ruby
      def merge(other)
        hash = dup
        hash.merge! other
      end
```

Each time we instantiate a `Rack::Response` we instantiate a `HeaderHash` twice: the first time because of `new`, and the second time because of `merge`.

## Req/s benchmark

By running this benchmark on my machine, I can see a performance gain of +350req/s.

**Gemfile**

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

gem "rack" #, git: "https://github.com/jodosha/rack.git", branch: "performance/remove-useless-header-merge"
gem "puma"
```

**config.ru**

```ruby
# frozen_string_literal: true

require "bundler/setup"

class MyAction
  def call(*)
    res = Rack::Response.new
    res.write "OK"
    res
  end
end

run MyAction.new
```

Run the app with:

```shell
$ bundle exec puma -e production -t 16:16 config.ru
```

**Before:**

```shell
$ wrk -t 2 http://localhost:9292/
Running 10s test @ http://localhost:9292/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.96ms  520.27us  17.09ms   86.12%
    Req/Sec     5.33k   317.62     5.67k    91.50%
  106150 requests in 10.00s, 4.05MB read
Requests/sec:  10614.81
Transfer/sec:    414.65KB
```

**After:**

```shell
$ wrk -t 2 http://localhost:9292/
Running 10s test @ http://localhost:9292/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.93ms  525.01us  16.51ms   87.49%
    Req/Sec     5.53k   358.19     5.85k    92.00%
  109938 requests in 10.00s, 4.19MB read
Requests/sec:  10993.58
Transfer/sec:    429.45KB
```