### PR TITLE
Rack::Directory : allow directory trasversal inside root directory

### DIFF
--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -96,6 +96,7 @@ table { width:100%%; }
 
     def check_forbidden(path_info)
       return unless path_info.include? ".."
+      return if ::File.expand_path(::File.join(@root, path_info)).start_with?(@root)
 
       body = "Forbidden\n"
       size = body.bytesize

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -72,14 +72,26 @@ describe Rack::Directory do
     res.must_be :bad_request?
   end
 
+  it "allow directory traversal inside root directory" do
+    res = Rack::MockRequest.new(Rack::Lint.new(app)).
+      get("/cgi/../rackup")
+
+    res.must_be :ok?
+
+    res = Rack::MockRequest.new(Rack::Lint.new(app)).
+      get("/cgi/%2E%2E/rackup")
+
+    res.must_be :ok?
+  end
+
   it "not allow directory traversal" do
     res = Rack::MockRequest.new(Rack::Lint.new(app)).
-      get("/cgi/../test")
+      get("/cgi/../../lib")
 
     res.must_be :forbidden?
 
     res = Rack::MockRequest.new(Rack::Lint.new(app)).
-      get("/cgi/%2E%2E/test")
+      get("/cgi/%2E%2E/%2E%2E/lib")
 
     res.must_be :forbidden?
   end


### PR DESCRIPTION
This PR allows use of `..` in HTTP request to retreive files with Rack::Directory middleware. This is allowed only if the file is accessible with a direct path.

For instance with this directory structure :

    /root/a/a.txt
    /root/b/b.txt
    /c/c.txt

And the following Rack application

    Rack::Directory.new("/root")

Responses to the following requests are:

    GET a/a.txt
    Before PR : 200, After PR : 200
    
    GET a/../b/b.txt
    Before PR : 403, After PR : 200
    
    GET a/../../c/c.txt
    Before PR : 403, After PR : 403

