### PR TITLE
Performance: Transform `Utils::STATUS_WITH_NO_ENTITY_BODY` into a `Hash`

### DIFF
--- a/lib/rack/chunked.rb
+++ b/lib/rack/chunked.rb
@@ -57,7 +57,7 @@ module Rack
       headers = HeaderHash.new(headers)
 
       if ! chunkable_version?(env[HTTP_VERSION]) ||
-         STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i) ||
+         STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) ||
          headers[CONTENT_LENGTH] ||
          headers[TRANSFER_ENCODING]
         [status, headers, body]

--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -17,7 +17,7 @@ module Rack
       status, headers, body = @app.call(env)
       headers = HeaderHash.new(headers)
 
-      if !STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i) &&
+      if !STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) &&
          !headers[CONTENT_LENGTH] &&
          !headers[TRANSFER_ENCODING] &&
          body.respond_to?(:to_ary)

--- a/lib/rack/content_type.rb
+++ b/lib/rack/content_type.rb
@@ -21,7 +21,7 @@ module Rack
       status, headers, body = @app.call(env)
       headers = Utils::HeaderHash.new(headers)
 
-      unless STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i)
+      unless STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i)
         headers[CONTENT_TYPE] ||= @content_type
       end
 

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -107,7 +107,7 @@ module Rack
     def should_deflate?(env, status, headers, body)
       # Skip compressing empty entity body responses and responses with
       # no-transform set.
-      if Utils::STATUS_WITH_NO_ENTITY_BODY.include?(status.to_i) ||
+      if Utils::STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) ||
           headers['Cache-Control'].to_s =~ /\bno-transform\b/ ||
          (headers['Content-Encoding'] && headers['Content-Encoding'] !~ /\bidentity\b/)
         return false

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -663,7 +663,7 @@ module Rack
         ## 204 or 304.
         if key.downcase == "content-type"
           assert("Content-Type header found in #{status} response, not allowed") {
-            not Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include? status.to_i
+            not Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.key? status.to_i
           }
           return
         end
@@ -677,7 +677,7 @@ module Rack
           ## There must not be a <tt>Content-Length</tt> header when the
           ## +Status+ is 1xx, 204 or 304.
           assert("Content-Length header found in #{status} response, not allowed") {
-            not Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include? status.to_i
+            not Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.key? status.to_i
           }
           @content_length = value
         end

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -26,6 +26,10 @@ module Rack
     alias headers header
 
     CHUNKED = 'chunked'
+    STATUS_WITH_NO_ENTITY_BODY = {
+      204 => true,
+      304 => true
+    }.freeze
 
     def initialize(body = [], status = 200, header = {})
       @status = status.to_i
@@ -62,7 +66,7 @@ module Rack
     def finish(&block)
       @block = block
 
-      if Utils::STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i)
+      if STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i)
         delete_header CONTENT_TYPE
         delete_header CONTENT_LENGTH
         close

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -62,7 +62,7 @@ module Rack
     def finish(&block)
       @block = block
 
-      if [204, 304].include?(status.to_i)
+      if Utils::STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i)
         delete_header CONTENT_TYPE
         delete_header CONTENT_LENGTH
         close

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -555,7 +555,7 @@ module Rack
     }
 
     # Responses with HTTP status codes that should not have an entity body
-    STATUS_WITH_NO_ENTITY_BODY = Set.new((100..199).to_a << 204 << 304)
+    STATUS_WITH_NO_ENTITY_BODY = Hash[((100..199).to_a << 204 << 304).product([true])]
 
     SYMBOL_TO_STATUS_CODE = Hash[*HTTP_STATUS_CODES.map { |code, message|
       [message.downcase.gsub(/\s|-|'/, '_').to_sym, code]


### PR DESCRIPTION
## Change

`Utils::STATUS_WITH_NO_ENTITY_BODY` is a `Set` instance and Rack uses `#include?`. My assumption is that `Set` is used to guarantee uniqueness of values and to have faster access than `Array`.

This is a proposal to change that constant from a `Set` into a `Hash`. It guarantees uniqueness of keys, and slightly faster access via `#key?`.

Please note that the use of `true` is just a dummy value. But it's important to use a singleton method to keep low the memory footprint.

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

require "benchmark/ips"
require "set"

STATUS_WITH_NO_ENTITY_BODY_SET  = Set.new((100..199).to_a << 204 << 304)
STATUS_WITH_NO_ENTITY_BODY_HASH = Hash[((100..199).to_a << 204 << 304).product([true])]

Benchmark.ips do |x|
  x.report("set")  { STATUS_WITH_NO_ENTITY_BODY_SET.include?(304) }
  x.report("hash") { STATUS_WITH_NO_ENTITY_BODY_HASH.key?(304) }
  x.compare!
end

__END__
Result:

  Warming up --------------------------------------
                 set   258.490k i/100ms
                hash   263.442k i/100ms
Calculating -------------------------------------
                 set      7.528M (± 4.9%) i/s -     37.740M in   5.025552s
                hash      8.345M (± 5.4%) i/s -     41.624M in   5.004100s

Comparison:
                hash:  8344683.5 i/s
                 set:  7528352.1 i/s - same-ish: difference falls within error

Ruby:

    ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-darwin16]

Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro12,1
      Processor Name: Intel Core i7
      Processor Speed: 3,1 GHz
      Number of Processors: 1
      Total Number of Cores: 2
      L2 Cache (per Core): 256 KB
      L3 Cache: 4 MB
      Memory: 16 GB
      Boot ROM Version: 180.0.0.0.0
      SMC Version (system): 2.28f7

Software:

    System Software Overview:

      System Version: macOS 10.12.6 (16G1618)
      Kernel Version: Darwin 16.7.0
      Time since boot: 17 days 28 minutes
```