### PR TITLE
Make Rack::Request#ssl? be true for wss scheme

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -270,7 +270,7 @@ module Rack
       end
 
       def ssl?
-        scheme == 'https'
+        scheme == 'https' || scheme == 'wss'
       end
 
       def ip

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -574,6 +574,10 @@ class RackRequestTest < Minitest::Spec
     request.scheme.must_equal "https"
     request.must_be :ssl?
 
+    request = make_request(Rack::MockRequest.env_for("/", 'rack.url_scheme' => 'wss'))
+    request.scheme.must_equal "wss"
+    request.must_be :ssl?
+
     request = make_request(Rack::MockRequest.env_for("/", 'HTTP_HOST' => 'www.example.org:8080'))
     request.scheme.must_equal "http"
     request.wont_be :ssl?


### PR DESCRIPTION
wss is used for Websockets sent over a TLS connection, just as
https is used for HTTP sent over a TLS connection.

Fixes #1020