### PR TITLE
Don't add headers when gzipped file returned 304

### DIFF
--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -130,6 +130,8 @@ module Rack
 
           if response[0] == 404
             response = nil
+          elsif response[0] == 304
+            # Do nothing, leave headers as is
           else
             if mime_type = Mime.mime_type(::File.extname(path), 'text/plain')
               response[1][CONTENT_TYPE] = mime_type

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -14,6 +14,8 @@ class DummyApp
 end
 
 describe Rack::Static do
+  DOCROOT = File.expand_path(File.dirname(__FILE__)) unless defined? DOCROOT
+
   def static(app, *args)
     Rack::Lint.new Rack::Static.new(app, *args)
   end
@@ -122,6 +124,15 @@ describe Rack::Static do
     res.headers['Content-Encoding'].must_be_nil
     res.headers['Content-Type'].must_equal 'text/plain'
     res.body.must_match(/ruby/)
+  end
+
+  it "returns 304 if gzipped file isn't modified since last serve" do
+    path = File.join(DOCROOT, "/cgi/test")
+    res = @gzip_request.get("/cgi/test", 'HTTP_IF_MODIFIED_SINCE' => File.mtime(path).httpdate)
+    res.status.must_equal 304
+    res.body.must_be :empty?
+    res.headers['Content-Encoding'].must_be_nil
+    res.headers['Content-Type'].must_be_nil
   end
 
   it "supports serving fixed cache-control (legacy option)" do


### PR DESCRIPTION
Steps to reproduce:

1. use `Rack::Static` with `gzip: true`
2. make two sequential request for a static asset with a browser.

The first request will succeed with **200 OK** and `Last-Modified` header set.

The second request will be made with `If-Modified-Since` header and failed with `Rack::Lint::LintError: Content-Type header found in 304 response, not allowed`.

`Rack::File` correctly handles 304 response headers. But `Rack::Static` with gzip enabled adds `Content-Type` header whenever the response is not 404.