### PR TITLE
Remove BodyProxy#each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Removed
 
+- `BodyProxy#each` as it was only needed to work around a bug in Ruby <1.9.3. ([@jeremyevans](https://github.com/jeremyevans))
 - `Session::Abstract::SessionHash#transform_keys`, no longer needed. (pavel)
 - `URLMap::INFINITY` and `URLMap::NEGATIVE_INFINITY`, in favor of `Float::INFINITY`. ([@ch1c0t](https://github.com/ch1c0t))
 - Deprecation of `Rack::File`. It will be deprecated again in rack 2.2 or 3.0. ([@rafaelfranca](https://github.com/rafaelfranca))

--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -26,14 +26,6 @@ module Rack
       @closed
     end
 
-    # N.B. This method is a special case to address the bug described by #434.
-    # We are applying this special case for #each only. Future bugs of this
-    # class will be handled by requesting users to patch their ruby
-    # implementation, to save adding too many methods in this class.
-    def each
-      @body.each { |body| yield body }
-    end
-
     def method_missing(method_name, *args, &block)
       @body.__send__(method_name, *args, &block)
     end

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -85,8 +85,4 @@ describe Rack::BodyProxy do
     proxy.close
     closed.must_equal true
   end
-
-  it 'provide an #each method' do
-    Rack::BodyProxy.method_defined?(:each).must_equal true
-  end
 end


### PR DESCRIPTION
This was added due to issue #434, but the links in that issue
make clear it is only needed in Ruby <1.9.3. As Ruby 2.3+ is
now required, this should be safe to remove.