### PR TITLE
return boolean in trusted_proxy?

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -3,6 +3,8 @@
 require 'rack/utils'
 require 'rack/media_type'
 
+require_relative 'core_ext/regexp'
+
 module Rack
   # Rack::Request provides a convenient interface to a Rack
   # environment.  It is stateless, the environment +env+ passed to the
@@ -13,11 +15,13 @@ module Rack
   #   req.params["data"]
 
   class Request
+    using ::Rack::RegexpExtensions
+
     class << self
       attr_accessor :ip_filter
     end
 
-    self.ip_filter = lambda { |ip| ip =~ /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i }
+    self.ip_filter = lambda { |ip| /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i.match?(ip) }
     ALLOWED_SCHEMES = %w(https http).freeze
     SCHEME_WHITELIST = ALLOWED_SCHEMES
     if Object.respond_to?(:deprecate_constant)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1321,26 +1321,26 @@ EOF
 
   it "regards local addresses as proxies" do
     req = make_request(Rack::MockRequest.env_for("/"))
-    req.trusted_proxy?('127.0.0.1').must_equal 0
-    req.trusted_proxy?('10.0.0.1').must_equal 0
-    req.trusted_proxy?('172.16.0.1').must_equal 0
-    req.trusted_proxy?('172.20.0.1').must_equal 0
-    req.trusted_proxy?('172.30.0.1').must_equal 0
-    req.trusted_proxy?('172.31.0.1').must_equal 0
-    req.trusted_proxy?('192.168.0.1').must_equal 0
-    req.trusted_proxy?('::1').must_equal 0
-    req.trusted_proxy?('fd00::').must_equal 0
-    req.trusted_proxy?('localhost').must_equal 0
-    req.trusted_proxy?('unix').must_equal 0
-    req.trusted_proxy?('unix:/tmp/sock').must_equal 0
+    req.trusted_proxy?('127.0.0.1').must_equal true
+    req.trusted_proxy?('10.0.0.1').must_equal true
+    req.trusted_proxy?('172.16.0.1').must_equal true
+    req.trusted_proxy?('172.20.0.1').must_equal true
+    req.trusted_proxy?('172.30.0.1').must_equal true
+    req.trusted_proxy?('172.31.0.1').must_equal true
+    req.trusted_proxy?('192.168.0.1').must_equal true
+    req.trusted_proxy?('::1').must_equal true
+    req.trusted_proxy?('fd00::').must_equal true
+    req.trusted_proxy?('localhost').must_equal true
+    req.trusted_proxy?('unix').must_equal true
+    req.trusted_proxy?('unix:/tmp/sock').must_equal true
 
-    req.trusted_proxy?("unix.example.org").must_be_nil
-    req.trusted_proxy?("example.org\n127.0.0.1").must_be_nil
-    req.trusted_proxy?("127.0.0.1\nexample.org").must_be_nil
-    req.trusted_proxy?("11.0.0.1").must_be_nil
-    req.trusted_proxy?("172.15.0.1").must_be_nil
-    req.trusted_proxy?("172.32.0.1").must_be_nil
-    req.trusted_proxy?("2001:470:1f0b:18f8::1").must_be_nil
+    req.trusted_proxy?("unix.example.org").must_equal false
+    req.trusted_proxy?("example.org\n127.0.0.1").must_equal false
+    req.trusted_proxy?("127.0.0.1\nexample.org").must_equal false
+    req.trusted_proxy?("11.0.0.1").must_equal false
+    req.trusted_proxy?("172.15.0.1").must_equal false
+    req.trusted_proxy?("172.32.0.1").must_equal false
+    req.trusted_proxy?("2001:470:1f0b:18f8::1").must_equal false
   end
 
   it "sets the default session to an empty hash" do


### PR DESCRIPTION
minor perf improvement

there's a change in behaviour, but I don't expect any compatibility issues.
<pre>
#trusted_proxy?
</pre>
now returns "true" / "false" instead of "0" / "nil".

<pre>
Warming up --------------------------------------
                 new    61.447k i/100ms
                 old    54.175k i/100ms
Calculating -------------------------------------
                 new      3.572M (± 6.8%) i/s -     17.758M in   5.006923s
                 old      2.447M (± 5.5%) i/s -     12.189M in   5.001299s

Comparison:
                 new:  3571977.9 i/s
                 old:  2447376.1 i/s - 1.46x  slower
</pre>