### PR TITLE
reduce allocations in strip_port

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -496,11 +496,18 @@ module Rack
       def strip_port(ip_address)
         # IPv6 format with optional port: "[2001:db8:cafe::17]:47011"
         # returns: "2001:db8:cafe::17"
-        return ip_address.gsub(/(^\[|\]:\d+$)/, '') if ip_address.include?('[')
+        sep_start = ip_address.index('[')
+        sep_end = ip_address.index(']')
+        if (sep_start && sep_end)
+          return ip_address[sep_start + 1, sep_end - 1]
+        end
 
         # IPv4 format with optional port: "192.0.2.43:47011"
         # returns: "192.0.2.43"
-        return ip_address.gsub(/:\d+$/, '') if ip_address.count(':') == 1
+        sep = ip_address.index(':')
+        if (sep && ip_address.count(':') == 1)
+          return ip_address[0, sep]
+        end
 
         ip_address
       end


### PR DESCRIPTION
a minor optimization

ip4
<pre>
Allocations -------------------------------------
                 old       8/0  alloc/ret        5/0  strings/ret
                 new       5/0  alloc/ret        4/0  strings/ret
Warming up --------------------------------------
                 old    19.195k i/100ms
                 new    51.614k i/100ms
Calculating -------------------------------------
                 old    253.405k (± 8.3%) i/s -      1.267M
                 new      1.251M (± 4.0%) i/s -      6.245M

Comparison:
                 new:  1250620.2 i/s
                 old:   253404.6 i/s - 4.94x slower
</pre>

ip6
<pre>
Allocations -------------------------------------
                 old       5/0  alloc/ret        3/0  strings/ret
                 new       3/0  alloc/ret        3/0  strings/ret
Warming up --------------------------------------
                 old    19.229k i/100ms
                 new    60.567k i/100ms
Calculating -------------------------------------
                 old    261.659k (± 4.2%) i/s -      1.308M
                 new      1.806M (± 8.1%) i/s -      8.964M

Comparison:
                 new:  1805840.5 i/s
                 old:   261658.8 i/s - 6.90x slower
</pre>