### PR TITLE
Remove `to_ary` from Response

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -9,10 +9,6 @@ module Rack
     end
 
     def respond_to?(method_name, include_all = false)
-      case method_name
-      when :to_ary, 'to_ary'
-        return false
-      end
       super or @body.respond_to?(method_name, include_all)
     end
 
@@ -39,7 +35,6 @@ module Rack
     end
 
     def method_missing(method_name, *args, &block)
-      super if :to_ary == method_name
       @body.__send__(method_name, *args, &block)
     end
   end

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -72,11 +72,10 @@ module Rack
         close
         [status.to_i, header, []]
       else
-        [status.to_i, header, BodyProxy.new(self){}]
+        [status.to_i, header, self]
       end
     end
     alias to_a finish           # For *response
-    alias to_ary finish         # For implicit-splat on Ruby 1.9.2
 
     def each(&callback)
       @body.each(&callback)

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -63,8 +63,8 @@ describe Rack::BodyProxy do
     body.respond_to?(:to_ary).must_equal true
 
     proxy = Rack::BodyProxy.new(body) { }
-    proxy.respond_to?(:to_ary).must_equal false
-    proxy.respond_to?("to_ary").must_equal false
+    x = [proxy]
+    assert_equal x, x.flatten
   end
 
   it 'not close more than one time' do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -466,8 +466,8 @@ describe Rack::Response do
 
   it "wraps the body from #to_ary to prevent infinite loops" do
     res = Rack::Response.new
-    res.finish.last.wont_respond_to(:to_ary)
-    lambda { res.finish.last.to_ary }.must_raise NoMethodError
+    x = res.finish
+    assert_equal x, x.flatten
   end
 end
 


### PR DESCRIPTION
Responses are not arrays, so we should not allow them to be implicitly
coerced to an array.  If you would like you response to be converted to
an array, you must explicitly do it with the `to_a` method.

This also prevents creation of unnecessary body proxies

refs #419 