### PR TITLE
Support magic comments in .ru files

### DIFF
--- a/test/builder/frozen.ru
+++ b/test/builder/frozen.ru
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+run lambda { |env|
+  body = 'frozen'
+  raise "Not frozen!" unless body.frozen?
+  [200, { 'Content-Type' => 'text/plain' }, [body]]
+}

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -270,6 +270,15 @@ describe Rack::Builder do
         Encoding.default_external = enc
       end
     end
+
+    it "respects the frozen_string_literal magic comment" do
+      app, _ = Rack::Builder.parse_file(config_file('frozen.ru'))
+      response = Rack::MockRequest.new(app).get('/')
+      response.body.must_equal 'frozen'
+      body = response.instance_variable_get(:@body)
+      body.must_equal(['frozen'])
+      body[0].frozen?.must_equal true
+    end
   end
 
   describe 'new_from_string' do


### PR DESCRIPTION
* Such as `# frozen_string_literal: true`.

This seems actually like a relevant bug fix because many files under `example` and `test` use `# frozen_string_literal: true` but actually it has not effect before this fix.

From the idea in https://github.com/rack/rack/pull/1544#issuecomment-581123830
cc @ioquatix @jeremyevans 