### PR TITLE
Generate etag even if Cache-Control: no-cache is set

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -57,8 +57,7 @@ module Rack
       end
 
       def skip_caching?(headers)
-        (headers[CACHE_CONTROL] && headers[CACHE_CONTROL].include?('no-cache')) ||
-          headers.key?(ETAG_STRING) || headers.key?('Last-Modified')
+        headers.key?(ETAG_STRING) || headers.key?('Last-Modified')
       end
 
       def digest_body(body)

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -93,12 +93,6 @@ describe Rack::ETag do
     response[1]['ETag'].must_be_nil
   end
 
-  it "not set ETag if no-cache is given" do
-    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Cache-Control' => 'no-cache, must-revalidate' }, ['Hello, World!']] }
-    response = etag(app).call(request)
-    response[1]['ETag'].must_be_nil
-  end
-
   it "close the original body" do
     body = StringIO.new
     app = lambda { |env| [200, {}, body] }


### PR DESCRIPTION
Currently an etag is not generated if `Cache-Control: no-cache` is set. Imo this is not ideal, as `no-cache` explicitly requires a validation of the content, in which case having an etag is very helpful.

Therefore this PR proposes to generate the etag whether `no-cache` is present or not.

Some background:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Directives
https://tools.ietf.org/html/rfc7234#section-5.2.1.4
https://tools.ietf.org/html/rfc7234#section-4.3

See also https://github.com/rack/rack/issues/1415

Thanks!