### PR TITLE
Update TargetRubyVersion to 2.3 in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   DisabledByDefault: true
   Exclude:
     - '**/vendor/**/*'


### PR DESCRIPTION
Since d81a5d3bdd20d80527164705b1fcfd0b7f4be6cd, Ruby 2.2 is no longer supported.