### PR TITLE
Simplify and make more consistent `Response#finish`

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -87,24 +87,17 @@ module Rack
       else
         if block_given?
           @block = block
-          [status.to_i, header, self]
-        else
-          [status.to_i, header, @body]
+          response = self
+          @body.define_singleton_method(:each) do |&each_block|
+            block.call(response)
+            super(&each_block)
+          end
         end
+        [status.to_i, header, @body]
       end
     end
 
     alias to_a finish           # For *response
-
-    def each(&callback)
-      @body.each(&callback)
-      @buffered = true
-
-      if @block
-        @writer = callback
-        @block.call(self)
-      end
-    end
 
     # Append to body and update Content-Length.
     #

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -66,6 +66,27 @@ describe Rack::Response do
     parts.must_equal ["foo", "bar", "baz"]
   end
 
+  it "calls finish block when body is iterated" do
+    response = Rack::Response.new
+
+    finished = false
+    _, _, body = response.finish do
+      finished = true
+      response.write "foo"
+      response.write "bar"
+      response.write "baz"
+    end
+
+    parts = []
+    finished.must_equal false
+    body.each do |part|
+      finished.must_equal true
+      parts << part
+    end
+
+    parts.must_equal ["foo", "bar", "baz"]
+  end
+
   it "can set and read headers" do
     response = Rack::Response.new
     response["Content-Type"].must_be_nil


### PR DESCRIPTION
Reduce a number of types of the last element in the response array.

Remove `Response#each` at all.

PLEASE! Be careful.

Tests are passed, but I don't understand Rack API completely, I'm a newbie in this. 