### PR TITLE
fix sendfile

### DIFF
--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -20,7 +20,8 @@ module Rack
       if !STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) &&
          !headers[CONTENT_LENGTH] &&
          !headers[TRANSFER_ENCODING] &&
-         body.respond_to?(:to_ary)
+         body.respond_to?(:to_ary) &&
+         !body.respond_to?(:to_path)
 
         obody = body
         body, length = [], 0


### PR DESCRIPTION
body.respond_to?(:to_ary) was returning false, but after this change, it returns true https://github.com/rack/rack/commit/72959ebc2f300f3b2ccb7ae2aae9f199e611dfb6

now the body is wrapped to a proxy here
https://github.com/rack/rack/blob/master/lib/rack/content_length.rb#L23

the wrapped body doesn't respond_to :to_path anymore
https://github.com/rack/rack/blob/master/lib/rack/sendfile.rb#L114

and the final response doesn't contain 'X-Sendfile' header as before
https://github.com/rack/rack/blob/master/lib/rack/sendfile.rb#L129

this change fixes the problem, but I've absolutely no idea if it's correct or not :)
I have to investigate more what's happening, is it a regression or is it intentional?