### PR TITLE
Remove unnecessary buffer growing when parsing multipart

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -277,6 +277,7 @@ module Rack
             delta = @sbuf.rest_size - @rx_max_size
             @collector.on_mime_body @mime_index, @sbuf.peek(delta)
             @sbuf.pos += delta
+            @sbuf.string =  @sbuf.rest
           end
           :want_read
         end

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -277,7 +277,7 @@ module Rack
             delta = @sbuf.rest_size - @rx_max_size
             @collector.on_mime_body @mime_index, @sbuf.peek(delta)
             @sbuf.pos += delta
-            @sbuf.string =  @sbuf.rest
+            @sbuf.string = @sbuf.rest
           end
           :want_read
         end


### PR DESCRIPTION
Problem: Large file upload consumes large memory (100MB file upload requires 100MB+ memory).
The cause of this issue is that Multipart::Parser uses StringScanner as buffer and appends chunk here,
```
      def on_read content
        handle_empty_content!(content)
        @sbuf.concat content #<- here
        run_parser
      end
```
and it keeps `@sbuf` growing but never discards processed chunk.
This PR discards chunk in buffer that have already processed in order to prevent huge memory consumption.
