### PR TITLE
Make body not respond to to_path to Rack::Files range requests

### DIFF
--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -165,6 +165,15 @@ describe Rack::Files do
     body.to_path.must_equal path
   end
 
+  it "return bodies that do not respond to #to_path if a byte range is requested" do
+    env = Rack::MockRequest.env_for("/cgi/test")
+    env["HTTP_RANGE"] = "bytes=22-33"
+    status, _, body = Rack::Files.new(DOCROOT).call(env)
+
+    status.must_equal 206
+    body.wont_respond_to :to_path
+  end
+
   it "return correct byte range in body" do
     env = Rack::MockRequest.env_for("/cgi/test")
     env["HTTP_RANGE"] = "bytes=22-33"


### PR DESCRIPTION
If the body responds to to_path, the server is allowed to serve
the file at that path and ignore the body.  That works well for
most requests, but not for range requests, since the correct
byte range won't be served.

Work around this issue by using a separate body class for the
partial content responses that does not respond to to_path, and
the current body class for non-partial content responses.

Fixes #1235