### PR TITLE
Require rack.session entry to respond to to_hash and return Hash instance

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -104,7 +104,7 @@ be implemented by the server.
                         fetch(key, default = nil) (aliased as []);
                         delete(key);
                         clear;
-                        to_hash (returning Hash instance);
+                        to_hash (returning unfrozen Hash instance);
 <tt>rack.logger</tt>:: A common object interface for logging messages.
                        The object must implement:
                         info(message, &block)

--- a/SPEC
+++ b/SPEC
@@ -104,6 +104,7 @@ be implemented by the server.
                         fetch(key, default = nil) (aliased as []);
                         delete(key);
                         clear;
+                        to_hash (returning Hash instance);
 <tt>rack.logger</tt>:: A common object interface for logging messages.
                        The object must implement:
                         info(message, &block)

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -206,6 +206,11 @@ module Rack
         assert("session #{session.inspect} must respond to clear") {
           session.respond_to?(:clear)
         }
+
+        ##                         to_hash (returning Hash instance);
+        assert("session #{session.inspect} must respond to to_hash and return Hash instance") {
+          session.respond_to?(:to_hash) && session.to_hash.kind_of?(Hash)
+        }
       end
 
       ## <tt>rack.logger</tt>:: A common object interface for logging messages.

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -207,9 +207,9 @@ module Rack
           session.respond_to?(:clear)
         }
 
-        ##                         to_hash (returning Hash instance);
-        assert("session #{session.inspect} must respond to to_hash and return Hash instance") {
-          session.respond_to?(:to_hash) && session.to_hash.kind_of?(Hash)
+        ##                         to_hash (returning unfrozen Hash instance);
+        assert("session #{session.inspect} must respond to to_hash and return unfrozen Hash instance") {
+          session.respond_to?(:to_hash) && session.to_hash.kind_of?(Hash) && !session.to_hash.frozen?
         }
       end
 

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -71,12 +71,17 @@ describe Rack::Lint do
     }.must_raise(Rack::Lint::LintError).
       message.must_equal "session [] must respond to store and []="
 
+    lambda {
+      Rack::Lint.new(nil).call(env("rack.session" => {}.freeze))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "session {} must respond to to_hash and return unfrozen Hash instance"
+
     obj = {}
     obj.singleton_class.send(:undef_method, :to_hash)
     lambda {
       Rack::Lint.new(nil).call(env("rack.session" => obj))
     }.must_raise(Rack::Lint::LintError).
-      message.must_equal "session {} must respond to to_hash and return Hash instance"
+      message.must_equal "session {} must respond to to_hash and return unfrozen Hash instance"
 
     obj.singleton_class.send(:undef_method, :clear)
     lambda {

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -71,6 +71,31 @@ describe Rack::Lint do
     }.must_raise(Rack::Lint::LintError).
       message.must_equal "session [] must respond to store and []="
 
+    obj = {}
+    obj.singleton_class.send(:undef_method, :to_hash)
+    lambda {
+      Rack::Lint.new(nil).call(env("rack.session" => obj))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "session {} must respond to to_hash and return Hash instance"
+
+    obj.singleton_class.send(:undef_method, :clear)
+    lambda {
+      Rack::Lint.new(nil).call(env("rack.session" => obj))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "session {} must respond to clear"
+
+    obj.singleton_class.send(:undef_method, :delete)
+    lambda {
+      Rack::Lint.new(nil).call(env("rack.session" => obj))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "session {} must respond to delete"
+
+    obj.singleton_class.send(:undef_method, :fetch)
+    lambda {
+      Rack::Lint.new(nil).call(env("rack.session" => obj))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "session {} must respond to fetch and []"
+
     lambda {
       Rack::Lint.new(nil).call(env("rack.logger" => []))
     }.must_raise(Rack::Lint::LintError).


### PR DESCRIPTION
This is already required by rack's session support, so it should
be in SPEC/Lint.

Add some more rack.session Lint tests while here.

Fixes #461