### PR TITLE
Remove implicit dependency on RubyGems

### DIFF
--- a/lib/rack/core_ext/regexp.rb
+++ b/lib/rack/core_ext/regexp.rb
@@ -5,12 +5,10 @@
 
 module Rack
   module RegexpExtensions
-    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(2.4)
-      refine Regexp do
-        def match?(string, pos = 0)
-          !!match(string, pos)
-        end unless //.respond_to?(:match?)
+    refine Regexp do
+      def match?(string, pos = 0)
+        !!match(string, pos)
       end
-    end
+    end unless //.respond_to?(:match?)
   end
 end


### PR DESCRIPTION
We should avoid adding new dependencies, including RubyGems.  This
commit just avoids using the `Gem` constant so don't need RubyGems.