### PR TITLE
Add back test for etag with no-cache

### DIFF
--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -93,6 +93,12 @@ describe Rack::ETag do
     response[1]['ETag'].must_be_nil
   end
 
+  it "set ETag even if no-cache is given" do
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Cache-Control' => 'no-cache, must-revalidate' }, ['Hello, World!']] }
+    response = etag(app).call(request)
+    response[1]['ETag'].must_equal "W/\"dffd6021bb2bd5b0af676290809ec3a5\""
+  end
+
   it "close the original body" do
     body = StringIO.new
     app = lambda { |env| [200, {}, body] }


### PR DESCRIPTION
The behavior changed in the previous commit, but I think it is
better to specify the new behavior versus leaving it unspecified.