### PR TITLE
Enable `Style/MethodDefParentheses` cop to avoid newly add no paren method def in the future

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ Style/FrozenStringLiteralComment:
 Style/HashSyntax:
   Enabled: true
 
+Style/MethodDefParentheses:
+  Enabled: true
+
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 

--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -48,7 +48,7 @@ table { width:100%%; }
       end
 
       private
-      def DIR_FILE_escape htmls
+      def DIR_FILE_escape(htmls)
         htmls.map { |e| Utils.escape_html(e) }
       end
     end

--- a/lib/rack/events.rb
+++ b/lib/rack/events.rb
@@ -56,26 +56,26 @@ module Rack
 
   class Events
     module Abstract
-      def on_start req, res
+      def on_start(req, res)
       end
 
-      def on_commit req, res
+      def on_commit(req, res)
       end
 
-      def on_send req, res
+      def on_send(req, res)
       end
 
-      def on_finish req, res
+      def on_finish(req, res)
       end
 
-      def on_error req, res, e
+      def on_error(req, res, e)
       end
     end
 
     class EventedBodyProxy < Rack::BodyProxy # :nodoc:
       attr_reader :request, :response
 
-      def initialize body, request, response, handlers, &block
+      def initialize(body, request, response, handlers, &block)
         super(body, &block)
         @request  = request
         @response = response
@@ -91,7 +91,7 @@ module Rack
     class BufferedResponse < Rack::Response::Raw # :nodoc:
       attr_reader :body
 
-      def initialize status, headers, body
+      def initialize(status, headers, body)
         super(status, headers)
         @body = body
       end
@@ -99,12 +99,12 @@ module Rack
       def to_a; [status, headers, body]; end
     end
 
-    def initialize app, handlers
+    def initialize(app, handlers)
       @app      = app
       @handlers = handlers
     end
 
-    def call env
+    def call(env)
       request = make_request env
       on_start request, nil
 
@@ -126,27 +126,27 @@ module Rack
 
     private
 
-    def on_error request, response, e
+    def on_error(request, response, e)
       @handlers.reverse_each { |handler| handler.on_error request, response, e }
     end
 
-    def on_commit request, response
+    def on_commit(request, response)
       @handlers.reverse_each { |handler| handler.on_commit request, response }
     end
 
-    def on_start request, response
+    def on_start(request, response)
       @handlers.each { |handler| handler.on_start request, nil }
     end
 
-    def on_finish request, response
+    def on_finish(request, response)
       @handlers.reverse_each { |handler| handler.on_finish request, response }
     end
 
-    def make_request env
+    def make_request(env)
       Rack::Request.new env
     end
 
-    def make_response status, headers, body
+    def make_response(status, headers, body)
       BufferedResponse.new status, headers, body
     end
   end

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -196,11 +196,11 @@ EOF
     end
 
     # The MIME type for the contents of the file located at @path
-    def mime_type path, default_mime
+    def mime_type(path, default_mime)
       Mime.mime_type(::File.extname(path), default_mime)
     end
 
-    def filesize path
+    def filesize(path)
       # If response_body is present, use its size.
       return response_body.bytesize if response_body
 

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -117,7 +117,7 @@ module Rack
 
         include Enumerable
 
-        def initialize tempfile
+        def initialize(tempfile)
           @tempfile = tempfile
           @mime_parts = []
           @open_files = 0
@@ -127,7 +127,7 @@ module Rack
           @mime_parts.each { |part| yield part }
         end
 
-        def on_mime_head mime_index, head, filename, content_type, name
+        def on_mime_head(mime_index, head, filename, content_type, name)
           if filename
             body = @tempfile.call(filename, content_type)
             body.binmode if body.respond_to?(:binmode)
@@ -143,11 +143,11 @@ module Rack
           check_open_files
         end
 
-        def on_mime_body mime_index, content
+        def on_mime_body(mime_index, content)
           @mime_parts[mime_index].body << content
         end
 
-        def on_mime_finish mime_index
+        def on_mime_finish(mime_index)
         end
 
         private
@@ -182,7 +182,7 @@ module Rack
         @head_regex = /(.*?#{EOL})#{EOL}/m
       end
 
-      def on_read content
+      def on_read(content)
         handle_empty_content!(content)
         @sbuf.concat content
         run_parser

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -88,7 +88,7 @@ module Rack
       #   assert_equal 'image/png,*/*', request.get_header('Accept')
       #
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-      def add_header key, v
+      def add_header(key, v)
         if v.nil?
           get_header key
         elsif has_header? key

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -168,7 +168,7 @@ module Rack
       #   assert_equal 'Accept-Encoding,Cookie', response.get_header('Vary')
       #
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-      def add_header key, v
+      def add_header(key, v)
         if v.nil?
           get_header key
         elsif has_header? key
@@ -216,7 +216,7 @@ module Rack
         get_header SET_COOKIE
       end
 
-      def set_cookie_header= v
+      def set_cookie_header=(v)
         set_header SET_COOKIE, v
       end
 
@@ -224,7 +224,7 @@ module Rack
         get_header CACHE_CONTROL
       end
 
-      def cache_control= v
+      def cache_control=(v)
         set_header CACHE_CONTROL, v
       end
 
@@ -232,7 +232,7 @@ module Rack
         get_header ETAG
       end
 
-      def etag= v
+      def etag=(v)
         set_header ETAG, v
       end
 
@@ -282,7 +282,7 @@ module Rack
       attr_reader :headers
       attr_accessor :status
 
-      def initialize status, headers
+      def initialize(status, headers)
         @status = status
         @headers = headers
       end

--- a/test/spec_events.rb
+++ b/test/spec_events.rb
@@ -7,27 +7,27 @@ module Rack
     class EventMiddleware
       attr_reader :events
 
-      def initialize events
+      def initialize(events)
         @events = events
       end
 
-      def on_start req, res
+      def on_start(req, res)
         events << [self, __method__]
       end
 
-      def on_commit req, res
+      def on_commit(req, res)
         events << [self, __method__]
       end
 
-      def on_send req, res
+      def on_send(req, res)
         events << [self, __method__]
       end
 
-      def on_finish req, res
+      def on_finish(req, res)
         events << [self, __method__]
       end
 
-      def on_error req, res, e
+      def on_error(req, res, e)
         events << [self, __method__]
       end
     end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -5,18 +5,18 @@ require 'timeout'
 
 describe Rack::Utils do
 
-  def assert_sets exp, act
+  def assert_sets(exp, act)
     exp = Set.new exp.split '&'
     act = Set.new act.split '&'
 
     assert_equal exp, act
   end
 
-  def assert_query exp, act
+  def assert_query(exp, act)
     assert_sets exp, Rack::Utils.build_query(act)
   end
 
-  def assert_nested_query exp, act
+  def assert_nested_query(exp, act)
     assert_sets exp, Rack::Utils.build_nested_query(act)
   end
 
@@ -732,9 +732,9 @@ end
 describe Rack::Utils::Context do
   class ContextTest
     attr_reader :app
-    def initialize app; @app = app; end
-    def call env; context env; end
-    def context env, app = @app; app.call(env); end
+    def initialize(app); @app = app; end
+    def call(env); context env; end
+    def context(env, app = @app); app.call(env); end
   end
   test_target1 = proc{|e| e.to_s + ' world' }
   test_target2 = proc{|e| e.to_i + 2 }


### PR DESCRIPTION
Ref https://github.com/rack/rack/pull/1549#discussion_r374383058.

If we'd not prefer the no paren method def style and avoid the style by
code review, we have a way to avoid that style by using RuboCop.