### PR TITLE
Fix RuboCop version so that it supports Ruby 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ c_platforms = Bundler::Dsl::VALID_PLATFORMS.dup.delete_if do |platform|
   platform =~ /jruby/
 end
 
-gem "rubocop", require: false
+gem "rubocop", "0.68.1", require: false
 
 # Alternative solution that might work, but it has bad interactions with
 # Gemfile.lock if that gets committed/reused:


### PR DESCRIPTION
Because RuboCop `0.69.0` doesn't support `2.2`.
However, Rack itself still supports `2.2`.

Should RuboCop be downgraded for now maybe?