### PR TITLE
Avoid use of unnecessary refinement

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -44,18 +44,6 @@ module Rack
       # SessionHash is responsible to lazily load the session from store.
 
       class SessionHash
-        using Module.new {
-          refine Hash do
-            def transform_keys(&block)
-              hash = {}
-              each do |key, value|
-                hash[block.call(key)] = value
-              end
-              hash
-            end
-          end
-        } unless {}.respond_to?(:transform_keys)
-
         include Enumerable
         attr_writer :id
 
@@ -206,7 +194,12 @@ module Rack
         end
 
         def stringify_keys(other)
-          other.to_hash.transform_keys(&:to_s)
+          # Use transform_keys after dropping Ruby 2.4 support
+          hash = {}
+          other.to_hash.each do |key, value|
+            hash[key.to_s] = value
+          end
+          hash
         end
       end
 


### PR DESCRIPTION
This is only used in a single place, it is better to use a unified
approach.  After Ruby 2.4 support is dropped, we can switch back
stringify_keys back, and avoid the refinement.