### PR TITLE
Add method for custom ip_filter and test to go with it

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -13,6 +13,12 @@ module Rack
   class Request
     SCHEME_WHITELIST = %w(https http).freeze
 
+    class << self
+      attr_accessor :ip_filter
+    end
+
+    self.ip_filter = lambda { |ip| ip =~ /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i }
+
     def initialize(env)
       @params = nil
       super(env)
@@ -417,7 +423,7 @@ module Rack
       end
 
       def trusted_proxy?(ip)
-        ip =~ /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i
+        Rack::Request.ip_filter.call(ip)
       end
 
       # shortcut for <tt>request.params[key]</tt>

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1295,6 +1295,14 @@ EOF
 
   end
 
+  it "uses a custom trusted proxy filter" do
+    old_ip = Rack::Request.ip_filter
+    Rack::Request.ip_filter = lambda { |ip| ip == 'foo' }
+    req = make_request(Rack::MockRequest.env_for("/"))
+    assert req.trusted_proxy?('foo')
+    Rack::Request.ip_filter = old_ip
+  end
+
   it "regards local addresses as proxies" do
     req = make_request(Rack::MockRequest.env_for("/"))
     req.trusted_proxy?('127.0.0.1').must_equal 0


### PR DESCRIPTION
This is a backport to `2-0-stable` of @svcastaneda's fix which was merged to `master` with https://github.com/rack/rack/pull/1290

---

This pull request extracts the `ip_filter` into a lambda so that users can configure their own ip_filter (e.g., #1276).