### PR TITLE
Split params by string instead of regex

### DIFF
--- a/lib/rack/auth/basic.rb
+++ b/lib/rack/auth/basic.rb
@@ -47,7 +47,7 @@ module Rack
         end
 
         def credentials
-          @credentials ||= params.unpack("m*").first.split(/:/, 2)
+          @credentials ||= params.unpack("m*").first.split(':', 2)
         end
 
         def username


### PR DESCRIPTION
It doesn't need to be a regex. A simple `':'` string is sufficient and faster.
```ruby
a = "user:pass"
Benchmark.ips do |x|
  x.report 'regex' do
    a.split(/:/, 2)
  end

  x.report 'string' do
    a.split(':', 2)
  end
  x.compare!
end
```
```
Warming up --------------------------------------
               regex   177.851k i/100ms
              string   221.746k i/100ms
Calculating -------------------------------------
               regex      2.558M (± 1.3%) i/s -     12.805M in   5.006704s
              string      3.523M (± 1.0%) i/s -     17.740M in   5.036624s

Comparison:
              string:  3522515.2 i/s
               regex:  2558096.5 i/s - 1.38x  slower
```