### PR TITLE
Allow global expectation explicitly for minitest.

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -28,7 +28,7 @@ EOF
   s.email           = 'leah@vuxu.org'
   s.homepage        = 'https://rack.github.io/'
   s.required_ruby_version = '>= 2.2.2'
-  s.metadata    = {
+  s.metadata = {
     "bug_tracker_uri"   => "https://github.com/rack/rack/issues",
     "changelog_uri"     => "https://github.com/rack/rack/blob/master/CHANGELOG.md",
     "documentation_uri" => "https://rubydoc.info/github/rack/rack",
@@ -39,5 +39,6 @@ EOF
 
   s.add_development_dependency 'minitest', "~> 5.0"
   s.add_development_dependency 'minitest-sprint'
+  s.add_development_dependency 'minitest-global_expectations'
   s.add_development_dependency 'rake'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 
 module Rack
   class TestCase < Minitest::Test

--- a/test/spec_auth_basic.rb
+++ b/test/spec_auth_basic.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/auth/basic'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_auth_digest.rb
+++ b/test/spec_auth_digest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/auth/digest/md5'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/body_proxy'
 require 'stringio'
 

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/builder'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_cascade.rb
+++ b/test/spec_cascade.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack'
 require 'rack/cascade'
 require 'rack/file'

--- a/test/spec_chunked.rb
+++ b/test/spec_chunked.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/chunked'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_common_logger.rb
+++ b/test/spec_common_logger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/common_logger'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_conditional_get.rb
+++ b/test/spec_conditional_get.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'time'
 require 'rack/conditional_get'
 require 'rack/mock'

--- a/test/spec_config.rb
+++ b/test/spec_config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/builder'
 require 'rack/config'
 require 'rack/content_length'

--- a/test/spec_content_length.rb
+++ b/test/spec_content_length.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/content_length'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_content_type.rb
+++ b/test/spec_content_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/content_type'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'stringio'
 require 'time'  # for Time#httpdate
 require 'rack/deflater'

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/directory'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/etag'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_file.rb
+++ b/test/spec_file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/file'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_handler.rb
+++ b/test/spec_handler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/handler'
 
 class Rack::Handler::Lobster; end

--- a/test/spec_head.rb
+++ b/test/spec_head.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/head'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'stringio'
 require 'tempfile'
 require 'rack/lint'

--- a/test/spec_lobster.rb
+++ b/test/spec_lobster.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/lobster'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/lint'
 require 'rack/lock'
 require 'rack/mock'

--- a/test/spec_logger.rb
+++ b/test/spec_logger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'stringio'
 require 'rack/lint'
 require 'rack/logger'

--- a/test/spec_media_type.rb
+++ b/test/spec_media_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/media_type'
 
 describe Rack::MediaType do

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'stringio'
 require 'rack/method_override'
 require 'rack/mock'

--- a/test/spec_mime.rb
+++ b/test/spec_mime.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/mime'
 
 describe Rack::Mime do

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'yaml'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack'
 require 'rack/multipart'
 require 'rack/multipart/parser'

--- a/test/spec_null_logger.rb
+++ b/test/spec_null_logger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/lint'
 require 'rack/mock'
 require 'rack/null_logger'

--- a/test/spec_recursive.rb
+++ b/test/spec_recursive.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/lint'
 require 'rack/recursive'
 require 'rack/mock'

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'stringio'
 require 'cgi'
 require 'rack/request'

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack'
 require 'rack/response'
 require 'stringio'

--- a/test/spec_rewindable_input.rb
+++ b/test/spec_rewindable_input.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'stringio'
 require 'rack/rewindable_input'
 

--- a/test/spec_runtime.rb
+++ b/test/spec_runtime.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/lint'
 require 'rack/mock'
 require 'rack/runtime'

--- a/test/spec_sendfile.rb
+++ b/test/spec_sendfile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'fileutils'
 require 'rack/lint'
 require 'rack/sendfile'

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack'
 require 'rack/server'
 require 'tempfile'

--- a/test/spec_session_abstract_id.rb
+++ b/test/spec_session_abstract_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 ### WARNING: there be hax in this file.
 
 require 'rack/session/abstract/id'

--- a/test/spec_session_abstract_session_hash.rb
+++ b/test/spec_session_abstract_session_hash.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/session/abstract/id'
 
 describe Rack::Session::Abstract::SessionHash do

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/session/cookie'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_session_memcache.rb
+++ b/test/spec_session_memcache.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 begin
   require 'rack/session/memcache'
   require 'rack/lint'

--- a/test/spec_session_pool.rb
+++ b/test/spec_session_pool.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'thread'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_show_exceptions.rb
+++ b/test/spec_show_exceptions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/show_exceptions'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_show_status.rb
+++ b/test/spec_show_status.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/show_status'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/static'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_tempfile_reaper.rb
+++ b/test/spec_tempfile_reaper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/tempfile_reaper'
 require 'rack/lint'
 require 'rack/mock'

--- a/test/spec_thin.rb
+++ b/test/spec_thin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 begin
 require 'rack/handler/thin'
 require File.expand_path('../testrequest', __FILE__)

--- a/test/spec_urlmap.rb
+++ b/test/spec_urlmap.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/urlmap'
 require 'rack/mock'
 

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/utils'
 require 'rack/mock'
 require 'timeout'

--- a/test/spec_version.rb
+++ b/test/spec_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack'
 
 describe Rack do

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require 'minitest/global_expectations/autorun'
 require 'rack/mock'
 require 'thread'
 require File.expand_path('../testrequest', __FILE__)


### PR DESCRIPTION
Global expectations were deprecated in Minitest some time ago: https://github.com/seattlerb/minitest/commit/e6bc4485730403faff6966c1671cf5de72b2d233

Though, they are widely used in the Rack test suit. Currently, the test run output is a mess of warnings:
```
[...]
DEPRECATED: global use of must_equal from /Users/nikolay/development/rack/test/spec_multipart.rb:334. Use _(obj).must_equal instead. This will fail in Minitest 6.
DEPRECATED: global use of must_equal from /Users/nikolay/development/rack/test/spec_multipart.rb:335. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/nikolay/development/rack/test/spec_multipart.rb:241. Use _(obj).must_equal instead. This will fail in Minitest 6.
[...]
```
It's not pretty, and it will start to fail after the upcoming major release of Minitest. 

There are two ways to deal with that:
* Explicitly allow the global expectations again, using an extension recommended by Minitest. This PR does exactly this. It'll allow us to keep things as they always were.
* Edit all asserts in the following way: 
`called.must_equal true` -> `_(called).must_equal true` And then follow this style in all new tests. Please let me know if you prefer this way to fix it.

So far, this is how the tests look with my change:
```
 # Running: .......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................S........................S......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
 Finished in 5.080622s, 202.9279 runs/s, 737.3113 assertions/s.
 1031 runs, 3746 assertions, 0 failures, 0 errors, 2 skips
```
