### PR TITLE
use base64

### DIFF
--- a/lib/rack/auth/basic.rb
+++ b/lib/rack/auth/basic.rb
@@ -2,6 +2,7 @@
 
 require 'rack/auth/abstract/handler'
 require 'rack/auth/abstract/request'
+require 'base64'
 
 module Rack
   module Auth
@@ -47,7 +48,7 @@ module Rack
         end
 
         def credentials
-          @credentials ||= params.unpack("m*").first.split(':', 2)
+          @credentials ||= Base64.decode64(params).split(':', 2)
         end
 
         def username

--- a/lib/rack/auth/digest/nonce.rb
+++ b/lib/rack/auth/digest/nonce.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'digest/md5'
+require 'base64'
 
 module Rack
   module Auth
@@ -20,7 +21,7 @@ module Rack
         end
 
         def self.parse(string)
-          new(*string.unpack("m*").first.split(' ', 2))
+          new(*Base64.decode64(string).split(' ', 2))
         end
 
         def initialize(timestamp = Time.now, given_digest = nil)
@@ -28,7 +29,7 @@ module Rack
         end
 
         def to_s
-          ["#{@timestamp} #{digest}"].pack("m*").strip
+          Base64.encode64("#{@timestamp} #{digest}").strip
         end
 
         def digest

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -6,6 +6,7 @@ require 'rack/request'
 require 'rack/response'
 require 'rack/session/abstract/id'
 require 'json'
+require 'base64'
 
 module Rack
 
@@ -51,11 +52,11 @@ module Rack
       # Encode session cookies as Base64
       class Base64
         def encode(str)
-          [str].pack('m')
+          ::Base64.encode64(str)
         end
 
         def decode(str)
-          str.unpack('m').first
+          ::Base64.decode64(str)
         end
 
         # Encode session cookies as Marshaled Base64 data


### PR DESCRIPTION
this PR reverts https://github.com/rack/rack/commit/e6b65296a247e23742d85e47cf31582b5883918a that was introduced for ruby 1.9 compatibility. The current version of rack does support ruby 2.2+

on ruby 2.4+ `unpack` is replaced by `unpack1` that doesn't allocate a temporarly array

       old decode      3.363M (± 4.9%) i/s -     16.775M in   5.005186s
       new decode      5.066M (± 5.8%) i/s -     25.224M in   5.004543s
       old encode      2.197M (± 5.4%) i/s -     10.970M in   5.016768s
       new encode      2.258M (± 4.5%) i/s -     11.277M in   5.007045s

benchmark
```
require 'base64'
require 'benchmark/ips'

str = 'test string'
unp = str.unpack("m*").first

Benchmark.ips do |x|
  x.report('old decode') { str.unpack("m*").first }
  x.report('new decode') { Base64.decode64(str) }
  x.report('old encode') { [unp].pack("m*") }
  x.report('new encode') { Base64.encode64(unp) }
  x.compare!
end
```