### PR TITLE
Remove `Rack::Files#response_body` as the implementation was broken.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file. For info on
 - `URLMap::INFINITY` and `URLMap::NEGATIVE_INFINITY`, in favor of `Float::INFINITY`. ([@ch1c0t](https://github.com/ch1c0t))
 - Deprecation of `Rack::File`. It will be deprecated again in rack 2.2 or 3.0. ([@rafaelfranca](https://github.com/rafaelfranca))
 - Support for Ruby 2.2 as it is well past EOL. ([@ioquatix](https://github.com/ioquatix))
+- Remove `Rack::Files#response_body` as the implementation was broken. ([#1153](https://github.com/rack/rack/pull/1153), [@ioquatix](https://github.com/ioquatix))
 
 ### Fixed
 

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -16,6 +16,13 @@ module Rack
     ALLOW_HEADER = ALLOWED_VERBS.join(', ')
     MULTIPART_BOUNDARY = 'AaB03x'
 
+    # @todo remove in 3.0
+    def self.method_added(name)
+      if name == :response_body
+        raise "#{self.class}\#response_body is no longer supported."
+      end
+    end
+
     attr_reader :root
 
     def initialize(root, headers = {}, default_mime = 'text/plain')
@@ -201,20 +208,10 @@ EOF
     end
 
     def filesize(path)
-      # If response_body is present, use its size.
-      return response_body.bytesize if response_body
-
       #   We check via File::size? whether this file provides size info
       #   via stat (e.g. /proc files often don't), otherwise we have to
       #   figure it out by reading the whole file into memory.
       ::File.size?(path) || ::File.read(path).bytesize
-    end
-
-    # By default, the response body for file requests is nil.
-    # In this case, the response body will be generated later
-    # from the file at @path
-    def response_body
-      nil
     end
   end
 end

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -300,18 +300,4 @@ e.join(File.dirname(_\r
     res.must_be :not_found?
     res.body.must_be :empty?
   end
-
-  class MyFile < Rack::File
-    def response_body
-      "hello world"
-    end
-  end
-
-  it "behaves gracefully if response_body is present" do
-    file = Rack::Lint.new MyFile.new(DOCROOT)
-    res  = Rack::MockRequest.new(file).get("/cgi/test")
-
-    res.must_be :ok?
-  end
-
 end


### PR DESCRIPTION
See https://github.com/rack/rack/pull/1153 for previous discussion.