### PR TITLE
Add MIME type for .mjs javascript modules

### DIFF
--- a/lib/rack/mime.rb
+++ b/lib/rack/mime.rb
@@ -331,6 +331,7 @@ module Rack
       ".mif"       => "application/vnd.mif",
       ".mime"      => "message/rfc822",
       ".mj2"       => "video/mj2",
+      ".mjs"       => "application/javascript",
       ".mlp"       => "application/vnd.dolby.mlp",
       ".mmd"       => "application/vnd.chipnuts.karaoke-mmd",
       ".mmf"       => "application/vnd.smaf",


### PR DESCRIPTION
While it's possible to use the `.js` extension for javascript modules, NodeJS requires the `.mjs` extension. Adding the MIME type for `.mjs` ensures compatibility with javascript modules designed to run both on NodeJS and in the browser.