### PR TITLE
Add test for multipart parsing without Content-Disposition

### DIFF
--- a/test/multipart/content_type_and_no_disposition
+++ b/test/multipart/content_type_and_no_disposition
@@ -1,0 +1,5 @@
+--AaB03x
+Content-Type: text/plain; charset=US-ASCII
+
+contents
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -30,6 +30,12 @@ describe Rack::Multipart do
     Rack::Multipart.parse_multipart(env).must_be_nil
   end
 
+  it "parse multipart content when content type present but disposition is not" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_disposition))
+    params = Rack::Multipart.parse_multipart(env)
+    params["text/plain; charset=US-ASCII"].must_equal ["contents"]
+  end
+
   it "parse multipart content when content type present but filename is not" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_filename))
     params = Rack::Multipart.parse_multipart(env)


### PR DESCRIPTION
In this case, rack doesn't have a parameter name, so it uses
the content type as the parameter name.  Since there can be
multiple parts without Content-Disposition, it uses an array.

Fixes #984