### PR TITLE
Support providing IO-like object to Rack::Multipart::UploadedFile

### DIFF
--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -510,6 +510,22 @@ Content-Type: image/jpeg\r
     params["people"][0]["files"][:tempfile].read.must_equal "contents"
   end
 
+  it "builds multipart body from StringIO" do
+    files = Rack::Multipart::UploadedFile.new(io: StringIO.new('foo'), filename: 'bar.txt')
+    data  = Rack::Multipart.build_multipart("submit-name" => "Larry", "files" => files)
+
+    options = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+      "CONTENT_LENGTH" => data.length.to_s,
+      :input => StringIO.new(data)
+    }
+    env = Rack::MockRequest.env_for("/", options)
+    params = Rack::Multipart.parse_multipart(env)
+    params["submit-name"].must_equal "Larry"
+    params["files"][:filename].must_equal "bar.txt"
+    params["files"][:tempfile].read.must_equal "foo"
+  end
+
   it "can parse fields that end at the end of the buffer" do
     input = File.read(multipart_file("bad_robots"))
 


### PR DESCRIPTION
This changes the UploadedFile API to use keyword arguments, being
backwards compatible with the previous API by keeping the positional
arguments and making the keyword defaults be the positional argument
values.

The two new arguments to UploadedFile#initialize are filename and io.
filename allows overriding the filename that will be used, instead of
always using the base name of the path.  io specifies an IO-like
object that can be read from to get the data, overridding any
provided path.  This allows you to generate UploadedFile instances
that previously were not possible without accessing the file system.

This changes the multipart generator to only include a Content-Length
for files with paths, and only include a filename in
Content-Disposition if the UploadedFile has one.

Fixes #1028.