### PR TITLE
Skip deflating in Rack::Deflater if Content-Length is 0

### DIFF
--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -124,6 +124,10 @@ module Rack
       # Skip if @condition lambda is given and evaluates to false
       return false if @condition && !@condition.call(env, status, headers, body)
 
+      # No point in compressing empty body, also handles usage with
+      # Rack::Sendfile.
+      return false if headers[CONTENT_LENGTH] == '0'
+
       true
     end
   end

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -362,6 +362,15 @@ describe Rack::Deflater do
     verify(200, 'Hello World!', { 'gzip' => nil }, options)
   end
 
+  it "not deflate if content-length is 0" do
+    options = {
+      'response_headers' => {
+        'Content-Length' => '0'
+      },
+    }
+    verify(200, '', { 'gzip' => nil }, options)
+  end
+
   it "deflate response if :if lambda evaluates to true" do
     options = {
       'deflater_options' => {


### PR DESCRIPTION
Fixes usage with Rack::Sendfile.

Fixes #1142