### PR TITLE
Remove mentions of outdated and unmaintained projects

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,14 +29,9 @@ The included *handlers* connect all kinds of web servers to \Rack:
 These web servers include \Rack handlers in their distributions:
 
 * Agoo[https://github.com/ohler55/agoo]
-* Ebb[https://github.com/gnosek/ebb]
-* Fuzed[https://github.com/KirinDave/fuzed]
-* {Glassfish v3}[https://rubygems.org/gems/glassfish]
 * {NGINX Unit}[https://unit.nginx.org/]
 * {Phusion Passenger}[https://www.phusionpassenger.com/] (which is mod_rack for Apache and for nginx)
 * Puma[https://puma.io/]
-* Reel[https://github.com/celluloid/reel]
-* unixrack[https://rubygems.org/gems/unixrack]
 * uWSGI[https://uwsgi-docs.readthedocs.io/en/latest/]
 
 Any valid \Rack app will run the same on all these handlers, without
@@ -48,23 +43,14 @@ These frameworks include \Rack adapters in their distributions:
 
 * Camping[http://www.ruby-camping.com/]
 * Coset[http://leahneukirchen.org/repos/coset/]
-* Espresso[https://rubygems.org/gems/espresso-framework]
-* Halcyon[https://rubygems.org/gems/espresso-framework]
-* Hanami[https://rubygems.org/gems/halcyon]
-* Mack[https://github.com/markbates/mack]
-* Maveric[https://rubygems.org/gems/maveric]
-* Merb[https://rubygems.org/gems/merb]
+* Hanami[https://hanamirb.org/]
 * Padrino[http://padrinorb.com/]
 * Racktools::SimpleApplication
 * Ramaze[http://ramaze.net/]
 * {Ruby on Rails}[https://rubyonrails.org/]
 * Rum[https://github.com/leahneukirchen/rum]
 * Sinatra[http://sinatrarb.com/]
-* Sin[https://github.com/raggi/sin]
-* Vintage[https://rubygems.org/gems/vintage]
 * WABuR[https://github.com/ohler55/wabur]
-* Waves[https://github.com/dyoder/waves]
-* Wee[https://github.com/mneumann/wee]
 * ... and many others.
 
 == Available middleware


### PR DESCRIPTION
Projects removed:
1. Ebb - last commit 12 years ago, 1 contributor, homepage is down.
2. Fuzed -  last commit 10 years ago, homepage is down
3. Glassfish v3 - last commit 9 years ago, homepage is down
4. Reel - repository is archived, author is looking for volunteer maintainers since August 2018 without any success
5. unixrack - last commit 6 years ago, 3 contributors
6. Espresso - repository is deleted, last release 6 years ago
7. Halcyon - last commit 11 years ago, homepage is down
8. Mack - last commit 11 years ago, 2 contributors, homepage is down
9. Maveric - repository is deleted, last release 10 years ago
10. Merb - last commit 7 years ago, homepage is down
11. Rum - last commit 11 years ago, 1 contributor
12. Sin - last commit 11 years ago, 2 contributors
13. Vintage - last release 10 years ago, homepage is down
14. Waves - last commit 10 years ago, 2 contributors, homepage is down
15. Wee - last two commits 4 and 9 years ago, 1 contributor