### PR TITLE
Backport to 2-0-stable : Add falcon as an option by default.

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -52,7 +52,7 @@ module Rack
       elsif ENV.include?("RACK_HANDLER")
         self.get(ENV["RACK_HANDLER"])
       else
-        pick ['puma', 'thin', 'webrick']
+        pick ['puma', 'thin', 'falcon', 'webrick']
       end
     end
 


### PR DESCRIPTION
This is a backport of [a commit in master](https://github.com/rack/rack/commit/4bd09c04f7e6497db4a4cef169ee9099d25c3391) to add falcon to the default options list. In case a 2.0.X version is released before 2.1