### PR TITLE
Use `const_get` to get klass without `inject`

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -19,7 +19,7 @@ module Rack
       end
 
       if klass = @handlers[server]
-        klass.split("::").inject(Object) { |o, x| o.const_get(x) }
+        const_get(klass)
       else
         const_get(server, false)
       end


### PR DESCRIPTION
`Enumerable#inject` was used to get constant in `Rack::Handler.get`.
But `Object#const_get` is available to get nested constant from Ruby version 2.0.0.
And the required minimum ruby version of Rack is 2.2.2.
It seems that `const_get` doesn't need `inject` anymore,
and this change is for replacing it without `inject`.