### PR TITLE
 Remove `@has_app` from `Rack::Cascade`.

### DIFF
--- a/lib/rack/cascade.rb
+++ b/lib/rack/cascade.rb
@@ -11,7 +11,7 @@ module Rack
     attr_reader :apps
 
     def initialize(apps, catch = [404, 405])
-      @apps = []; @has_app = {}
+      @apps = []
       apps.each { |app| add app }
 
       @catch = {}
@@ -41,12 +41,11 @@ module Rack
     end
 
     def add(app)
-      @has_app[app] = true
       @apps << app
     end
 
     def include?(app)
-      @has_app.include? app
+      @apps.include?(app)
     end
 
     alias_method :<<, :add


### PR DESCRIPTION
I don't think we need `@has_app` in this class. 

1. `@apps` is an array we can use the `Array#include?` to check if target element in it.
2. if the `@apps` array not very large it is not a good choice to use `Hash` to store the status.