### PR TITLE
Add support for SameSite cookie to 1.4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
+dist: trusty
+language: ruby
 before_install: sudo apt-get install lighttpd libfcgi-dev libmemcache-dev memcached
 install:
   - gem env version | grep '^\(2\|1.\(8\|9\|[0-9][0-9]\)\)' || gem update --system
-  - gem install --conservative rake
+  - gem install rake -v '~> 0.9.6'
   - rake deps
 script: rake ci
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - rbx-2.0
-  - jruby
+  - 2.0.0
+  - jruby-1.7
   - ree
-branches:
-  # The old 1.1, 1.2, and 1.3 branches aren't correctly setup yet.
-  only: master
-notifications:
-  email: false
-  irc: "irc.freenode.org#rack"

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -247,6 +247,8 @@ module Rack
           case value[:same_site]
           when false, nil
             nil
+          when :none, 'None', :None
+            '; SameSite=None'
           when :lax, 'Lax', :Lax
             '; SameSite=Lax'.freeze
           when true, :strict, 'Strict', :Strict

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -243,14 +243,17 @@ module Rack
           rfc2822(value[:expires].clone.gmtime) if value[:expires]
         secure = "; secure"  if value[:secure]
         httponly = "; HttpOnly" if value[:httponly]
-        same_site = if value[:same_site]
+        same_site =
           case value[:same_site]
-          when Symbol, String
-            "; SameSite=#{value[:same_site]}"
+          when false, nil
+            nil
+          when :lax, 'Lax', :Lax
+            '; SameSite=Lax'.freeze
+          when true, :strict, 'Strict', :Strict
+            '; SameSite=Strict'.freeze
           else
-            "; SameSite"
+            raise ArgumentError, "Invalid SameSite value: #{value[:same_site].inspect}"
           end
-        end
         value = value[:value]
       end
       value = [value] unless Array === value

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -243,12 +243,20 @@ module Rack
           rfc2822(value[:expires].clone.gmtime) if value[:expires]
         secure = "; secure"  if value[:secure]
         httponly = "; HttpOnly" if value[:httponly]
+        same_site = if value[:same_site]
+          case value[:same_site]
+          when Symbol, String
+            "; SameSite=#{value[:same_site]}"
+          else
+            "; SameSite"
+          end
+        end
         value = value[:value]
       end
       value = [value] unless Array === value
       cookie = escape(key) + "=" +
         value.map { |v| escape v }.join("&") +
-        "#{domain}#{path}#{expires}#{secure}#{httponly}"
+        "#{domain}#{path}#{expires}#{secure}#{httponly}#{same_site}"
 
       case header["Set-Cookie"]
       when nil, ''

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "rack"
-  s.version         = "1.4.7"
+  s.version         = "1.4.7.1"
   s.platform        = Gem::Platform::RUBY
   s.summary         = "a modular Ruby webserver interface"
 

--- a/test/spec_chunked.rb
+++ b/test/spec_chunked.rb
@@ -43,7 +43,7 @@ describe Rack::Chunked do
     response.headers.should.not.include 'Content-Length'
     response.headers['Transfer-Encoding'].should.equal 'chunked'
     response.body.encoding.to_s.should.equal "ASCII-8BIT"
-    response.body.should.equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n"
+    response.body.should.equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".force_encoding("BINARY")
   end if RUBY_VERSION >= "1.9"
 
   should 'not modify response when Content-Length header present' do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -85,6 +85,24 @@ describe Rack::Response do
     response["Set-Cookie"].should.equal "foo=bar; HttpOnly"
   end
 
+  it "can set SameSite cookies with symbol value :none" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :none}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with symbol value :None" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :None}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=None"
+  end
+
+  it "can set SameSite cookies with string value 'None'" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => "None"}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=None"
+  end
+
   it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :lax}

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -85,10 +85,16 @@ describe Rack::Response do
     response["Set-Cookie"].should.equal "foo=bar; HttpOnly"
   end
 
-  it "can set SameSite cookies with any truthy value" do
+  it "can set SameSite cookies with symbol value :lax" do
     response = Rack::Response.new
-    response.set_cookie "foo", {:value => "bar", :same_site => Object.new}
-    response["Set-Cookie"].should.equal "foo=bar; SameSite"
+    response.set_cookie "foo", {:value => "bar", :same_site => :lax}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Lax"
+  end
+
+  it "can set SameSite cookies with symbol value :Lax" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :lax}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Lax"
   end
 
   it "can set SameSite cookies with string value 'Lax'" do
@@ -97,13 +103,39 @@ describe Rack::Response do
     response["Set-Cookie"].should.equal "foo=bar; SameSite=Lax"
   end
 
+  it "can set SameSite cookies with boolean value true" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => true}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
+  end
+
   it "can set SameSite cookies with symbol value :strict" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :strict}
-    response["Set-Cookie"].should.equal "foo=bar; SameSite=strict"
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
   end
 
   it "can set SameSite cookies with symbol value :Strict" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :Strict}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
+  end
+
+  it "can set SameSite cookies with string value 'Strict'" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => "Strict"}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
+  end
+
+  it "validates the SameSite option value" do
+    response = Rack::Response.new
+    lambda {
+      response.set_cookie "foo", {:value => "bar", :same_site => "Foo"}
+    }.should.raise(ArgumentError).
+      message.should.match(/Invalid SameSite value: "Foo"/)
+  end
+
+  it "can set SameSite cookies with symbol value" do
     response = Rack::Response.new
     response.set_cookie "foo", {:value => "bar", :same_site => :Strict}
     response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -85,6 +85,38 @@ describe Rack::Response do
     response["Set-Cookie"].should.equal "foo=bar; HttpOnly"
   end
 
+  it "can set SameSite cookies with any truthy value" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => Object.new}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite"
+  end
+
+  it "can set SameSite cookies with string value 'Lax'" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => "Lax"}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Lax"
+  end
+
+  it "can set SameSite cookies with symbol value :strict" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :strict}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=strict"
+  end
+
+  it "can set SameSite cookies with symbol value :Strict" do
+    response = Rack::Response.new
+    response.set_cookie "foo", {:value => "bar", :same_site => :Strict}
+    response["Set-Cookie"].should.equal "foo=bar; SameSite=Strict"
+  end
+
+  [ nil, false ].each do |non_truthy|
+    it "omits SameSite attribute given a #{non_truthy.inspect} value" do
+      response = Rack::Response.new
+      response.set_cookie "foo", {:value => "bar", :same_site => non_truthy}
+      response["Set-Cookie"].should.equal "foo=bar"
+    end
+  end
+
   it "can delete cookies" do
     response = Rack::Response.new
     response.set_cookie "foo", "bar"


### PR DESCRIPTION
We have a Rails 3 app that is still using Rack 1.4.7 that needs `SameSite` cookie flag.

This is not a security fix, but there was a significant [policy change in Chrome 80](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html), released 4 February 2020, that requires this capability with cookie flags in applications that are third-party resources.

Backports of #1033, #1051 and #1358.