### PR TITLE
Do not clobber :BindAddress in Webrick handler

### DIFF
--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -28,7 +28,9 @@ module Rack
         environment  = ENV['RACK_ENV'] || 'development'
         default_host = environment == 'development' ? 'localhost' : nil
 
-        options[:BindAddress] = options.delete(:Host) || default_host
+        if !options[:BindAddress] || options[:Host]
+          options[:BindAddress] = options.delete(:Host) || default_host
+        end
         options[:Port] ||= 8080
         if options[:SSLEnable]
           require 'webrick/https'


### PR DESCRIPTION
If :BindAddress is currently set and :Host is not set, then
:BindAddress is overwritten with the default_host, which is
probably not the desired behavior in that scenario.

Fixes #821