### PR TITLE
Fix deflater zlib buffer errors on empty body part

### DIFF
--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -88,8 +88,9 @@ module Rack
         gzip = ::Zlib::GzipWriter.new(self)
         gzip.mtime = @mtime if @mtime
         @body.each { |part|
-          gzip.write(part)
-          gzip.flush if @sync
+          len = gzip.write(part)
+          # Flushing empty parts would raise Zlib::BufError.
+          gzip.flush if @sync && len > 0
         }
       ensure
         gzip.close

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -114,6 +114,19 @@ describe Rack::Deflater do
     end
   end
 
+  it 'be able to deflate bodies that respond to each and contain empty chunks' do
+    app_body = Object.new
+    class << app_body; def each; yield('foo'); yield(''); yield('bar'); end; end
+
+    verify(200, 'foobar', deflate_or_gzip, { 'app_body' => app_body }) do |status, headers, body|
+      headers.must_equal({
+        'Content-Encoding' => 'gzip',
+        'Vary' => 'Accept-Encoding',
+        'Content-Type' => 'text/plain'
+      })
+    end
+  end
+
   it 'flush deflated chunks to the client as they become ready' do
     app_body = Object.new
     class << app_body; def each; yield('foo'); yield('bar'); end; end


### PR DESCRIPTION
This fixes a `Zlib::BufError` exception in `Rack::Deflater` that happens with enumerable response bodies if a body part is an empty string and sync mode is enabled (default).

Fixes #959