### PR TITLE
Only use ::Rack::RegexpExtensions on Ruby 2.3

### DIFF
--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -19,7 +19,7 @@ module Rack
   # directive of 'no-transform' is present, or when the response status
   # code is one that doesn't allow an entity body.
   class Deflater
-    using ::Rack::RegexpExtensions
+    using ::Rack::RegexpExtensions if RUBY_VERSION < '2.4'
 
     ##
     # Creates Rack::Deflater middleware.

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -9,7 +9,7 @@ module Rack
     class MultipartPartLimitError < Errno::EMFILE; end
 
     class Parser
-      using ::Rack::RegexpExtensions
+      using ::Rack::RegexpExtensions if RUBY_VERSION < '2.4'
 
       BUFSIZE = 1_048_576
       TEXT_PLAIN = "text/plain"

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -4,7 +4,7 @@ require_relative 'core_ext/regexp'
 
 module Rack
   class QueryParser
-    using ::Rack::RegexpExtensions
+    using ::Rack::RegexpExtensions if RUBY_VERSION < '2.4'
 
     DEFAULT_SEP = /[&;] */n
     COMMON_SEP = { ";" => /[;] */n, ";," => /[;,] */n, "&" => /[&] */n }

--- a/lib/rack/reloader.rb
+++ b/lib/rack/reloader.rb
@@ -24,7 +24,7 @@ module Rack
   # It is performing a check/reload cycle at the start of every request, but
   # also respects a cool down time, during which nothing will be done.
   class Reloader
-    using ::Rack::RegexpExtensions
+    using ::Rack::RegexpExtensions if RUBY_VERSION < '2.4'
 
     def initialize(app, cooldown = 10, backend = Stat)
       @app = app

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -15,7 +15,7 @@ module Rack
   #   req.params["data"]
 
   class Request
-    using ::Rack::RegexpExtensions
+    using ::Rack::RegexpExtensions if RUBY_VERSION < '2.4'
 
     class << self
       attr_accessor :ip_filter

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -8,7 +8,7 @@ require_relative 'core_ext/regexp'
 module Rack
 
   class Server
-    using ::Rack::RegexpExtensions
+    using ::Rack::RegexpExtensions if RUBY_VERSION < '2.4'
 
     class Options
       def parse!(args)

--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -91,7 +91,7 @@ module Rack
   #         ]
   #
   class Static
-    using ::Rack::RegexpExtensions
+    using ::Rack::RegexpExtensions if RUBY_VERSION < '2.4'
 
     def initialize(app, options = {})
       @app = app

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -15,7 +15,7 @@ module Rack
   # applications adopted from all kinds of Ruby libraries.
 
   module Utils
-    using ::Rack::RegexpExtensions
+    using ::Rack::RegexpExtensions if RUBY_VERSION < '2.4'
 
     ParameterTypeError = QueryParser::ParameterTypeError
     InvalidParameterError = QueryParser::InvalidParameterError


### PR DESCRIPTION
Ruby 2.4+ support Regexp#match? and does not require loading a
refinement.