### PR TITLE
Base 64 encoding should be strict

### DIFF
--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -51,11 +51,11 @@ module Rack
       # Encode session cookies as Base64
       class Base64
         def encode(str)
-          [str].pack('m')
+          [str].pack('m0')
         end
 
         def decode(str)
-          str.unpack('m').first
+          str.unpack('m0').first
         end
 
         # Encode session cookies as Marshaled Base64 data

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -64,7 +64,7 @@ module Rack
 
         def _decode( str, meth = :strict_decode64 )
           ::Marshal.load( Base64.send meth, str )
-        rescue ArgumentError
+        rescue ArgumentError => e
           # Try non-strict Base64 before failing gracefully
           if meth == :strict_decode64
             meth = :decode64

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -76,26 +76,26 @@ describe Rack::Session::Cookie do
     it 'uses base64 to encode' do
       coder = Rack::Session::Cookie::Base64.new
       str   = 'fuuuuu'
-      coder.encode(str).must_equal [str].pack('m')
+      coder.encode(str).must_equal [str].pack('m0')
     end
 
     it 'uses base64 to decode' do
       coder = Rack::Session::Cookie::Base64.new
-      str   = ['fuuuuu'].pack('m')
-      coder.decode(str).must_equal str.unpack('m').first
+      str   = ['fuuuuu'].pack('m0')
+      coder.decode(str).must_equal str.unpack('m0').first
     end
 
     describe 'Marshal' do
       it 'marshals and base64 encodes' do
         coder = Rack::Session::Cookie::Base64::Marshal.new
         str   = 'fuuuuu'
-        coder.encode(str).must_equal [::Marshal.dump(str)].pack('m')
+        coder.encode(str).must_equal [::Marshal.dump(str)].pack('m0')
       end
 
       it 'marshals and base64 decodes' do
         coder = Rack::Session::Cookie::Base64::Marshal.new
-        str   = [::Marshal.dump('fuuuuu')].pack('m')
-        coder.decode(str).must_equal ::Marshal.load(str.unpack('m').first)
+        str   = [::Marshal.dump('fuuuuu')].pack('m0')
+        coder.decode(str).must_equal ::Marshal.load(str.unpack('m0').first)
       end
 
       it 'rescues failures on decode' do
@@ -108,13 +108,13 @@ describe Rack::Session::Cookie do
       it 'JSON and base64 encodes' do
         coder = Rack::Session::Cookie::Base64::JSON.new
         obj   = %w[fuuuuu]
-        coder.encode(obj).must_equal [::JSON.dump(obj)].pack('m')
+        coder.encode(obj).must_equal [::JSON.dump(obj)].pack('m0')
       end
 
       it 'JSON and base64 decodes' do
         coder = Rack::Session::Cookie::Base64::JSON.new
-        str   = [::JSON.dump(%w[fuuuuu])].pack('m')
-        coder.decode(str).must_equal ::JSON.parse(str.unpack('m').first)
+        str   = [::JSON.dump(%w[fuuuuu])].pack('m0')
+        coder.decode(str).must_equal ::JSON.parse(str.unpack('m0').first)
       end
 
       it 'rescues failures on decode' do
@@ -128,14 +128,14 @@ describe Rack::Session::Cookie do
         coder = Rack::Session::Cookie::Base64::ZipJSON.new
         obj   = %w[fuuuuu]
         json = JSON.dump(obj)
-        coder.encode(obj).must_equal [Zlib::Deflate.deflate(json)].pack('m')
+        coder.encode(obj).must_equal [Zlib::Deflate.deflate(json)].pack('m0')
       end
 
       it 'base64 decodes, inflates, and decodes json' do
         coder = Rack::Session::Cookie::Base64::ZipJSON.new
         obj   = %w[fuuuuu]
         json  = JSON.dump(obj)
-        b64   = [Zlib::Deflate.deflate(json)].pack('m')
+        b64   = [Zlib::Deflate.deflate(json)].pack('m0')
         coder.decode(b64).must_equal obj
       end
 


### PR DESCRIPTION
Hi there,

According to RFC 6265 [1]:

> To maximize compatibility with user agents, servers that wish to
store arbitrary data in a cookie-value SHOULD encode that data, for
example, using Base64 [RFC4648]

RFC 4648 uses m0 for the encoding (according to String#unpack in the
Ruby docs [2]). It's a SHOULD not a MUST but I don't see anything in
the logs to indicate why the advice isn't followed.

The encoding was introduced in 417ac6a and refactored in e6b6529.

[1] https://tools.ietf.org/html/rfc6265#section-4.1.1
[2] https://ruby-doc.org/core-2.6.3/String.html#method-i-unpack

Regards,
iain