### PR TITLE
Simplify joining 2 strings

### DIFF
--- a/lib/rack/auth/digest/nonce.rb
+++ b/lib/rack/auth/digest/nonce.rb
@@ -28,11 +28,11 @@ module Rack
         end
 
         def to_s
-          [([ @timestamp, digest ] * ' ')].pack("m*").strip
+          ["#{@timestamp} #{digest}"].pack("m*").strip
         end
 
         def digest
-          ::Digest::MD5.hexdigest([ @timestamp, self.class.private_key ] * ':')
+          ::Digest::MD5.hexdigest("#{@timestamp}:#{self.class.private_key}")
         end
 
         def valid?


### PR DESCRIPTION
I think it's easier to read string interpolation than `Array#join`/`Array#*` when joining 2 strings.
It also happens to be faster:
```ruby
require 'benchmark/ips'

raise unless ([1,2] * ?:) == "#{1}:#{2}"

puts "RUBY_VERSION = #{RUBY_VERSION}"

Benchmark.ips do |x|
  x.report 'Array#*' do
    [1,2] * ?:
  end

  x.report 'String Interpolation' do
    "#{1}:#{2}"
  end
  x.compare!
end
```
Results:
```
RUBY_VERSION = 2.4.7
Warming up --------------------------------------
             Array#*   110.705k i/100ms
String Interpolation   175.994k i/100ms
Calculating -------------------------------------
             Array#*      1.216M (±18.0%) i/s -      5.867M in   5.028823s
String Interpolation      2.678M (±12.6%) i/s -     13.200M in   5.019289s

Comparison:
String Interpolation:  2678103.5 i/s
             Array#*:  1215670.1 i/s - 2.20x  slower
```
```
RUBY_VERSION = 2.5.6
Warming up --------------------------------------
             Array#*   119.767k i/100ms
String Interpolation   205.382k i/100ms
Calculating -------------------------------------
             Array#*      1.501M (± 1.4%) i/s -      7.545M in   5.028239s
String Interpolation      3.187M (± 1.1%) i/s -     16.020M in   5.027338s

Comparison:
String Interpolation:  3186959.2 i/s
             Array#*:  1500868.7 i/s - 2.12x  slower
```
```
RUBY_VERSION = 2.6.4
Warming up --------------------------------------
             Array#*   115.776k i/100ms
String Interpolation   219.973k i/100ms
Calculating -------------------------------------
             Array#*      1.469M (± 0.9%) i/s -      7.410M in   5.045101s
String Interpolation      3.502M (± 1.1%) i/s -     17.598M in   5.025490s

Comparison:
String Interpolation:  3502126.2 i/s
             Array#*:  1468793.5 i/s - 2.38x  slower
```