### PR TITLE
Speedup/simplify unpacked_cookie_data

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -139,9 +139,7 @@ module Rack
           session_data = request.cookies[@key]
 
           if @secrets.size > 0 && session_data
-            digest, session_data = session_data.reverse.split("--", 2)
-            digest.reverse! if digest
-            session_data.reverse! if session_data
+            session_data, _, digest = session_data.rpartition('--')
             session_data = nil unless digest_match?(session_data, digest)
           end
 


### PR DESCRIPTION
This is more obvious to me than the existing reverse implementation and about twice as fast in a small benchmark (see https://gist.github.com/fcheung/1f986be62515ab34965a35f361e5efb5 ),

It allocates one fewer string, & if my reading of the source of rpartition is correct those two strings are CoW views on the original string so the two new strings share the heap storage of the original vavvlue from request.cookies