### PR TITLE
Escape [ and ] in Rack::Utils.escape

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -32,7 +32,7 @@ module Rack
 
     # URI escapes. (CGI style space to +)
     def escape(s)
-      URI.encode_www_form_component(s)
+      URI.encode_www_form_component(s).gsub('[', '%5B').gsub(']', '%5D')
     end
     module_function :escape
 
@@ -119,11 +119,11 @@ module Rack
       case value
       when Array
         value.map { |v|
-          build_nested_query(v, "#{prefix}[]")
+          build_nested_query(v, "#{prefix}%5B%5D")
         }.join("&")
       when Hash
         value.map { |k, v|
-          build_nested_query(v, prefix ? "#{prefix}[#{escape(k)}]" : escape(k))
+          build_nested_query(v, prefix ? "#{prefix}%5B#{escape(k)}%5D" : escape(k))
         }.delete_if(&:empty?).join('&')
       when nil
         prefix

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -167,7 +167,7 @@ describe Rack::MockRequest do
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["QUERY_STRING"].must_include "baz=2"
-    env["QUERY_STRING"].must_include "foo[bar]=1"
+    env["QUERY_STRING"].must_include "foo%5Bbar%5D=1"
     env["PATH_INFO"].must_equal "/foo"
     env["mock.postdata"].must_equal ""
   end
@@ -177,7 +177,7 @@ describe Rack::MockRequest do
     env = YAML.load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["QUERY_STRING"].must_include "baz=2"
-    env["QUERY_STRING"].must_include "foo[bar]=1"
+    env["QUERY_STRING"].must_include "foo%5Bbar%5D=1"
     env["PATH_INFO"].must_equal "/foo"
     env["mock.postdata"].must_equal ""
   end
@@ -189,7 +189,7 @@ describe Rack::MockRequest do
     env["QUERY_STRING"].must_equal ""
     env["PATH_INFO"].must_equal "/foo"
     env["CONTENT_TYPE"].must_equal "application/x-www-form-urlencoded"
-    env["mock.postdata"].must_equal "foo[bar]=1"
+    env["mock.postdata"].must_equal "foo%5Bbar%5D=1"
   end
 
   it "accept raw input in params for POST requests" do

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -281,9 +281,9 @@ describe Rack::Utils do
     assert_nested_query("my+weird+field=q1%212%22%27w%245%267%2Fz8%29%3F",
                         "my weird field" => "q1!2\"'w$5&7/z8)?")
 
-    Rack::Utils.build_nested_query("foo" => [nil]).must_equal "foo[]"
-    Rack::Utils.build_nested_query("foo" => [""]).must_equal "foo[]="
-    Rack::Utils.build_nested_query("foo" => ["bar"]).must_equal "foo[]=bar"
+    Rack::Utils.build_nested_query("foo" => [nil]).must_equal "foo%5B%5D"
+    Rack::Utils.build_nested_query("foo" => [""]).must_equal "foo%5B%5D="
+    Rack::Utils.build_nested_query("foo" => ["bar"]).must_equal "foo%5B%5D=bar"
     Rack::Utils.build_nested_query('foo' => []).must_equal ''
     Rack::Utils.build_nested_query('foo' => {}).must_equal ''
     Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => []).must_equal 'foo=bar'
@@ -294,35 +294,37 @@ describe Rack::Utils do
     Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => '').
       must_equal 'foo=bar&baz='
     Rack::Utils.build_nested_query('foo' => ['1', '2']).
-      must_equal 'foo[]=1&foo[]=2'
+      must_equal 'foo%5B%5D=1&foo%5B%5D=2'
     Rack::Utils.build_nested_query('foo' => 'bar', 'baz' => ['1', '2', '3']).
-      must_equal 'foo=bar&baz[]=1&baz[]=2&baz[]=3'
+      must_equal 'foo=bar&baz%5B%5D=1&baz%5B%5D=2&baz%5B%5D=3'
     Rack::Utils.build_nested_query('foo' => ['bar'], 'baz' => ['1', '2', '3']).
-      must_equal 'foo[]=bar&baz[]=1&baz[]=2&baz[]=3'
+      must_equal 'foo%5B%5D=bar&baz%5B%5D=1&baz%5B%5D=2&baz%5B%5D=3'
     Rack::Utils.build_nested_query('foo' => ['bar'], 'baz' => ['1', '2', '3']).
-      must_equal 'foo[]=bar&baz[]=1&baz[]=2&baz[]=3'
+      must_equal 'foo%5B%5D=bar&baz%5B%5D=1&baz%5B%5D=2&baz%5B%5D=3'
     Rack::Utils.build_nested_query('x' => { 'y' => { 'z' => '1' } }).
-      must_equal 'x[y][z]=1'
+      must_equal 'x%5By%5D%5Bz%5D=1'
     Rack::Utils.build_nested_query('x' => { 'y' => { 'z' => ['1'] } }).
-      must_equal 'x[y][z][]=1'
+      must_equal 'x%5By%5D%5Bz%5D%5B%5D=1'
     Rack::Utils.build_nested_query('x' => { 'y' => { 'z' => ['1', '2'] } }).
-      must_equal 'x[y][z][]=1&x[y][z][]=2'
+      must_equal 'x%5By%5D%5Bz%5D%5B%5D=1&x%5By%5D%5Bz%5D%5B%5D=2'
     Rack::Utils.build_nested_query('x' => { 'y' => [{ 'z' => '1' }] }).
-      must_equal 'x[y][][z]=1'
+      must_equal 'x%5By%5D%5B%5D%5Bz%5D=1'
     Rack::Utils.build_nested_query('x' => { 'y' => [{ 'z' => ['1'] }] }).
-      must_equal 'x[y][][z][]=1'
+      must_equal 'x%5By%5D%5B%5D%5Bz%5D%5B%5D=1'
     Rack::Utils.build_nested_query('x' => { 'y' => [{ 'z' => '1', 'w' => '2' }] }).
-      must_equal 'x[y][][z]=1&x[y][][w]=2'
+      must_equal 'x%5By%5D%5B%5D%5Bz%5D=1&x%5By%5D%5B%5D%5Bw%5D=2'
     Rack::Utils.build_nested_query('x' => { 'y' => [{ 'v' => { 'w' => '1' } }] }).
-      must_equal 'x[y][][v][w]=1'
+      must_equal 'x%5By%5D%5B%5D%5Bv%5D%5Bw%5D=1'
     Rack::Utils.build_nested_query('x' => { 'y' => [{ 'z' => '1', 'v' => { 'w' => '2' } }] }).
-      must_equal 'x[y][][z]=1&x[y][][v][w]=2'
+      must_equal 'x%5By%5D%5B%5D%5Bz%5D=1&x%5By%5D%5B%5D%5Bv%5D%5Bw%5D=2'
     Rack::Utils.build_nested_query('x' => { 'y' => [{ 'z' => '1' }, { 'z' => '2' }] }).
-      must_equal 'x[y][][z]=1&x[y][][z]=2'
+      must_equal 'x%5By%5D%5B%5D%5Bz%5D=1&x%5By%5D%5B%5D%5Bz%5D=2'
     Rack::Utils.build_nested_query('x' => { 'y' => [{ 'z' => '1', 'w' => 'a' }, { 'z' => '2', 'w' => '3' }] }).
-      must_equal 'x[y][][z]=1&x[y][][w]=a&x[y][][z]=2&x[y][][w]=3'
+      must_equal 'x%5By%5D%5B%5D%5Bz%5D=1&x%5By%5D%5B%5D%5Bw%5D=a&x%5By%5D%5B%5D%5Bz%5D=2&x%5By%5D%5B%5D%5Bw%5D=3'
     Rack::Utils.build_nested_query({ "foo" => ["1", ["2"]] }).
-      must_equal 'foo[]=1&foo[][]=2'
+      must_equal 'foo%5B%5D=1&foo%5B%5D%5B%5D=2'
+    Rack::Utils.build_nested_query({ "foo" => '[]' }).
+      must_equal 'foo=%5B%5D'
 
     lambda { Rack::Utils.build_nested_query("foo=bar") }.
       must_raise(ArgumentError).


### PR DESCRIPTION
These should be escaped per RFC 3986 section 3.4, which does not
allow them in query strings.

Rack already handled these correctly when processing input, the
test changes are places where the values were checked directly
without running it through an input processor.

Fixes #792