### PR TITLE
Make BackProxy#method handle delegated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Fixed
 
+- `BodyProxy#method` correctly handles methods delegated to the body object. ([@jeremyevans](https://github.com/jeremyevans))
+- `Request#host` and `Request#host_with_port` handle IPv6 addresses correctly. ([@AlexWayfer](https://github.com/AlexWayfer))
 - `Lint` checks when response hijacking that `rack.hijack` is called with a valid object. ([@jeremyevans](https://github.com/jeremyevans))
 - `Response#write` correctly updates `Content-Length` if initialized with a body. ([@jeremyevans](https://github.com/jeremyevans))
 - `CommonLogger` includes `SCRIPT_NAME` when logging. ([@Erol](https://github.com/Erol))

--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -8,7 +8,7 @@ module Rack
       @closed = false
     end
 
-    def respond_to?(method_name, include_all = false)
+    def respond_to_missing?(method_name, include_all = false)
       super or @body.respond_to?(method_name, include_all)
     end
 

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -56,6 +56,13 @@ describe Rack::BodyProxy do
     proxy.respond_to?(:foo, false).must_equal false
   end
 
+  it 'allows #method to work with delegated methods' do
+    body  = Object.new
+    def body.banana; :pear end
+    proxy = Rack::BodyProxy.new(body) { }
+    proxy.method(:banana).call.must_equal :pear
+  end
+
   it 'not respond to :to_ary' do
     body = Object.new.tap { |o| def o.to_ary() end }
     body.respond_to?(:to_ary).must_equal true


### PR DESCRIPTION
This doesn't work if you define respond_to?, but does work if
you define respond_to_missing?.