### PR TITLE
Fix incorrect MockResponse#body String encoding

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -196,9 +196,13 @@ module Rack
       #     ...
       #     res.body.should == "foo!"
       #   end
-      buffer = String.new
+      buffer = String.new(encoding: Encoding::UTF_8)
 
       super.each do |chunk|
+        if chunk.encoding == Encoding::ASCII_8BIT
+          buffer.encode!(Encoding::ASCII_8BIT)
+        end
+
         buffer << chunk
       end
 

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -348,6 +348,19 @@ describe Rack::MockResponse do
     res.body.must_equal 'hi'
   end
 
+  it "return non-binary response body as UTF-8 string" do
+    body = ["utf8 body", "iso-8859-1 body".encode(Encoding::ISO_8859_1)]
+    res = Rack::MockResponse.new(200, {}, body)
+    res.body.encoding.must_equal Encoding::UTF_8
+  end
+
+  it "return binary response body as binary string" do
+    fixture = File.join(File.dirname(__FILE__), "multipart", "rack-logo.png")
+    body = [File.binread(fixture)]
+    res = Rack::MockResponse.new(200, {}, body)
+    res.body.encoding.must_equal Encoding::ASCII_8BIT
+  end
+
   it "optionally make Rack errors fatal" do
     lambda {
       Rack::MockRequest.new(app).get("/?error=foo", fatal: true)


### PR DESCRIPTION
This is a regression introduced in Rack 2.1.0, possibly after 8c62821f4a464858a6b6ca3c3966ec308d2bb53e was introduced.

Before the aforementioned commit, `MockResponse#body` would return a UTF-8 string as it joins all the response parts together. However, because the aforementioned commit uses `String.new` without specifying an encoding, Ruby would [create a new String with `ASCII-8BIT` encoding
by default](https://ruby-doc.org/core-2.7.0/String.html#method-c-new).

This commit adds failing test cases to prevent future regression to ensure that we return UTF-8 String for all string body, and also making sure that we return binary string if any of the response part is a binary string (with `ASCII-8BIT` encoding).

---

As a side note, I found out about this regression after upgrading to Rack 2.1.1 and found out that API documentation, which is generated using [rspec_api_documentation](https://github.com/zipmark/rspec_api_documentation), no longer show JSON response body. After digging through the code, it turns out they check for [string encoding](https://github.com/zipmark/rspec_api_documentation/blob/560c3bdc7bd5581e7c223334390221ecfc910be8/lib/rspec_api_documentation/client_base.rb#L90-L95) to see if they should include the response body in the documentation or not. After than, I dug through the code and found 8c62821f4a464858a6b6ca3c3966ec308d2bb53e which uses `String.new` without specifying the encoding.

Please let me know if there's any further work on this PR needed to get it merged, or if I'm wrong to assume that I should get UTF-8 String back from `MockResponse#body`. Thank you.