### PR TITLE
Reduce memory usage in Rack::Auth::Digest::MD5 methods

### DIFF
--- a/lib/rack/auth/digest/md5.rb
+++ b/lib/rack/auth/digest/md5.rb
@@ -108,7 +108,7 @@ module Rack
         alias :H :md5
 
         def KD(secret, data)
-          H([secret, data] * ':')
+          H "#{secret}:#{data}"
         end
 
         def A1(auth, password)

--- a/lib/rack/auth/digest/md5.rb
+++ b/lib/rack/auth/digest/md5.rb
@@ -116,7 +116,7 @@ module Rack
         end
 
         def A2(auth)
-          [ auth.method, auth.uri ] * ':'
+          "#{auth.method}:#{auth.uri}"
         end
 
         def digest(auth, password)

--- a/lib/rack/auth/digest/md5.rb
+++ b/lib/rack/auth/digest/md5.rb
@@ -122,7 +122,7 @@ module Rack
         def digest(auth, password)
           password_hash = passwords_hashed? ? password : H(A1(auth, password))
 
-          KD(password_hash, [ auth.nonce, auth.nc, auth.cnonce, QOP, H(A2(auth)) ] * ':')
+          KD password_hash, "#{auth.nonce}:#{auth.nc}:#{auth.cnonce}:#{QOP}:#{H A2(auth)}"
         end
 
       end

--- a/lib/rack/auth/digest/md5.rb
+++ b/lib/rack/auth/digest/md5.rb
@@ -112,7 +112,7 @@ module Rack
         end
 
         def A1(auth, password)
-          [ auth.username, auth.realm, password ] * ':'
+          "#{auth.username}:#{auth.realm}:#{password}"
         end
 
         def A2(auth)


### PR DESCRIPTION
We can replace `[] * ':'` with interpolation which greatly reduces the number of arrays allocated.