### PR TITLE
Remove dead code in multipart parser

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -99,12 +99,6 @@ module Rack
 
               data = { filename: fn, type: content_type,
                       name: name, tempfile: body, head: head }
-            elsif !filename && content_type && body.is_a?(IO)
-              body.rewind
-
-              # Generic multipart cases, not coming from a form
-              data = { type: content_type,
-                      name: name, tempfile: body, head: head }
             end
 
             yield data


### PR DESCRIPTION
This can only be hit if filename is nil/false.  However, when
the MimePart is created, it is either a TempfilePart if there
is a filename or a BufferPart otherwise.  In the TempfilePart
case, the filename is present so this code is not hit.  In the
BufferPart case, the body is a String and not an IO, so this
cannot be hit.