### PR TITLE
Optimize Rack::Utils.select_best_encoding

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -177,27 +177,26 @@ module Rack
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
 
       expanded_accept_encoding =
-        accept_encoding.map { |m, q|
+        accept_encoding.each_with_object([]) do |(m, q), list|
           if m == "*"
-            (available_encodings - accept_encoding.map { |m2, _| m2 }).map { |m2| [m2, q] }
+            (available_encodings - accept_encoding.map(&:first))
+              .each { |m2| list << [m2, q] }
           else
-            [[m, q]]
+            list << [m, q]
           end
-        }.inject([]) { |mem, list|
-          mem + list
-        }
+        end
 
-      encoding_candidates = expanded_accept_encoding.sort_by { |_, q| -q }.map { |m, _| m }
+      encoding_candidates = expanded_accept_encoding.sort_by { |_, q| -q }.map!(&:first)
 
       unless encoding_candidates.include?("identity")
         encoding_candidates.push("identity")
       end
 
-      expanded_accept_encoding.each { |m, q|
+      expanded_accept_encoding.each do |m, q|
         encoding_candidates.delete(m) if q == 0.0
-      }
+      end
 
-      return (encoding_candidates & available_encodings)[0]
+      (encoding_candidates & available_encodings)[0]
     end
     module_function :select_best_encoding
 


### PR DESCRIPTION
```ruby
available_encodings: ["compress", "gzip", "identity"]
accept_encoding:     [["compress", 1.0], ["gzip", 1.0]]

Warming up --------------------------------------
            original    20.744k i/100ms
           optimized    23.904k i/100ms
Calculating -------------------------------------
            original    233.218k (± 2.2%) i/s -      1.182M in   5.072651s
           optimized    266.016k (± 2.0%) i/s -      1.339M in   5.034269s

Comparison:
           optimized:   266016.2 i/s
            original:   233218.0 i/s - 1.14x  slower

Calculating -------------------------------------
            original   440.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        200 allocated
            original:        440 allocated - 2.20x more
--
available_encodings: []
accept_encoding:     [["x", 1]]

Warming up --------------------------------------
            original    41.396k i/100ms
           optimized    48.258k i/100ms
Calculating -------------------------------------
            original    485.695k (± 2.3%) i/s -      2.442M in   5.031350s
           optimized    573.344k (± 4.5%) i/s -      2.895M in   5.063525s

Comparison:
           optimized:   573343.6 i/s
            original:   485694.5 i/s - 1.18x  slower

Calculating -------------------------------------
            original   320.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   160.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        160 allocated
            original:        320 allocated - 2.00x more
--
available_encodings: ["identity"]
accept_encoding:     [["identity", 0.0]]

Warming up --------------------------------------
            original    33.776k i/100ms
           optimized    32.429k i/100ms
Calculating -------------------------------------
            original    379.654k (± 4.1%) i/s -      1.925M in   5.080204s
           optimized    441.838k (± 2.8%) i/s -      2.238M in   5.068720s

Comparison:
           optimized:   441837.7 i/s
            original:   379654.2 i/s - 1.16x  slower

Calculating -------------------------------------
            original   360.000  memsize (     0.000  retained)
                         9.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        200 allocated
            original:        360 allocated - 1.80x more
--
available_encodings: ["identity"]
accept_encoding:     [["*", 0.0]]

Warming up --------------------------------------
            original    25.629k i/100ms
           optimized    27.979k i/100ms
Calculating -------------------------------------
            original    282.771k (± 1.7%) i/s -      1.435M in   5.077016s
           optimized    317.650k (± 1.7%) i/s -      1.595M in   5.022088s

Comparison:
           optimized:   317649.7 i/s
            original:   282771.2 i/s - 1.12x  slower

Calculating -------------------------------------
            original   440.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   280.000  memsize (     0.000  retained)
                         7.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        280 allocated
            original:        440 allocated - 1.57x more
--
available_encodings: ["identity"]
accept_encoding:     [["compress", 1.0], ["gzip", 1.0]]

Warming up --------------------------------------
            original    21.847k i/100ms
           optimized    24.611k i/100ms
Calculating -------------------------------------
            original    242.023k (± 2.6%) i/s -      1.223M in   5.058749s
           optimized    278.259k (± 2.6%) i/s -      1.403M in   5.044967s

Comparison:
           optimized:   278258.9 i/s
            original:   242022.6 i/s - 1.15x  slower

Calculating -------------------------------------
            original   440.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        200 allocated
            original:        440 allocated - 2.20x more
--
available_encodings: ["compress", "gzip", "identity"]
accept_encoding:     [["compress", 1.0], ["gzip", 1.0]]

Warming up --------------------------------------
            original    21.648k i/100ms
           optimized    23.780k i/100ms
Calculating -------------------------------------
            original    234.183k (± 1.7%) i/s -      1.191M in   5.085784s
           optimized    266.815k (± 1.7%) i/s -      1.355M in   5.081724s

Comparison:
           optimized:   266814.9 i/s
            original:   234183.2 i/s - 1.14x  slower

Calculating -------------------------------------
            original   440.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        200 allocated
            original:        440 allocated - 2.20x more
--
available_encodings: ["compress", "gzip", "identity"]
accept_encoding:     [["compress", 0.5], ["gzip", 1.0]]

Warming up --------------------------------------
            original    21.570k i/100ms
           optimized    23.749k i/100ms
Calculating -------------------------------------
            original    230.707k (± 4.9%) i/s -      1.165M in   5.063931s
           optimized    264.257k (± 2.7%) i/s -      1.330M in   5.036700s

Comparison:
           optimized:   264256.8 i/s
            original:   230706.8 i/s - 1.15x  slower

Calculating -------------------------------------
            original   440.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        200 allocated
            original:        440 allocated - 2.20x more
--
available_encodings: ["foo", "bar", "identity"]
accept_encoding:     []

Warming up --------------------------------------
            original    44.000k i/100ms
           optimized    46.466k i/100ms
Calculating -------------------------------------
            original    513.624k (± 5.9%) i/s -      2.596M in   5.076496s
           optimized    565.794k (± 2.3%) i/s -      2.834M in   5.012514s

Comparison:
           optimized:   565793.7 i/s
            original:   513623.9 i/s - 1.10x  slower

Calculating -------------------------------------
            original   200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   120.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        120 allocated
            original:        200 allocated - 1.67x more
--
available_encodings: ["foo", "bar", "identity"]
accept_encoding:     [["*", 1.0]]

Warming up --------------------------------------
            original    16.730k i/100ms
           optimized    17.592k i/100ms
Calculating -------------------------------------
            original    176.713k (± 1.8%) i/s -    886.690k in   5.019419s
           optimized    191.056k (± 2.6%) i/s -    967.560k in   5.067954s

Comparison:
           optimized:   191055.6 i/s
            original:   176713.0 i/s - 1.08x  slower

Calculating -------------------------------------
            original   480.000  memsize (     0.000  retained)
                        12.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   320.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        320 allocated
            original:        480 allocated - 1.50x more
--
available_encodings: ["foo", "bar", "identity"]
accept_encoding:     [["*", 1.0], ["foo", 0.9]]

Warming up --------------------------------------
            original    15.703k i/100ms
           optimized    17.251k i/100ms
Calculating -------------------------------------
            original    165.368k (± 2.3%) i/s -    832.259k in   5.035476s
           optimized    185.810k (± 1.8%) i/s -    931.554k in   5.015079s

Comparison:
           optimized:   185810.0 i/s
            original:   165368.0 i/s - 1.12x  slower

Calculating -------------------------------------
            original   560.000  memsize (     0.000  retained)
                        14.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   320.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        320 allocated
            original:        560 allocated - 1.75x more
--
available_encodings: ["foo", "bar", "identity"]
accept_encoding:     [["foo", 0], ["bar", 0]]

Warming up --------------------------------------
            original    20.256k i/100ms
           optimized    22.434k i/100ms
Calculating -------------------------------------
            original    221.468k (± 1.8%) i/s -      1.114M in   5.032036s
           optimized    248.544k (± 2.1%) i/s -      1.256M in   5.057031s

Comparison:
           optimized:   248544.0 i/s
            original:   221468.2 i/s - 1.12x  slower

Calculating -------------------------------------
            original   440.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   200.000  memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        200 allocated
            original:        440 allocated - 2.20x more
--
available_encodings: ["foo", "bar", "baz", "identity"]
accept_encoding:     [["*", 0], ["identity", 0.1]]

Warming up --------------------------------------
            original    11.851k i/100ms
           optimized    13.379k i/100ms
Calculating -------------------------------------
            original    124.474k (± 4.8%) i/s -    628.103k in   5.060276s
           optimized    142.971k (± 2.1%) i/s -    722.466k in   5.055632s

Comparison:
           optimized:   142970.9 i/s
            original:   124474.0 i/s - 1.15x  slower

Calculating -------------------------------------
            original   728.000  memsize (     0.000  retained)
                        15.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
           optimized   584.000  memsize (     0.000  retained)
                         9.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
           optimized:        584 allocated
            original:        728 allocated - 1.25x more
```