### PR TITLE
Require password for basic authentication

### DIFF
--- a/lib/rack/auth/basic.rb
+++ b/lib/rack/auth/basic.rb
@@ -44,7 +44,7 @@ module Rack
 
       class Request < Auth::AbstractRequest
         def basic?
-          "basic" == scheme
+          "basic" == scheme && credentials.length == 2
         end
 
         def credentials

--- a/test/spec_auth_basic.rb
+++ b/test/spec_auth_basic.rb
@@ -84,6 +84,15 @@ describe Rack::Auth::Basic do
     end
   end
 
+  it 'return 400 Bad Request for a authorization header with only username' do
+    auth = 'Basic ' + ['foo'].pack("m*")
+    request 'HTTP_AUTHORIZATION' => auth do |response|
+      response.must_be :client_error?
+      response.status.must_equal 400
+      response.wont_include 'WWW-Authenticate'
+    end
+  end
+
   it 'takes realm as optional constructor arg' do
     app = Rack::Auth::Basic.new(unprotected_app, realm) { true }
     realm.must_equal app.realm

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -76,7 +76,7 @@ describe Rack::Deflater do
           Time.httpdate(last_mod).to_i.must_equal mtime
         else
           mtime.must_be(:<=, Time.now.to_i)
-          mtime.must_be(:>=, start.to_i)
+          mtime.must_be(:>=, start.to_i - 1)
         end
         tmp = gz.read
         gz.close


### PR DESCRIPTION
Empty passwords are still allowed, but there must be a colon to
separate username from password, as required by RFC 2617.

Fixes #1138