### PR TITLE
Backport: Preserve forwarded IP address for trusted proxy chains

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -261,7 +261,7 @@ module Rack
 
         forwarded_ips = split_ip_addresses(get_header('HTTP_X_FORWARDED_FOR'))
 
-        return reject_trusted_ip_addresses(forwarded_ips).last || get_header("REMOTE_ADDR")
+        return reject_trusted_ip_addresses(forwarded_ips).last || forwarded_ips.first || get_header("REMOTE_ADDR")
       end
 
       # The media type (type/subtype) portion of the CONTENT_TYPE header

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1286,7 +1286,16 @@ EOF
     res.body.must_equal '2.2.2.3'
   end
 
-  it "regard local addresses as proxies" do
+  it "preserves ip for trusted proxy chain" do
+    mock = Rack::MockRequest.new(Rack::Lint.new(ip_app))
+    res = mock.get '/',
+      'HTTP_X_FORWARDED_FOR' => '192.168.0.11, 192.168.0.7',
+      'HTTP_CLIENT_IP' => '127.0.0.1'
+    res.body.must_equal '192.168.0.11'
+
+  end
+
+  it "regards local addresses as proxies" do
     req = make_request(Rack::MockRequest.env_for("/"))
     req.trusted_proxy?('127.0.0.1').must_equal 0
     req.trusted_proxy?('10.0.0.1').must_equal 0


### PR DESCRIPTION
This is a backport to `2-0-stable` of @SamSaffron's fix which was merged to `master` with https://github.com/rack/rack/pull/1224

@eileencodes @tenderlove it would be super awesome if you could make a new rack release with this backport 😊 .

---

Sometimes proxies make requests to Rack applications, for example
HAProxy health checks and so on.

Previously the forwarded IP implementation ate up these IP addresses,
making it hard to tell in Rack applications who made the request
