### PR TITLE
Fix stringify_keys error when other is SessionHash

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -29,6 +29,14 @@ module Rack
           end
         } unless {}.respond_to?(:transform_keys)
 
+        def transform_keys(&block)
+          hash = dup
+          each do |key, value|
+            hash[block.call(key)] = value
+          end
+          hash
+        end
+
         include Enumerable
         attr_writer :id
 

--- a/test/spec_session_abstract_session_hash.rb
+++ b/test/spec_session_abstract_session_hash.rb
@@ -44,4 +44,10 @@ describe Rack::Session::Abstract::SessionHash do
       lambda { hash.fetch(:unknown) }.must_raise KeyError
     end
   end
+
+  describe "#stringify_keys" do
+    it "returns hash or session hash with keys stringified" do
+      assert_equal({ "foo" => :bar, "baz" => :qux }, hash.send(:stringify_keys, hash).to_h)
+    end
+  end
 end


### PR DESCRIPTION
Handle case when other is also SessionHash.
Should fix errors in Sinatra as reported in [here](https://github.com/rack/rack/pull/1391#issuecomment-542980651).
I'm not sure if the test I add is the correct way to test `stringify_keys`.