### PR TITLE
Allow direct access to response body through SimpleBodyProxy.

### DIFF
--- a/lib/rack/simple_body_proxy.rb
+++ b/lib/rack/simple_body_proxy.rb
@@ -2,6 +2,8 @@
 
 module Rack
   class SimpleBodyProxy
+    attr_reader :body
+
     def initialize(body)
       @body = body
     end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -287,6 +287,12 @@ describe Rack::Response do
     r.status.must_equal 200
   end
 
+  it "allows direct access to body" do
+    r = Rack::Response.new(["foo", "bar"])
+    _status, _header, body_proxy = r.finish
+    body_proxy.body.must_equal ["foo", "bar"]
+  end
+
   it "has a constructor that can take a block" do
     r = Rack::Response.new { |res|
       res.status = 404


### PR DESCRIPTION
A faster body proxy was introduced in Rack: https://github.com/rack/rack/pull/1327 in order to achieve performance benefit and get rid of a circular dependency between response and body wrapper.

However, it breaks some clients that rely on the old behavior, because the Response method `#body` (https://github.com/rack/rack/blob/master/lib/rack/response.rb#L25) always has been accessible before through the body wrapper.

I personally have discovered it with the popular API Ruby library: https://github.com/ruby-grape/grape. If uses rack inside https://github.com/ruby-grape/grape/blob/master/lib/grape/middleware/formatter.rb#L47 but expect the `#body` to be accessible https://github.com/ruby-grape/grape/blob/master/spec/grape/middleware/formatter_spec.rb#L197 
As I see, Rack joins the body content through the `each` method(https://github.com/rack/rack/blob/master/test/spec_response.rb#L269) in order to access it, but I believe there are many other cases in the wild besides Grape that would expect the presence of "#body" method.

Thus, I propose to add a getter to the raw body object on `SimpleBodyProxy`. Bringing this method back won't jeopardize any goals why this new wrapper has been introduced.  Namely, the performance and avoiding a circular dependency between response and the wrapper.
