### PR TITLE
Remove redundant freeze method

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -447,7 +447,7 @@ module Rack
       end
 
       def []=(k, v)
-        canonical = k.downcase.freeze
+        canonical = k.downcase
         delete k if @names[canonical] && @names[canonical] != k # .delete is expensive, don't invoke it unless necessary
         @names[canonical] = k
         super k, v

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -447,7 +447,7 @@ module Rack
       end
 
       def []=(k, v)
-        canonical = k.downcase
+        canonical = k.downcase.freeze
         delete k if @names[canonical] && @names[canonical] != k # .delete is expensive, don't invoke it unless necessary
         @names[canonical] = k
         super k, v

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -388,7 +388,7 @@ describe Rack::Deflater do
     app_body = Object.new
     class << app_body
       def each
-        (0..20).each { |i| yield "hello\n".freeze }
+        (0..20).each { |i| yield "hello\n" }
       end
     end
 


### PR DESCRIPTION
Frozen string literal pragma has been introduced to all of Rack. cf. https://github.com/rack/rack/issues/1243
Therefore, string literals do not need to be frozen with `Object#freeze` method anymore.
This PR tends to remove redundant `"str".freeze`.
Thanks.

lib/rack/utils.rb:
https://github.com/rack/rack/blob/29e9aeb63cdebe49682ea0cf9ef423007ac1d738/lib/rack/utils.rb#L2
test/spec_deflater.rb:
https://github.com/rack/rack/blob/29e9aeb63cdebe49682ea0cf9ef423007ac1d738/test/spec_deflater.rb#L1