### PR TITLE
Revert "CHANGELOG link fix"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -208,9 +208,9 @@ Set to 0 for no limit.
 
 Can also be set via the +RACK_MULTIPART_PART_LIMIT+ environment variable.
 
-== Changelog
+== History
 
-See {CHANGELOG.md}[https://github.com/rack/rack/blob/master/CHANGELOG.md].
+See {HISTORY.md}[https://github.com/rack/rack/blob/master/HISTORY.md].
 
 == Contact
 


### PR DESCRIPTION
Reverts rack/rack#1291От 9f6810b4f99becfd59d9327c0c667e4bd56afa9f Пон Сеп 17 00:00:00 2001
От: Брайън Кефарт <briantkephart@gmail.com>
Дата: пт, 24 август 2018 г. 01:14:38 -0500
Тема: [PATCH] Промяна на връзката в README.md, за да сочи към CHANGELOG.md вместо
 HISTORY.md (премахнато в 3524692)

---
 README.rdoc | 4 ++ -
 1 променен файл, 2 вмъквания (+), 2 изтривания (-)

diff - git a / README.rdoc b / README.rdoc
индекс 9295013cc..124e2f614 100644
--- a / README.rdoc
+++ b / README.rdoc
@@ -215,9 +215,9 @@ Задайте 0 без ограничение.
 
 Може да се зададе и чрез променливата + RACK_MULTIPART_PART_LIMIT +.
 
- == История
+ == Промените
 
Виж {HISTORY.md} [https://github.com/rack/rack/blob/master/HISTORY.md].
+ Вижте {CHANGELOG.md} [https://github.com/rack/rack/blob/master/CHANGELOG.md].
 
 == Контакт
 @defunkt @macournoyer @bmizerany #1291 #1360 