### PR TITLE
Make SessionId#to_s be an alias of #public_id

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -28,9 +28,9 @@ module Rack
       end
 
       alias :cookie_value :public_id
+      alias :to_s :public_id
 
       def empty?; false; end
-      def to_s; raise; end
       def inspect; public_id.inspect; end
 
       private


### PR DESCRIPTION
This restores backwards compatibility with code that uses the
session id.

No justification was given for making to_s raise in the commit
that changed the behavior (cc1d162d28396b6a71f266e6a40ffc19a258792b).

If there is a reason to keep raising an exception, a specific
exception class and explicit error message should be used.