### PR TITLE
Require the response headers be a hash in SPEC

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -224,8 +224,8 @@ if the request env has <tt>rack.hijack?</tt> <tt>true</tt>.
 This is an HTTP status. When parsed as integer (+to_i+), it must be
 greater than or equal to 100.
 === The Headers
-The header must respond to +each+, and yield values of key and value.
-The header keys must be Strings.
+The header must be a unfrozen Hash.
+The keys of the header must be Strings.
 Special headers starting "rack." are for communicating with the
 server, and must not be sent back to the client.
 The header must not contain a +Status+ key.

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -631,13 +631,16 @@ module Rack
 
     ## === The Headers
     def check_headers(header)
-      ## The header must respond to +each+, and yield values of key and value.
-      assert("headers object should respond to #each, but doesn't (got #{header.class} as headers)") {
-         header.respond_to? :each
+      ## The header must be a unfrozen Hash.
+      assert("headers object should be a hash, but isn't (got #{header.class} as headers)") {
+         header.kind_of?(Hash)
+      }
+      assert("headers object should not be frozen, but is") {
+         !header.frozen?
       }
 
       header.each { |key, value|
-        ## The header keys must be Strings.
+        ## The keys of the header must be Strings.
         assert("header key must be a string, was #{key.class}") {
           key.kind_of? String
         }

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -196,12 +196,21 @@ describe Rack::Lint do
   end
 
   it "notice header errors" do
+    obj = Object.new
+    def obj.each; end
     lambda {
       Rack::Lint.new(lambda { |env|
-                       [200, Object.new, []]
+                       [200, obj, []]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
-      message.must_equal "headers object should respond to #each, but doesn't (got Object as headers)"
+      message.must_equal "headers object should be a hash, but isn't (got Object as headers)"
+    lambda {
+      Rack::Lint.new(lambda { |env|
+                       [200, {}.freeze, []]
+                     }).call(env({}))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "headers object should not be frozen, but is"
+
 
     lambda {
       Rack::Lint.new(lambda { |env|
@@ -273,10 +282,13 @@ describe Rack::Lint do
                      [200, { "Foo-Bar" => "one\ntwo\nthree", "Content-Length" => "0", "Content-Type" => "text/plain" }, []]
                    }).call(env({})).first.must_equal 200
 
-    # non-Hash header responses.must_be :allowed?
-    Rack::Lint.new(lambda { |env|
+    lambda {
+      Rack::Lint.new(lambda { |env|
                      [200, [%w(Content-Type text/plain), %w(Content-Length 0)], []]
-                   }).call(env({})).first.must_equal 200
+                     }).call(env({}))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "headers object should be a hash, but isn't (got Array as headers)"
+
   end
 
   it "notice content-type errors" do

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -181,7 +181,7 @@ describe Rack::Handler::WEBrick do
     Rack::Lint.new(lambda{ |req|
       [
         200,
-        [ [ "rack.hijack", io_lambda ] ],
+        { "rack.hijack" => io_lambda },
         [""]
       ]
     })


### PR DESCRIPTION
This is stricter than what was previously required.  However,
non-hash response headers would break most of the middleware
that accesses response headers.

Fixes #1222