### PR TITLE
Avoid regex in Request#host

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -243,7 +243,12 @@ module Rack
 
       def host
         # Remove port number.
-        host_with_port.to_s.sub(/:\d+\z/, '')
+        h = host_with_port
+        if colon_index = h.index(":")
+          h[0, colon_index]
+        else
+          h
+        end
       end
 
       def port


### PR DESCRIPTION
This PR changes an implementation detail in `Request#host`: to cut off the port number, index into a string instead `String#sub(regex)`.

# Details

- this method now assumes the same thing as `#port`: `#host_with_port` returns a String
- this method now assumes that a colon appears in the `#host_with_port` result _once_

# Background

This was inspired by the code in Puma.