### PR TITLE
Set Content-Length response header even for bodies not responding to to_ary

### DIFF
--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -19,8 +19,7 @@ module Rack
 
       if !STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) &&
          !headers[CONTENT_LENGTH] &&
-         !headers[TRANSFER_ENCODING] &&
-         body.respond_to?(:to_ary)
+         !headers[TRANSFER_ENCODING]
 
         obody = body
         body, length = [], 0

--- a/test/spec_content_length.rb
+++ b/test/spec_content_length.rb
@@ -20,13 +20,13 @@ describe Rack::ContentLength do
     response[1]['Content-Length'].must_equal '13'
   end
 
-  it "not set Content-Length on variable length bodies" do
+  it "set Content-Length on variable length bodies" do
     body = lambda { "Hello World!" }
     def body.each ; yield call ; end
 
     app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, body] }
     response = content_length(app).call(request)
-    response[1]['Content-Length'].must_be_nil
+    response[1]['Content-Length'].must_equal '12'
   end
 
   it "not change Content-Length if it is already set" do


### PR DESCRIPTION
This to_ary check was previously there to work around an infinite
loop issue due to Rack::Response#to_ary being defined.
Rack::Response#to_ary has been removed, so this check can be removed,
and the middleware can correctly calculate Content-Length for all
valid rack responses.

Fixes #734