### PR TITLE
Remove unnecessary super on Rack::Session::Abstract::ID.inherited

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -415,7 +415,6 @@ module Rack
             warn "#{klass} is inheriting from #{ID}.  Inheriting from #{ID} is deprecated, please inherit from #{Persisted} instead" if $VERBOSE
             k.instance_variable_set(:"@_rack_warned", true)
           end
-          super
         end
 
         # All thread safety and session retrieval procedures should occur here.


### PR DESCRIPTION
Currently there is no ancestors of Rack::Session::Abstract::ID that implement `.inherited`.
So, I guess this `super` is unnecessary.