### PR TITLE
Eliminate warnings for Ruby2.7.0-preview3

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -225,9 +225,9 @@ This is an HTTP status. When parsed as integer (+to_i+), it must be
 greater than or equal to 100.
 === The Headers
 The header must respond to +each+, and yield values of key and value.
+The header keys must be Strings.
 Special headers starting "rack." are for communicating with the
 server, and must not be sent back to the client.
-The header keys must be Strings.
 The header must not contain a +Status+ key.
 The header must conform to RFC7230 token specification, i.e. cannot
 contain non-printable ASCII, DQUOTE or "(),/:;<=>?@[\]{}".

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -627,15 +627,17 @@ module Rack
       assert("headers object should respond to #each, but doesn't (got #{header.class} as headers)") {
          header.respond_to? :each
       }
-      header.each { |key, value|
-        ## Special headers starting "rack." are for communicating with the
-        ## server, and must not be sent back to the client.
-        next if key =~ /^rack\..+$/
 
+      header.each { |key, value|
         ## The header keys must be Strings.
         assert("header key must be a string, was #{key.class}") {
           key.kind_of? String
         }
+
+        ## Special headers starting "rack." are for communicating with the
+        ## server, and must not be sent back to the client.
+        next if key =~ /^rack\..+$/
+
         ## The header must not contain a +Status+ key.
         assert("header must not contain Status") { key.downcase != "status" }
         ## The header must conform to RFC7230 token specification, i.e. cannot

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -132,7 +132,11 @@ describe Rack::Server do
     )
     t = Thread.new { server.start { |s| Thread.current[:server] = s } }
     t.join(0.01) until t[:server] && t[:server].status != :Stop
-    body = URI.open("http://127.0.0.1:#{server.options[:Port]}/") { |f| f.read }
+    body = if URI.respond_to?(:open)
+             URI.open("http://127.0.0.1:#{server.options[:Port]}/") { |f| f.read }
+           else
+             open("http://127.0.0.1:#{server.options[:Port]}/") { |f| f.read }
+           end
     body.must_equal 'success'
 
     Process.kill(:INT, $$)

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -132,7 +132,7 @@ describe Rack::Server do
     )
     t = Thread.new { server.start { |s| Thread.current[:server] = s } }
     t.join(0.01) until t[:server] && t[:server].status != :Stop
-    body = open("http://127.0.0.1:#{server.options[:Port]}/") { |f| f.read }
+    body = URI.open("http://127.0.0.1:#{server.options[:Port]}/") { |f| f.read }
     body.must_equal 'success'
 
     Process.kill(:INT, $$)


### PR DESCRIPTION
## Problem

Some warnings are found when I run `$ rake test` on Ruby2.7.0-preview3.

<details>

```
# Running:

........................................................................~/github/rack/rack/test/spec_server.rb:135: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly
...............................................................................................................................................................................................................................................................~github/rack/rack/lib/rack/lint.rb:633: warning: deprecated Object#=~ is called on TrueClass; it always returns nil
.....................................................................................................................................................................................................................................................................................................................S........................................S................................................................................................................................................................................................................................................................................................................................................................

Finished in 5.389522s, 191.2971 runs/s, 694.8668 assertions/s.

1031 runs, 3745 assertions, 0 failures, 0 errors, 2 skips

You have skipped tests. Run with --verbose for details.
```

</details>

### Warning 1

>test/spec_server.rb:135: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly
https://github.com/rack/rack/blob/d6668ee1f6f8d91c1ee2aac09ccfcd5e117216bd/test/spec_server.rb#L135

Using `Kernel#open` will be deprecated on Ruby 2.7.0.
https://github.com/ruby/ruby/blob/54072e329cab7207fba133caba4fc12b45add8f9/NEWS

You can find the background at the following issue of Ruby-lang.
https://bugs.ruby-lang.org/issues/15893


### Warning 2

>lib/rack/lint.rb:633: warning: deprecated Object#=~ is called on TrueClass; it always returns nil
https://github.com/rack/rack/blob/d6668ee1f6f8d91c1ee2aac09ccfcd5e117216bd/lib/rack/lint.rb#L630-L638

In Ruby2.6.0, this warning occurs only when '-W' option is added.
https://github.com/ruby/ruby/blob/c5eb24349a4535948514fe765c3ddb0628d81004/doc/NEWS-2.6.0#compatibility-issues-excluding-feature-bug-fixes

In 2.7.0, this warning always occurs whether '-W' is added or not.
https://bugs.ruby-lang.org/issues/15231

## Solution

### Warning 1

To use `URI.open` instead.

### Warning 2

To move class assertion for `key` above of the source location of the warning.

## Environment

Edge Version: Ruby2.7.0-preview3
Stable Version: Ruby2.6.5