### PR TITLE
Added support for SameSite=None cookie value

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -230,6 +230,8 @@ module Rack
           case value[:same_site]
           when false, nil
             nil
+          when :none, 'None', :None
+            '; SameSite=None'
           when :lax, 'Lax', :Lax
             '; SameSite=Lax'
           when true, :strict, 'Strict', :Strict

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -127,6 +127,24 @@ describe Rack::Response do
     response["Set-Cookie"].must_equal "foo=bar"
   end
 
+  it "can set SameSite cookies with symbol value :none" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: :none }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with symbol value :None" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: :None }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with string value 'None'" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: "None" }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
   it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
     response.set_cookie "foo", { value: "bar", same_site: :lax }


### PR DESCRIPTION
This value was added in revision 3 of rfc6265bis:
 https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#appendix-A.4

The value "None" indicates that cookie is used as a third party cookie. Chrome 76, due for release late July, will default to SameSite=Lax unless SameSite is set. The only way to set cookies used as third party cookies will be to set them with SameSite=None: 
https://web.dev/samesite-cookies-explained/