### PR TITLE
Use Regexp match? instead of =~

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'core_ext/regexp'
+
 module Rack
   # Rack::Builder implements a small DSL to iteratively construct Rack
   # applications.
@@ -31,11 +33,13 @@ module Rack
   # You can use +map+ to construct a Rack::URLMap in a convenient way.
 
   class Builder
+    using ::Rack::RegexpExtensions
+
     # https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-without-bom
     UTF_8_BOM = '\xef\xbb\xbf'
 
     def self.parse_file(config, opts = Server::Options.new)
-      if config =~ /\.ru$/
+      if /\.ru$/.match?(config)
         return self.load_file(config, opts)
       else
         require config

--- a/lib/rack/core_ext/regexp.rb
+++ b/lib/rack/core_ext/regexp.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Regexp has `match?` since Ruby 2.4
+# so to support Ruby < 2.4 we need to define this method
+
+module Rack
+  module RegexpExtensions
+    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(2.4)
+      refine Regexp do
+        def match?(string, pos = 0)
+          !!match(string, pos)
+        end unless //.respond_to?(:match?)
+      end
+    end
+  end
+end

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -4,6 +4,8 @@ require "zlib"
 require "time"  # for Time.httpdate
 require 'rack/utils'
 
+require_relative 'core_ext/regexp'
+
 module Rack
   # This middleware enables compression of http responses.
   #
@@ -17,6 +19,8 @@ module Rack
   # directive of 'no-transform' is present, or when the response status
   # code is one that doesn't allow an entity body.
   class Deflater
+    using ::Rack::RegexpExtensions
+
     ##
     # Creates Rack::Deflater middleware.
     #
@@ -108,7 +112,7 @@ module Rack
       # Skip compressing empty entity body responses and responses with
       # no-transform set.
       if Utils::STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) ||
-          headers['Cache-Control'].to_s =~ /\bno-transform\b/ ||
+          /\bno-transform\b/.match?(headers['Cache-Control'].to_s) ||
          (headers['Content-Encoding'] && headers['Content-Encoding'] !~ /\bidentity\b/)
         return false
       end

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -2,12 +2,15 @@
 
 require 'rack/utils'
 require 'strscan'
+require 'rack/core_ext/regexp'
 
 module Rack
   module Multipart
     class MultipartPartLimitError < Errno::EMFILE; end
 
     class Parser
+      using ::Rack::RegexpExtensions
+
       BUFSIZE = 1_048_576
       TEXT_PLAIN = "text/plain"
       TEMPFILE_FACTORY = lambda { |filename, content_type|
@@ -311,7 +314,7 @@ module Rack
 
         return unless filename
 
-        if filename.scan(/%.?.?/).all? { |s| s =~ /%[0-9a-fA-F]{2}/ }
+        if filename.scan(/%.?.?/).all? { |s| /%[0-9a-fA-F]{2}/.match?(s) }
           filename = Utils.unescape_path(filename)
         end
 

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'core_ext/regexp'
+
 module Rack
   class QueryParser
+    using ::Rack::RegexpExtensions
+
     DEFAULT_SEP = /[&;] */n
     COMMON_SEP = { ";" => /[;] */n, ";," => /[;,] */n, "&" => /[&] */n }
 
@@ -137,7 +141,7 @@ module Rack
     end
 
     def params_hash_has_key?(hash, key)
-      return false if key =~ /\[\]/
+      return false if /\[\]/.match?(key)
 
       key.split(/[\[\]]+/).inject(hash) do |h, part|
         next h if part == ''

--- a/lib/rack/reloader.rb
+++ b/lib/rack/reloader.rb
@@ -6,6 +6,8 @@
 
 require 'pathname'
 
+require_relative 'core_ext/regexp'
+
 module Rack
 
   # High performant source reloader
@@ -22,6 +24,8 @@ module Rack
   # It is performing a check/reload cycle at the start of every request, but
   # also respects a cool down time, during which nothing will be done.
   class Reloader
+    using ::Rack::RegexpExtensions
+
     def initialize(app, cooldown = 10, backend = Stat)
       @app = app
       @cooldown = cooldown
@@ -71,7 +75,7 @@ module Rack
         paths = ['./', *$LOAD_PATH].uniq
 
         files.map{|file|
-          next if file =~ /\.(so|bundle)$/ # cannot reload compiled files
+          next if /\.(so|bundle)$/.match?(file) # cannot reload compiled files
 
           found, stat = figure_path(file, paths)
           next unless found && stat && mtime = stat.mtime

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -3,10 +3,12 @@
 require 'optparse'
 require 'fileutils'
 
+require_relative 'core_ext/regexp'
 
 module Rack
 
   class Server
+    using ::Rack::RegexpExtensions
 
     class Options
       def parse!(args)
@@ -134,7 +136,7 @@ module Rack
 
             has_options = false
             server.valid_options.each do |name, description|
-              next if name.to_s.match(/^(Host|Port)[^a-zA-Z]/) # ignore handler's host and port options, we do our own.
+              next if /^(Host|Port)[^a-zA-Z]/.match?(name.to_s) # ignore handler's host and port options, we do our own.
               info << "  -O %-21s %s" % [name, description]
               has_options = true
             end
@@ -252,7 +254,7 @@ module Rack
     class << self
       def logging_middleware
         lambda { |server|
-          server.server.name =~ /CGI/ || server.options[:quiet] ? nil : [Rack::CommonLogger, $stderr]
+          /CGI/.match?(server.server.name) || server.options[:quiet] ? nil : [Rack::CommonLogger, $stderr]
         }
       end
 

--- a/lib/rack/session/memcache.rb
+++ b/lib/rack/session/memcache.rb
@@ -4,6 +4,7 @@
 
 require 'rack/session/abstract/id'
 require 'memcache'
+require 'rack/core_ext/regexp'
 
 module Rack
   module Session
@@ -22,6 +23,8 @@ module Rack
     # a full description of behaviour, please see memcache's documentation.
 
     class Memcache < Abstract::ID
+      using ::Rack::RegexpExtensions
+
       attr_reader :mutex, :pool
 
       DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge \
@@ -52,7 +55,7 @@ module Rack
         with_lock(env) do
           unless sid and session = @pool.get(sid)
             sid, session = generate_sid, {}
-            unless /^STORED/ =~ @pool.add(sid, session)
+            unless /^STORED/.match?(@pool.add(sid, session))
               raise "Session collision on '#{sid.inspect}'"
             end
           end

--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -3,6 +3,8 @@
 require "rack/file"
 require "rack/utils"
 
+require_relative 'core_ext/regexp'
+
 module Rack
 
   # The Rack::Static middleware intercepts requests for static files
@@ -84,6 +86,7 @@ module Rack
   #         ]
   #
   class Static
+    using ::Rack::RegexpExtensions
 
     def initialize(app, options = {})
       @app = app
@@ -101,7 +104,7 @@ module Rack
     end
 
     def add_index_root?(path)
-      @index && route_file(path) && path =~ /\/$/
+      @index && route_file(path) && /\/$/.match?(path)
     end
 
     def overwrite_file_path(path)
@@ -122,7 +125,7 @@ module Rack
       if can_serve(path)
         if overwrite_file_path(path)
           env[PATH_INFO] = (add_index_root?(path) ? path + @index : @urls[path])
-        elsif @gzip && env['HTTP_ACCEPT_ENCODING'] =~ /\bgzip\b/
+        elsif @gzip && /\bgzip\b/.match?(env['HTTP_ACCEPT_ENCODING'])
           path = env[PATH_INFO]
           env[PATH_INFO] += '.gz'
           response = @file_server.call(env)
@@ -159,14 +162,14 @@ module Rack
         when :all
           true
         when :fonts
-          path =~ /\.(?:ttf|otf|eot|woff2|woff|svg)\z/
+          /\.(?:ttf|otf|eot|woff2|woff|svg)\z/.match?(path)
         when String
           path = ::Rack::Utils.unescape(path)
           path.start_with?(rule) || path.start_with?('/' + rule)
         when Array
-          path =~ /\.(#{rule.join('|')})\z/
+          /\.(#{rule.join('|')})\z/.match?(path)
         when Regexp
-          path =~ rule
+          rule.match?(path)
         else
           false
         end

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -8,11 +8,15 @@ require 'tempfile'
 require 'rack/query_parser'
 require 'time'
 
+require_relative 'core_ext/regexp'
+
 module Rack
   # Rack::Utils contains a grab-bag of useful methods for writing web
   # applications adopted from all kinds of Ruby libraries.
 
   module Utils
+    using ::Rack::RegexpExtensions
+
     ParameterTypeError = QueryParser::ParameterTypeError
     InvalidParameterError = QueryParser::InvalidParameterError
     DEFAULT_SEP = QueryParser::DEFAULT_SEP
@@ -273,15 +277,15 @@ module Rack
         cookies = header
       end
 
-      cookies.reject! { |cookie|
-        if value[:domain]
-          cookie =~ /\A#{escape(key)}=.*domain=#{value[:domain]}/
-        elsif value[:path]
-          cookie =~ /\A#{escape(key)}=.*path=#{value[:path]}/
-        else
-          cookie =~ /\A#{escape(key)}=/
-        end
-      }
+      regexp = if value[:domain]
+                 /\A#{escape(key)}=.*domain=#{value[:domain]}/
+               elsif value[:path]
+                 /\A#{escape(key)}=.*path=#{value[:path]}/
+               else
+                 /\A#{escape(key)}=/
+               end
+
+      cookies.reject! { |cookie| regexp.match? cookie }
 
       cookies.join("\n")
     end


### PR DESCRIPTION
`Regexp#match?` is way faster than `=~` so we can gain a little bit of speed.

Ruby introduced `Regexp#match?` in 2.4 so we need to polyfill it for Ruby < 2.4.