### PR TITLE
Respect preexisting `:BindAddress` options passed to `Rack::Handler::WEBrick.run`

### DIFF
--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -28,7 +28,7 @@ module Rack
         environment  = ENV['RACK_ENV'] || 'development'
         default_host = environment == 'development' ? 'localhost' : nil
 
-        options[:BindAddress] = options.delete(:Host) || default_host
+        options[:BindAddress] ||= options.delete(:Host) || default_host
         options[:Port] ||= 8080
         if options[:SSLEnable]
           require 'webrick/https'


### PR DESCRIPTION
I have noticed that other projects which use `Rack::Handler::WEBrick` directly will pass in WEBrick options (ex: `:BindAddress`) as opposed to the standard Rack options (ex: `:Host`). This change prevents overriding any `:BindAddress` options that were explicitly passed in.