### PR TITLE
Simplify delete_param

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -407,7 +407,8 @@ module Rack
       #
       # <tt>env['rack.input']</tt> is not touched.
       def delete_param(k)
-        [ self.POST.delete(k), self.GET.delete(k) ].compact.first
+        post_value, get_value = self.POST.delete(k), self.GET.delete(k)
+        post_value || get_value
       end
 
       def base_url


### PR DESCRIPTION
Don't use `compact` to delete POST and GET params.

It seems that memoization and `||` is faster.
```ruby
Benchmark.ips do |x|
  x.report 'compact -> first' do
    a = {a: 2, c: 4, d: 5}
    [a.delete(:a), a.delete(:b)].compact.first
    [a.delete(:b), a.delete(:c)].compact.first
    [a.delete(:c), a.delete(:d)].compact.first
  end

  x.report '||' do
    a = {a: 2, c: 4, d: 5}
    b, c = a.delete(:a), a.delete(:b)
    b || c
    b, c = a.delete(:b), a.delete(:c)
    b || c
    b, c = a.delete(:c), a.delete(:d)
    b || c
  end
  x.compare!
end
```
```
Warming up --------------------------------------
    compact -> first   101.688k i/100ms
                  ||   142.951k i/100ms
Calculating -------------------------------------
    compact -> first      1.285M (± 7.5%) i/s -      6.406M in   5.017583s
                  ||      1.970M (± 5.2%) i/s -      9.864M in   5.023221s

Comparison:
                  ||:  1969780.4 i/s
    compact -> first:  1285326.8 i/s - 1.53x  slower
```