### PR TITLE
Fix multipart forms for Phusion Passenger in Rack 2.0

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -39,8 +39,6 @@ module Rack
           str
         end
 
-        def eof?; @content_length == @cursor; end
-
         def rewind
           @io.rewind
         end
@@ -65,11 +63,11 @@ module Rack
         io = BoundedIO.new(io, content_length) if content_length
 
         parser = new(boundary, tmpfile, bufsize, qp)
-        parser.on_read io.read(bufsize), io.eof?
+        parser.on_read io.read(bufsize)
 
         loop do
           break if parser.state == :DONE
-          parser.on_read io.read(bufsize), io.eof?
+          parser.on_read io.read(bufsize)
         end
 
         io.rewind
@@ -181,8 +179,8 @@ module Rack
         @collector = Collector.new tempfile
       end
 
-      def on_read content, eof
-        handle_empty_content!(content, eof)
+      def on_read content
+        handle_empty_content!(content)
         @buf << content
         run_parser
       end
@@ -358,10 +356,9 @@ module Rack
       end
 
 
-      def handle_empty_content!(content, eof)
+      def handle_empty_content!(content)
         if content.nil? || content.empty?
-          raise EOFError if eof
-          return true
+          raise EOFError
         end
       end
     end


### PR DESCRIPTION
The multipart parser expects its given Input Stream to respond to `#eof?`. However, this is not part of the [Rack SPEC](https://www.rubydoc.info/github/rack/rack/master/file/SPEC#label-The+Input+Stream). When `io.rewind` is called in Passenger, a `PhusionPassenger::Utils::TeeInput` is returned that does not respond to `#eof?` and _is_ SPEC compliant. This breaks all of the multipart forms in our main production application.

The fix has been in master since 2017 in df4a028a9c992db19ee50e7d8cc00d5d1f54f1a0. This is a backport of that change for the Rack 2 series as it has real-world implications.