### PR TITLE
Memoize header hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file. For info on
 - `Files` handling of range requests no longer return a body that supports `to_path`, to ensure range requests are handled correctly. ([@jeremyevans](https://github.com/jeremyevans))
 - `Multipart::Generator` only includes `Content-Length` for files with paths, and `Content-Disposition` `filename` if the `UploadedFile` instance has one. ([@jeremyevans](https://github.com/jeremyevans))
 - `Request#ssl?` is true for the `wss` scheme (secure websockets). ([@jeremyevans](https://github.com/jeremyevans))
+- `Rack::HeaderHash` is memoized by default. ([#1549](https://github.com/rack/rack/pull/1549), [@ioquatix](https://github.com/ioquatix))
 
 ### Removed
 

--- a/lib/rack/chunked.rb
+++ b/lib/rack/chunked.rb
@@ -69,7 +69,7 @@ module Rack
 
     def call(env)
       status, headers, body = @app.call(env)
-      headers = HeaderHash.new(headers)
+      headers = HeaderHash[headers]
 
       if ! chunkable_version?(env[SERVER_PROTOCOL]) ||
          STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) ||

--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -30,10 +30,10 @@ module Rack
 
     def call(env)
       began_at = Utils.clock_time
-      status, header, body = @app.call(env)
-      header = Utils::HeaderHash.new(header)
-      body = BodyProxy.new(body) { log(env, status, header, began_at) }
-      [status, header, body]
+      status, headers, body = @app.call(env)
+      headers = Utils::HeaderHash[headers]
+      body = BodyProxy.new(body) { log(env, status, headers, began_at) }
+      [status, headers, body]
     end
 
     private

--- a/lib/rack/conditional_get.rb
+++ b/lib/rack/conditional_get.rb
@@ -23,7 +23,7 @@ module Rack
       case env[REQUEST_METHOD]
       when "GET", "HEAD"
         status, headers, body = @app.call(env)
-        headers = Utils::HeaderHash.new(headers)
+        headers = Utils::HeaderHash[headers]
         if status == 200 && fresh?(env, headers)
           status = 304
           headers.delete(CONTENT_TYPE)

--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -12,7 +12,7 @@ module Rack
 
     def call(env)
       status, headers, body = @app.call(env)
-      headers = HeaderHash.new(headers)
+      headers = HeaderHash[headers]
 
       if !STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) &&
          !headers[CONTENT_LENGTH] &&

--- a/lib/rack/content_type.rb
+++ b/lib/rack/content_type.rb
@@ -17,7 +17,7 @@ module Rack
 
     def call(env)
       status, headers, body = @app.call(env)
-      headers = Utils::HeaderHash.new(headers)
+      headers = Utils::HeaderHash[headers]
 
       unless STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i)
         headers[CONTENT_TYPE] ||= @content_type

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -40,7 +40,7 @@ module Rack
 
     def call(env)
       status, headers, body = @app.call(env)
-      headers = Utils::HeaderHash.new(headers)
+      headers = Utils::HeaderHash[headers]
 
       unless should_deflate?(env, status, headers, body)
         return [status, headers, body]

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -593,7 +593,7 @@ module Rack
 
       # this check uses headers like a hash, but the spec only requires
       # headers respond to #each
-      headers = Rack::Utils::HeaderHash.new(headers)
+      headers = Rack::Utils::HeaderHash[headers]
 
       ## In order to do this, an application may set the special header
       ## <tt>rack.hijack</tt> to an object that responds to <tt>call</tt>

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -41,7 +41,7 @@ module Rack
     # Providing a body which responds to #to_str is legacy behaviour.
     def initialize(body = nil, status = 200, headers = {})
       @status = status.to_i
-      @headers = Utils::HeaderHash.new(headers)
+      @headers = Utils::HeaderHash[headers]
 
       @writer = self.method(:append)
 

--- a/lib/rack/show_status.rb
+++ b/lib/rack/show_status.rb
@@ -18,7 +18,7 @@ module Rack
 
     def call(env)
       status, headers, body = @app.call(env)
-      headers = Utils::HeaderHash.new(headers)
+      headers = Utils::HeaderHash[headers]
       empty = headers[CONTENT_LENGTH].to_i <= 0
 
       # client or server error, or explicit message

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -405,7 +405,7 @@ module Rack
     #
     # @api private
     class HeaderHash < Hash # :nodoc:
-      def self.[] headers
+      def self.[](headers)
         if headers.is_a?(HeaderHash)
           return headers
         else

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -405,6 +405,14 @@ module Rack
     #
     # @api private
     class HeaderHash < Hash # :nodoc:
+      def self.[] headers
+        if headers.is_a?(HeaderHash)
+          return headers
+        else
+          return self.new(headers)
+        end
+      end
+
       def initialize(hash = {})
         super()
         @names = {}

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -406,7 +406,7 @@ module Rack
     # @api private
     class HeaderHash < Hash # :nodoc:
       def self.[](headers)
-        if headers.is_a?(HeaderHash)
+        if headers.is_a?(HeaderHash) && !headers.frozen?
           return headers
         else
           return self.new(headers)

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -71,13 +71,13 @@ describe Rack::Response do
   end
 
   it "doesn't mutate given headers" do
-    [{}, Rack::Utils::HeaderHash.new].each do |header|
-      response = Rack::Response.new([], 200, header)
-      response.header["Content-Type"] = "text/plain"
-      response.header["Content-Type"].must_equal "text/plain"
+    headers = {}
 
-      header.wont_include("Content-Type")
-    end
+    response = Rack::Response.new([], 200, headers)
+    response.headers["Content-Type"] = "text/plain"
+    response.headers["Content-Type"].must_equal "text/plain"
+
+    headers.wont_include("Content-Type")
   end
 
   it "can override the initial Content-Type with a different case" do

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -727,6 +727,35 @@ describe Rack::Utils::HeaderHash do
     h['foo'].must_be_nil
     h.wont_include 'foo'
   end
+
+  it "uses memoized header hash" do
+    env = {}
+    headers = Rack::Utils::HeaderHash.new({ 'content-type' => "text/plain", "content-length" => "3" })
+
+    app = lambda do |env|
+      [200, headers, []]
+    end
+
+    app = Rack::ContentLength.new(app)
+
+    response = app.call(env)
+    assert_same response[1], headers
+  end
+
+	it "duplicates header hash" do
+    env = {}
+    headers = Rack::Utils::HeaderHash.new({ 'content-type' => "text/plain", "content-length" => "3" })
+		headers.freeze
+
+    app = lambda do |env|
+      [200, headers, []]
+    end
+
+    app = Rack::ContentLength.new(app)
+
+    response = app.call(env)
+    refute_same response[1], headers
+  end
 end
 
 describe Rack::Utils::Context do


### PR DESCRIPTION
The motivation/measurements/benchmarks are in `benchmark/header-hash/README.md`.

Fixes the main performance issues outlined by https://github.com/rack/rack/issues/738