### PR TITLE
Optimize Rack::MediaType params and type parsers

### DIFF
--- a/lib/rack/media_type.rb
+++ b/lib/rack/media_type.rb
@@ -25,9 +25,12 @@ module Rack
       #   { 'charset' => 'utf-8' }
       def params(content_type)
         return {} if content_type.nil?
-        Hash[*content_type.split(SPLIT_PATTERN)[1..-1].
-          collect { |s| s.split('=', 2) }.
-          map { |k, v| [k.downcase, strip_doublequotes(v)] }.flatten]
+
+        content_type.split(SPLIT_PATTERN)[1..-1].each_with_object({}) do |s, hsh|
+          k, v = s.split('=', 2)
+
+          hsh[k.tap(&:downcase!)] = strip_doublequotes(v)
+        end
       end
 
       private

--- a/lib/rack/media_type.rb
+++ b/lib/rack/media_type.rb
@@ -15,7 +15,7 @@ module Rack
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7
       def type(content_type)
         return nil unless content_type
-        content_type.split(SPLIT_PATTERN, 2).first.downcase
+        content_type.split(SPLIT_PATTERN, 2).first.tap &:downcase!
       end
 
       # The media type parameters provided in CONTENT_TYPE as a Hash, or


### PR DESCRIPTION
```ruby
media_type: application/text

Warming up --------------------------------------
            original    38.980k i/100ms
           optimized    71.472k i/100ms
Calculating -------------------------------------
            original    482.257k (± 7.9%) i/s -      2.417M in   5.051485s
           optimized      1.010M (± 1.5%) i/s -      5.075M in   5.027185s

Comparison:
           optimized:  1009657.3 i/s
            original:   482256.8 i/s - 2.09x  slower

Calculating -------------------------------------
            original   280.000  memsize (     0.000  retained)
                         7.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
           optimized   160.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
           optimized:        160 allocated
            original:        280 allocated - 1.75x more

media_type: application/text;CHARSET="utf-8"

Warming up --------------------------------------
            original    15.787k i/100ms
           optimized    20.540k i/100ms
Calculating -------------------------------------
            original    170.264k (± 1.1%) i/s -    852.498k in   5.007564s
           optimized    221.719k (± 4.5%) i/s -      1.109M in   5.015915s

Comparison:
           optimized:   221719.2 i/s
            original:   170264.4 i/s - 1.30x  slower

Calculating -------------------------------------
            original     1.112k memsize (     0.000  retained)
                        18.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)
           optimized   912.000  memsize (     0.000  retained)
                        13.000  objects (     0.000  retained)
                         6.000  strings (     0.000  retained)

Comparison:
           optimized:        912 allocated
            original:       1112 allocated - 1.22x more
```