### PR TITLE
Remove chunked middleware from default server stack.

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -262,13 +262,11 @@ module Rack
         m = Hash.new {|h, k| h[k] = []}
         m["deployment"] = [
           [Rack::ContentLength],
-          [Rack::Chunked],
           logging_middleware,
           [Rack::TempfileReaper]
         ]
         m["development"] = [
           [Rack::ContentLength],
-          [Rack::Chunked],
           logging_middleware,
           [Rack::ShowExceptions],
           [Rack::Lint],


### PR DESCRIPTION
The chunked middleware assumes details about the protocol level
implementation. Due to recent changes from HTTP_VERSION to SERVER_PROTOCOL,
this dormant middleware now appears to be breaking a lot of assumptions.

https://github.com/rack/rack/issues/1472
https://github.com/rack/rack/issues/1266