### PR TITLE
Fix Response#write calculation of Content-Length if initialized with a body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Changed
 
+- Rely on autoload to load constants instead of requiring internal files, make sure to require 'rack' and not just 'rack/...'. ([@jeremyevans](https://github.com/jeremyevans))
 - `Etag` will continue sending ETag even if the response should not be cached. ([@henm](https://github.com/henm))
 - `Request#host_with_port` no longer includes a colon for a missing or empty port. ([@AlexWayfer](https://github.com/AlexWayfer))
 - All handlers uses keywords arguments instead of an options hash argument. ([@ioquatix](https://github.com/ioquatix))
@@ -39,6 +40,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Fixed
 
+- `Response#write` correctly updates `Content-Length` if initialized with a body. ([@jeremyevans](https://github.com/jeremyevans))
 - `CommonLogger` includes `SCRIPT_NAME` when logging. ([@Erol](https://github.com/Erol))
 - `Utils.parse_nested_query` correctly handles empty queries, using an empty instance of the params class instead of a hash. ([@jeremyevans](https://github.com/jeremyevans))
 - `Directory` correctly escapes paths in links. ([@yous](https://github.com/yous))

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -46,18 +46,20 @@ module Rack
       @writer = self.method(:append)
 
       @block = nil
-      @length = 0
 
       # Keep track of whether we have expanded the user supplied body.
       if body.nil?
         @body = []
         @buffered = true
+        @length = 0
       elsif body.respond_to?(:to_str)
         @body = [body]
         @buffered = true
+        @length = body.to_str.bytesize
       else
         @body = body
         @buffered = false
+        @length = 0
       end
 
       yield self if block_given?
@@ -242,6 +244,9 @@ module Rack
         if @body.is_a?(Array)
           # The user supplied body was an array:
           @body = @body.compact
+          @body.each do |part|
+            @length += part.to_s.bytesize
+          end
         else
           # Turn the user supplied body into a buffered array:
           body = @body


### PR DESCRIPTION
Before, @length was always set to 0 in the constructor. The breaks
the case where a string was provided, since that is automatically
bufferred.  Fix that by using the bytesize of the string.

If body was provided as an array, when switching to buffered mode,
iterate over the body to figure out the content length.

Note this only occurs when doing Response#write, as that is the
only case where Response updates the Content-Length.

I found one spec that called Response#write inside a Response#finish
block.  That updates the response body after the header hash is
returned, and does not call Response#append as the @writer has been
changed to the Response#finish block, so it doesn't update the
Content-Length in the returned header hash.