### PR TITLE
Implement SessionHash#dig

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -98,6 +98,11 @@ module Rack
           @data[key.to_s]
         end
 
+        def dig(key, *keys)
+          load_for_read!
+          @data.dig(key.to_s, *keys)
+        end
+
         def fetch(key, default = Unspecified, &block)
           load_for_read!
           if default == Unspecified

--- a/test/spec_session_abstract_session_hash.rb
+++ b/test/spec_session_abstract_session_hash.rb
@@ -10,7 +10,7 @@ describe Rack::Session::Abstract::SessionHash do
     super
     store = Class.new do
       def load_session(req)
-        ["id", { foo: :bar, baz: :qux }]
+        ["id", { foo: :bar, baz: :qux, x: { y: 1 } }]
       end
       def session_exists?(req)
         true
@@ -20,11 +20,22 @@ describe Rack::Session::Abstract::SessionHash do
   end
 
   it "returns keys" do
-    assert_equal ["foo", "baz"], hash.keys
+    assert_equal ["foo", "baz", "x"], hash.keys
   end
 
   it "returns values" do
-    assert_equal [:bar, :qux], hash.values
+    assert_equal [:bar, :qux, { y: 1 }], hash.values
+  end
+
+  describe "#dig" do
+    it "operates like Hash#dig" do
+      assert_equal({ y: 1 }, hash.dig("x"))
+      assert_equal(1, hash.dig(:x, :y))
+      assert_nil(hash.dig(:z))
+      assert_nil(hash.dig(:x, :z))
+      lambda { hash.dig(:x, :y, :z) }.must_raise TypeError
+      lambda { hash.dig }.must_raise ArgumentError
+    end
   end
 
   describe "#fetch" do
@@ -47,7 +58,7 @@ describe Rack::Session::Abstract::SessionHash do
 
   describe "#stringify_keys" do
     it "returns hash or session hash with keys stringified" do
-      assert_equal({ "foo" => :bar, "baz" => :qux }, hash.send(:stringify_keys, hash).to_h)
+      assert_equal({ "foo" => :bar, "baz" => :qux, "x" => { y: 1 } }, hash.send(:stringify_keys, hash).to_h)
     end
   end
 end


### PR DESCRIPTION
Now that rack supports Ruby 2.3+, it makes sense to implement
dig.

Fixes #1120