### PR TITLE
Performance: Introduce Rack::SimpleBodyProxy

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -3,6 +3,7 @@
 require 'rack/request'
 require 'rack/utils'
 require 'rack/body_proxy'
+require 'rack/simple_body_proxy'
 require 'rack/media_type'
 require 'time'
 
@@ -68,7 +69,11 @@ module Rack
         close
         [status.to_i, header, []]
       else
-        [status.to_i, header, BodyProxy.new(self){}]
+        if @block.nil?
+          [status.to_i, header, SimpleBodyProxy.new(@body)]
+        else
+          [status.to_i, header, BodyProxy.new(self){}]
+        end
       end
     end
     alias to_a finish           # For *response

--- a/lib/rack/simple_body_proxy.rb
+++ b/lib/rack/simple_body_proxy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Rack
+  class SimpleBodyProxy
+    def initialize(body)
+      @body = body
+    end
+
+    def each(&blk)
+      @body.each(&blk)
+    end
+  end
+end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -11,7 +11,7 @@ describe Rack::Response do
     cc = 'foo'
     response.cache_control = cc
     assert_equal cc, response.cache_control
-    assert_equal cc, response.to_a[2]['Cache-Control']
+    assert_equal cc, response.to_a[1]['Cache-Control']
   end
 
   it 'has an etag method' do
@@ -19,7 +19,7 @@ describe Rack::Response do
     etag = 'foo'
     response.etag = etag
     assert_equal etag, response.etag
-    assert_equal etag, response.to_a[2]['ETag']
+    assert_equal etag, response.to_a[1]['ETag']
   end
 
   it "have sensible default values" do


### PR DESCRIPTION
## Change

Passing the entire `Rack::Response` to `Rack::BodyProxy` has a two downsides: 1. cyclic dependency 2. perf penalty.

By looking at the git history, it seems to be introduced to allow this [syntax](https://github.com/rack/rack/blob/master/test/spec_response.rb#L43-L56):

```ruby
  response = Rack::Response.new

    _, _, body = response.finish do
      response.write "foo"
      response.write "bar"
      response.write "baz"
    end

    parts = []
    body.each { |part| parts << part }

    parts.must_equal ["foo", "bar", "baz"]
```

Which is important to keep for backward compatibility, but it isn't the most common use case.

Having by default `Rack::BodyProxy` is overkilling.

---

Why not returning `@body` then? Because the body wrapper MUST NOT respond to `to_ary`, and `to_a`, as per Rack current design.

Here's the introduction of `Rack::SimpleBodyProxy`: it doesn't respond to these methods, it respond to `#each`, and simply wraps `@body`.

## Potential breaking change

**TL;DR** I changed tests that I believe were **wrong**. Please double check if the tests were wrong or if there is a breaking change.

I made changes to `test/spec_response.rb` in order to make the tests to pass. IMO the specs were wrong: they were asserting headers in `response[2]` (body) instead of `response[1]` (headers).

IMO the test were **accidentally passing** because `Rack::BodyProxy` (returned by `response[2]`) uses `method_missing` to ask the wrapped object (`Rack::Response`) to respond to a method. That if we invoke `Rack::BodyProxy#[]`, the method that is invoked is `Rack::Response#[]`, which is aliased to `#get_header`, so it returns a HTTP header.

## Req/s bench

By running this benchmark on my machine, I can see a performance gain of almost 500req/s.

**Gemfile**

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

gem "rack" # , git: "https://github.com/jodosha/rack.git", branch: "performance/simple-body-proxy"
gem "puma"
```

**config.ru**

```ruby
# frozen_string_literal: true

require "bundler/setup"

class MyAction
  def call(*)
    res = Rack::Response.new
    res.write "OK"
    res
  end
end

run MyAction.new
```

Run the app with:

```shell
$ bundle exec puma -e production -t 16:16 config.ru
```

**Before**

```shell
$ wrk -t 2 http://localhost:9292/
Running 10s test @ http://localhost:9292/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.98ms  526.99us  13.19ms   84.79%
    Req/Sec     5.24k   379.67     5.64k    91.50%
  104351 requests in 10.00s, 3.98MB read
Requests/sec:  10435.11
Transfer/sec:    407.63KB
```

**After**

```shell
$ wrk -t 2 http://localhost:9292/
Running 10s test @ http://localhost:9292/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.94ms  758.15us  24.11ms   95.27%
    Req/Sec     5.49k   362.83     6.01k    93.56%
  110426 requests in 10.10s, 4.21MB read
Requests/sec:  10932.98
Transfer/sec:    427.09KB
```