### PR TITLE
Skip failing server spec that can't work in Docker

### DIFF
--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -161,6 +161,8 @@ describe Rack::Server do
   end
 
   it "check pid file presence and not owned process" do
+    owns_pid_1 = (Process.kill(0, 1) rescue nil) == 1
+    skip "cannot test if pid 1 owner matches current process (eg. docker/lxc)" if owns_pid_1
     pidfile = Tempfile.open('pidfile') { |f| f.write(1); break f }.path
     server = Rack::Server.new(pid: pidfile)
     server.send(:pidfile_process_status).must_equal :not_owned


### PR DESCRIPTION
This skips the server spec for the :not_owned pid file status, if PID 1 is owned by the same user as the current process, which is usually true if the specs are run as root or in a Docker / LXC container.

This should fix the failing specs on Circle CI.