### PR TITLE
Fix: Add `to_hash` to wrap Hash and Session classes on `stringify_keys`

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -182,7 +182,7 @@ module Rack
         end
 
         def stringify_keys(other)
-          other.transform_keys(&:to_s)
+          other.to_hash.transform_keys(&:to_s)
         end
       end
 


### PR DESCRIPTION
When using Rails application and go to Sidekiq Web management page I've got the following error:
```
undefined method 'transform_keys' for #<ActionDispatch::Request::Session:0x00007f8fa6d3bcc8>
```
With code :
```
        def stringify_keys(other)
          other.transform_keys(&:to_s) # <-- Error happened here
        end
      end
```
Application Trace:
```
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/session/abstract/id.rb:185:in `stringify_keys'
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/session/abstract/id.rb:121:in `update'
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/session/abstract/id.rb:290:in `prepare_session'
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/session/abstract/id.rb:249:in `context'
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/session/abstract/id.rb:244:in `call'
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/urlmap.rb:77:in `block in call'
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/urlmap.rb:61:in `each'
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/urlmap.rb:61:in `call'
/Users/olehd/.rvm/gems/ruby-2.3.7/bundler/gems/rack-e82f06b354fa/lib/rack/builder.rb:176:in `call'
sidekiq (5.2.7) lib/sidekiq/web.rb:103:in `call'
sidekiq (5.2.7) lib/sidekiq/web.rb:108:in `call'
actionpack (5.0.7.2) lib/action_dispatch/routing/mapper.rb:17:in `block in <class:Constraints>'
actionpack (5.0.7.2) lib/action_dispatch/routing/mapper.rb:46:in `serve'
actionpack (5.0.7.2) lib/action_dispatch/journey/router.rb:39:in `block in serve'
actionpack (5.0.7.2) lib/action_dispatch/journey/router.rb:26:in `each'
actionpack (5.0.7.2) lib/action_dispatch/journey/router.rb:26:in `serve'
actionpack (5.0.7.2) lib/action_dispatch/routing/route_set.rb:727:in `call'
```

Gems Versions:
ruby - `2.3.7`
rails - `5.0.7.2`
sidekiq - `5.2.7`
rack - `master` branch

This PR solved issue.