### PR TITLE
Set X-Accel-Redirect to percent-encoded path

### DIFF
--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -117,7 +117,8 @@ module Rack
           path = ::File.expand_path(body.to_path)
           if url = map_accel_path(env, path)
             headers[CONTENT_LENGTH] = '0'
-            headers[type] = url
+            # '?' must be percent-encoded because it is not query string but a part of path
+            headers[type] = ::Rack::Utils.escape_path(url).gsub('?', '%3F')
             obody = body
             body = Rack::BodyProxy.new([]) do
               obody.close if obody.respond_to?(:close)


### PR DESCRIPTION
This patch makes it possible to serve a file whose name includes % symbol or other non-ascii codes using X-Accel-Redirect and solves #1306.

As far as I searched, nginx expects X-Accel-Redirect is set to percent-encoded path after [this patch is merged](https://github.com/nginx/nginx/commit/f7ff5e65d0d20ba0425be7e3d8de4d04ceec9206) about 5 years ago.

I tested accessing to files under /var/www using nginx 1.14.0 and configs below.

```config.ru
require 'pathname'
require 'rack/sendfile'

use Rack::Sendfile

run ->(env) do
  path = URI.decode(env['REQUEST_PATH'])
  file = Pathname.new('/var/www' + path)
  [200, {}, file]
end
```

```/etc/nginx/sites-enabled/default
server {
    listen       80;
    server_name  localhost;

    location / {
        proxy_redirect     off;

        proxy_set_header   Host                $host;
        proxy_set_header   X-Real-IP           $remote_addr;
        proxy_set_header   X-Forwarded-For     $proxy_add_x_forwarded_for;

        proxy_set_header   X-Sendfile-Type     X-Accel-Redirect;
        proxy_set_header   X-Accel-Mapping     /var/www/=/foo/bar%/;

        proxy_pass http://127.0.0.1:9292;
    }

    location ~ /foo/bar%/(.*) {
        internal;
        alias /var/www/$1;
    }
}
```