### PR TITLE
Update Thin handler to better handle more options

### DIFF
--- a/lib/rack/handler/thin.rb
+++ b/lib/rack/handler/thin.rb
@@ -14,14 +14,20 @@ module Rack
         environment  = ENV['RACK_ENV'] || 'development'
         default_host = environment == 'development' ? 'localhost' : '0.0.0.0'
 
-        host = options.delete(:Host) || default_host
-        port = options.delete(:Port) || 8080
-        args = [host, port, app, options]
-        # Thin versions below 0.8.0 do not support additional options
-        args.pop if ::Thin::VERSION::MAJOR < 1 && ::Thin::VERSION::MINOR < 8
-        server = ::Thin::Server.new(*args)
-        yield server if block_given?
-        server.start
+        if block_given?
+          host = options.delete(:Host) || default_host
+          port = options.delete(:Port) || 8080
+          args = [host, port, app, options]
+          # Thin versions below 0.8.0 do not support additional options
+          args.pop if ::Thin::VERSION::MAJOR < 1 && ::Thin::VERSION::MINOR < 8
+          server = ::Thin::Server.new(*args)
+          yield server
+          server.start
+        else
+          options[:address] = options[:Host] || default_host
+          options[:port] = options[:Port] || 8080
+          ::Thin::Controllers::Controller.new(options).start
+        end
       end
 
       def self.valid_options


### PR DESCRIPTION
This uses Thin::Controllers::Controller instead of Thin::Server.
Thin::Controllers::Controller will do options parsing and then
create a Thin::Server instance based on them.

Fixes #745