### PR TITLE
Added support for SameSite=None cookie for 1.6

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -315,6 +315,8 @@ module Rack
           case value[:same_site]
           when false, nil
             nil
+          when :none, 'None', :None
+            '; SameSite=None'.freeze
           when :lax, 'Lax', :Lax
             '; SameSite=Lax'.freeze
           when true, :strict, 'Strict', :Strict

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -97,6 +97,24 @@ describe Rack::Response do
     response["Set-Cookie"].should.equal "foo=bar"
   end
 
+  it "can set SameSite cookies with symbol value :none" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: :none }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with symbol value :None" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: :None }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with string value 'None'" do
+    response = Rack::Response.new
+    response.set_cookie "foo", { value: "bar", same_site: "None" }
+    response["Set-Cookie"].must_equal "foo=bar; SameSite=None"
+  end
+
   it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :lax}


### PR DESCRIPTION
I have some projects with Rails 4.
Could you backport support of same site cookie is none for 1.6?
