### PR TITLE
Backport support for SameSite=None cookie flag to 2-0-stable branch

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -252,6 +252,8 @@ module Rack
           case value[:same_site]
           when false, nil
             nil
+          when :none, 'None', :None
+            '; SameSite=None'.freeze
           when :lax, 'Lax', :Lax
             '; SameSite=Lax'.freeze
           when true, :strict, 'Strict', :Strict

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -115,6 +115,24 @@ describe Rack::Response do
     response["Set-Cookie"].must_equal "foo=bar"
   end
 
+  it "can set SameSite cookies with symbol value :none" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: :none }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with symbol value :None" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: :None }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with string value 'None'" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: "None" }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
   it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :lax}


### PR DESCRIPTION
Backport https://github.com/rack/rack/pull/1358 to 2-0-stable branch

Chrome is planning to block cookies with SameSite=None not set as early as in February 2020:
https://www.chromium.org/updates/same-site

Current master and potentially 2.1 release are not yet compatible with too many things:
- sidekiq web interface is broken when loaded as sub-route
- grape gem is broken
