### PR TITLE
Allow HeaderHash objects to be deserialized

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -440,24 +440,24 @@ module Rack
       end
 
       def [](k)
-        super(k) || super(@names[k.downcase])
+        super(k) || super(names[k.downcase])
       end
 
       def []=(k, v)
         canonical = k.downcase.freeze
-        delete k if @names[canonical] && @names[canonical] != k # .delete is expensive, don't invoke it unless necessary
-        @names[canonical] = k
+        delete k if names[canonical] && names[canonical] != k # .delete is expensive, don't invoke it unless necessary
+        names[canonical] = k
         super k, v
       end
 
       def delete(k)
         canonical = k.downcase
-        result = super @names.delete(canonical)
+        result = super names.delete(canonical)
         result
       end
 
       def include?(k)
-        super || @names.include?(k.downcase)
+        super || names.include?(k.downcase)
       end
 
       alias_method :has_key?, :include?
@@ -481,8 +481,9 @@ module Rack
       end
 
       protected
+
         def names
-          @names
+          @names ||= {}
         end
     end
 

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -692,6 +692,13 @@ describe Rack::Utils::HeaderHash do
     h['foo'].must_be_nil
     h.wont_include 'foo'
   end
+
+  it "be deserialized" do
+    a = Rack::Utils::HeaderHash.new("foo" => "bar")
+    dump = YAML.dump(a)
+    b = YAML.load(dump)
+    b.must_equal a
+  end
 end
 
 describe Rack::Utils::Context do


### PR DESCRIPTION
`Rack::Utils::HeaderHash` raises an error when attempting to deserialize because `[]=` tries to access an instance variable that is not yet defined.

Resolves #1186.