### PR TITLE
Ensure `Rack::Lint` to work with `Rack::Response` on 2.1

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -48,7 +48,7 @@ module Rack
       env[RACK_ERRORS] = ErrorWrapper.new(env[RACK_ERRORS])
 
       ## and returns an Array of exactly three values:
-      status, headers, @body = @app.call(env)
+      status, headers, @body = @app.call(env).to_a
       ## The *status*,
       check_status status
       ## the *headers*,

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -17,6 +17,12 @@ describe Rack::Lint do
                    }).call(env({})).first.must_equal 200
   end
 
+  it "works with Rack::Response" do
+    Rack::Lint.new(lambda { |env|
+                     Rack::Response.new(["foo"], 200, { "Content-type" => "test/plain", "Content-length" => "3" })
+                   }).call(env({})).first.must_equal 200
+  end
+
   it "notice fatal errors" do
     lambda { Rack::Lint.new(nil).call }.must_raise(Rack::Lint::LintError).
       message.must_match(/No env given/)


### PR DESCRIPTION
When you use `Rack::MockRequest#request` the returning value is a `Rack::MockResponse`, which is a subclass of `Rack::Response`.

Given Rack 2.1 [removed](https://github.com/rack/rack/commit/72959ebc2f300f3b2ccb7ae2aae9f199e611dfb6) `Rack::Response#to_ary`, `Rack::Lint` should explicitly invoke `#to_a` to extract status, headers, and body from current response.

Without this patch, you'll get errors like the following:

```shell
Failures:

  1) Hanami::Router#root path recognition block recognizes
     Failure/Error: actual = app.request("GET", "/", lint: true)

     NoMethodError:
       undefined method `to_i' for #<Rack::MockResponse:0x00007f9212d970c8>
       Did you mean?  to_s
                      to_a
     # /Users/luca/.gem/ruby/2.7.0/gems/rack-2.1.1/lib/rack/lint.rb:621:in `block in check_status'
     # /Users/luca/.gem/ruby/2.7.0/gems/rack-2.1.1/lib/rack/lint.rb:21:in `assert'
     # /Users/luca/.gem/ruby/2.7.0/gems/rack-2.1.1/lib/rack/lint.rb:621:in `check_status'
     # /Users/luca/.gem/ruby/2.7.0/gems/rack-2.1.1/lib/rack/lint.rb:53:in `_call'
     # /Users/luca/.gem/ruby/2.7.0/gems/rack-2.1.1/lib/rack/lint.rb:39:in `call'
     # /Users/luca/.gem/ruby/2.7.0/gems/rack-2.1.1/lib/rack/mock.rb:77:in `request'
     # ./spec/integration/hanami/router/routing_spec.rb:204:in `block (5 levels) in <top (required)>'
```