### PR TITLE
Rework host/hostname/authority implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. For info on
 - `rack.session` request environment entry must respond to `to_hash` and return unfrozen Hash. ([@jeremyevans](https://github.com/jeremyevans))
 - Request environment cannot be frozen. ([@jeremyevans](https://github.com/jeremyevans))
 - CGI values in the request environment with non-ASCII characters must use ASCII-8BIT encoding. ([@jeremyevans](https://github.com/jeremyevans))
+- Improve SPEC/lint relating to SERVER_NAME, SERVER_PORT and HTTP_HOST. ([#1561](https://github.com/rack/rack/pull/1561), [@ioquatix](https://github.com/ioquatix))
 
 ### Added
 
@@ -37,7 +38,7 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::HeaderHash` is memoized by default. ([#1549](https://github.com/rack/rack/pull/1549), [@ioquatix](https://github.com/ioquatix))
 - `Rack::Directory` allow directory traversal inside root directory. ([#1417](https://github.com/rack/rack/pull/1417), [@ThomasSevestre](https://github.com/ThomasSevestre))
 - Sort encodings by server preference. ([#1184](https://github.com/rack/rack/pull/1184), [@ioquatix](https://github.com/ioquatix), [@wjordan](https://github.com/wjordan))
-- Rework host/hostname/authority implementation in `Rack::Request`. ([#1561](https://github.com/rack/rack/pull/1561), [@ioquatix](https://github.com/ioquatix))
+- Rework host/hostname/authority implementation in `Rack::Request`. `#host` and `#host_with_port` have been changed to correctly return IPv6 addresses formatted with square brackets, as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-3.2.2). ([#1561](https://github.com/rack/rack/pull/1561), [@ioquatix](https://github.com/ioquatix))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::HeaderHash` is memoized by default. ([#1549](https://github.com/rack/rack/pull/1549), [@ioquatix](https://github.com/ioquatix))
 - `Rack::Directory` allow directory traversal inside root directory. ([#1417](https://github.com/rack/rack/pull/1417), [@ThomasSevestre](https://github.com/ThomasSevestre))
 - Sort encodings by server preference. ([#1184](https://github.com/rack/rack/pull/1184), [@ioquatix](https://github.com/ioquatix), [@wjordan](https://github.com/wjordan))
+- Rework host/hostname/authority implementation in `Rack::Request`. ([#1561](https://github.com/rack/rack/pull/1561), [@ioquatix](https://github.com/ioquatix))
 
 ### Removed
 

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -15,6 +15,7 @@ require_relative 'rack/version'
 
 module Rack
   HTTP_HOST         = 'HTTP_HOST'
+  HTTP_PORT         = 'HTTP_PORT'
   HTTP_VERSION      = 'HTTP_VERSION'
   HTTPS             = 'HTTPS'
   PATH_INFO         = 'PATH_INFO'

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -284,15 +284,13 @@ module Rack
       end
 
       ## The <tt>SERVER_NAME</tt> must be a valid authority as defined by RFC7540.
-      assert("env[SERVER_NAME] must be a valid host") do
-        server_name = env["SERVER_NAME"]
-        URI.parse("http://#{server_name}").host == server_name rescue false
+      assert("#{env[SERVER_NAME]} must be a valid authority") do
+        URI.parse("http://#{env[SERVER_NAME]}/") rescue false
       end
 
       ## The <tt>HTTP_HOST</tt> must be a valid authority as defined by RFC7540.
-      assert("env[HTTP_HOST] must be a valid host") do
-        http_host = env["HTTP_HOST"]
-        URI.parse("http://#{http_host}/").host == http_host rescue false
+      assert("#{env[HTTP_HOST]} must be a valid authority") do
+        URI.parse("http://#{env[HTTP_HOST]}/") rescue false
       end
 
       ## The environment must not contain the keys

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -271,12 +271,29 @@ module Rack
       ## accepted specifications and must not be used otherwise.
       ##
 
-      %w[REQUEST_METHOD SERVER_NAME SERVER_PORT
-         QUERY_STRING
+      %w[REQUEST_METHOD SERVER_NAME QUERY_STRING
          rack.version rack.input rack.errors
          rack.multithread rack.multiprocess rack.run_once].each { |header|
         assert("env missing required key #{header}") { env.include? header }
       }
+
+      ## The <tt>SERVER_PORT</tt> must be an integer if set.
+      assert("env[SERVER_PORT] is not an integer") do
+        server_port = env["SERVER_PORT"]
+        server_port.nil? || (Integer(server_port) rescue false)
+      end
+
+      ## The <tt>SERVER_NAME</tt> must be a valid authority as defined by RFC7540.
+      assert("env[SERVER_NAME] must be a valid host") do
+        server_name = env["SERVER_NAME"]
+        URI.parse("http://#{server_name}").host == server_name rescue false
+      end
+
+      ## The <tt>HTTP_HOST</tt> must be a valid authority as defined by RFC7540.
+      assert("env[HTTP_HOST] must be a valid host") do
+        http_host = env["HTTP_HOST"]
+        URI.parse("http://#{http_host}/").host == http_host rescue false
+      end
 
       ## The environment must not contain the keys
       ## <tt>HTTP_CONTENT_TYPE</tt> or <tt>HTTP_CONTENT_LENGTH</tt>

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -117,17 +117,19 @@ module Rack
       ##                         follows the <tt>?</tt>, if any. May be
       ##                         empty, but is always required!
 
-      ## <tt>SERVER_NAME</tt>, <tt>SERVER_PORT</tt>::
-      ##                        When combined with <tt>SCRIPT_NAME</tt> and
+      ## <tt>SERVER_NAME</tt>:: When combined with <tt>SCRIPT_NAME</tt> and
       ##                        <tt>PATH_INFO</tt>, these variables can be
       ##                        used to complete the URL. Note, however,
       ##                        that <tt>HTTP_HOST</tt>, if present,
       ##                        should be used in preference to
       ##                        <tt>SERVER_NAME</tt> for reconstructing
       ##                        the request URL.
-      ##                        <tt>SERVER_NAME</tt> and <tt>SERVER_PORT</tt>
-      ##                        can never be empty strings, and so
-      ##                        are always required.
+      ##                        <tt>SERVER_NAME</tt> can never be an empty
+      ##                        string, and so is always required.
+
+      ## <tt>SERVER_PORT</tt>:: An optional +Integer+ which is the port the
+      ##                        server is running on. Should be specified if
+      ##                        the server is running on a non-standard port.
 
       ## <tt>HTTP_</tt> Variables:: Variables corresponding to the
       ##                            client-supplied HTTP request
@@ -280,7 +282,7 @@ module Rack
       ## The <tt>SERVER_PORT</tt> must be an integer if set.
       assert("env[SERVER_PORT] is not an integer") do
         server_port = env["SERVER_PORT"]
-        server_port.nil? || (Integer(server_port) rescue false)
+        server_port.nil? || server_port.is_a?(Integer)
       end
 
       ## The <tt>SERVER_NAME</tt> must be a valid authority as defined by RFC7540.

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -279,10 +279,10 @@ module Rack
         assert("env missing required key #{header}") { env.include? header }
       }
 
-      ## The <tt>SERVER_PORT</tt> must be an integer if set.
-      assert("env[SERVER_PORT] is not an integer") do
+      ## The <tt>SERVER_PORT</tt> must be an Integer if set.
+      assert("env[SERVER_PORT] is not an Integer") do
         server_port = env["SERVER_PORT"]
-        server_port.nil? || server_port.is_a?(Integer)
+        server_port.nil? || (Integer(server_port) rescue false)
       end
 
       ## The <tt>SERVER_NAME</tt> must be a valid authority as defined by RFC7540.

--- a/lib/rack/recursive.rb
+++ b/lib/rack/recursive.rb
@@ -19,7 +19,7 @@ module Rack
       @env[PATH_INFO]       = @url.path
       @env[QUERY_STRING]    = @url.query  if @url.query
       @env[HTTP_HOST]       = @url.host   if @url.host
-      @env["HTTP_PORT"]     = @url.port   if @url.port
+      @env[HTTP_PORT]       = @url.port   if @url.port
       @env[RACK_URL_SCHEME] = @url.scheme if @url.scheme
 
       super "forwarding to #{url}"

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -219,7 +219,7 @@ module Rack
         end
       end
 
-      # The authority of the incoming reuqest as defined by RFC2976.
+      # The authority of the incoming request as defined by RFC3976.
       # https://tools.ietf.org/html/rfc3986#section-3.2
       #
       # In HTTP/1, this is the `host` header.

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -403,6 +403,7 @@ module Rack
       def form_data?
         type = media_type
         meth = get_header(RACK_METHODOVERRIDE_ORIGINAL_METHOD) || get_header(REQUEST_METHOD)
+
         (meth == POST && type.nil?) || FORM_DATA_MEDIA_TYPES.include?(type)
       end
 
@@ -590,7 +591,22 @@ module Rack
         value ? value.strip.split(/[,\s]+/) : []
       end
 
-      AUTHORITY = /(?<host>(\[(?<ip6>.*)\])|(?<ip4>[\d\.]+)|(?<name>[a-zA-Z0-9\.\-]+))(:(?<port>\d+))?/
+      AUTHORITY = /
+        # The host:
+        (?<host>
+          # An IPv6 address:
+          (\[(?<ip6>.*)\])
+          |
+          # An IPv4 address:
+          (?<ip4>[\d\.]+)
+          |
+          # A hostname:
+          (?<name>[a-zA-Z0-9\.\-]+)
+        )
+        # The optional port:
+        (:(?<port>\d+))?
+      /x
+
       private_constant :AUTHORITY
 
       def split_authority(authority)

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -129,11 +129,23 @@ module Rack
       # to include the port in a generated URI.
       DEFAULT_PORTS = { 'http' => 80, 'https' => 443, 'coffee' => 80 }
 
+      # The address of the client which connected to the proxy.
+      HTTP_X_FORWARDED_FOR = 'HTTP_X_FORWARDED_FOR'
+
+      # The contents of the host/:authority header sent to the proxy.
+      HTTP_X_FORWARDED_HOST = 'HTTP_X_FORWARDED_HOST'
+
+      # The value of the scheme sent to the proxy.
       HTTP_X_FORWARDED_SCHEME = 'HTTP_X_FORWARDED_SCHEME'
-      HTTP_X_FORWARDED_PROTO  = 'HTTP_X_FORWARDED_PROTO'
-      HTTP_X_FORWARDED_HOST   = 'HTTP_X_FORWARDED_HOST'
-      HTTP_X_FORWARDED_PORT   = 'HTTP_X_FORWARDED_PORT'
-      HTTP_X_FORWARDED_SSL    = 'HTTP_X_FORWARDED_SSL'
+
+      # The protocol used to connect to the proxy.
+      HTTP_X_FORWARDED_PROTO = 'HTTP_X_FORWARDED_PROTO'
+
+      # The port used to connect to the proxy.
+      HTTP_X_FORWARDED_PORT = 'HTTP_X_FORWARDED_PORT'
+
+      # Another way for specifing https scheme was used.
+      HTTP_X_FORWARDED_SSL = 'HTTP_X_FORWARDED_SSL'
 
       def body;            get_header(RACK_INPUT)                         end
       def script_name;     get_header(SCRIPT_NAME).to_s                   end

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -301,7 +301,10 @@ module Rack
         split_authority(self.authority)[0]
       end
 
-      # Returns an address suitable for being used with `getaddrinfo`.
+      # Returns an address suitable for being to resolve to an address.
+      # In the case of a domain name or IPv4 address, the result is the same
+      # as +host+. In the case of IPv6 or future address formats, the square
+      # brackets are removed.
       def hostname
         split_authority(self.authority)[1]
       end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -145,7 +145,7 @@ class RackRequestTest < Minitest::Spec
     env = Rack::MockRequest.env_for("/")
     env.delete("SERVER_NAME")
     req = make_request(env)
-    req.host.must_equal ""
+    req.host.must_be_nil
   end
 
   it "figure out the correct port" do
@@ -220,7 +220,7 @@ class RackRequestTest < Minitest::Spec
     req.host_with_port.must_equal "example.org:9292"
 
     req = make_request \
-      Rack::MockRequest.env_for("/", "SERVER_NAME" => "example.org", "SERVER_PORT" => "")
+      Rack::MockRequest.env_for("/", "SERVER_NAME" => "example.org")
     req.host_with_port.must_equal "example.org"
 
     req = make_request \

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -114,27 +114,33 @@ class RackRequestTest < Minitest::Spec
     req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "www2.example.org")
     req.host.must_equal "www2.example.org"
+    req.hostname.must_equal "www2.example.org"
 
     req = make_request \
       Rack::MockRequest.env_for("/", "SERVER_NAME" => "example.org", "SERVER_PORT" => "9292")
     req.host.must_equal "example.org"
+    req.hostname.must_equal "example.org"
 
     req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org:9292")
     req.host.must_equal "example.org"
+    req.hostname.must_equal "example.org"
 
     req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[2001:db8:cafe::17]:47011")
-    req.host.must_equal "2001:db8:cafe::17"
+    req.host.must_equal "[2001:db8:cafe::17]"
+    req.hostname.must_equal "2001:db8:cafe::17"
 
     req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "2001:db8:cafe::17")
-    req.host.must_equal "2001:db8:cafe::17"
+    req.host.must_equal "[2001:db8:cafe::17]"
+    req.hostname.must_equal "2001:db8:cafe::17"
 
     env = Rack::MockRequest.env_for("/", "SERVER_ADDR" => "192.168.1.1", "SERVER_PORT" => "9292")
     env.delete("SERVER_NAME")
     req = make_request(env)
     req.host.must_equal "192.168.1.1"
+    req.hostname.must_equal "192.168.1.1"
 
     env = Rack::MockRequest.env_for("/")
     env.delete("SERVER_NAME")
@@ -175,7 +181,7 @@ class RackRequestTest < Minitest::Spec
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "HTTP_X_FORWARDED_SSL" => "on")
     req.port.must_equal 443
 
-     req = make_request \
+    req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "HTTP_X_FORWARDED_PROTO" => "https")
     req.port.must_equal 443
 
@@ -227,7 +233,7 @@ class RackRequestTest < Minitest::Spec
 
     req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "2001:db8:cafe::17")
-    req.host_with_port.must_equal "2001:db8:cafe::17"
+    req.host_with_port.must_equal "[2001:db8:cafe::17]"
 
     req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "SERVER_PORT" => "9393")


### PR DESCRIPTION
Attempt to rework the host/hostname/authority methods to better follow the RFCs regarding host/authority, along with URI specifications for host/hostname. Fixes #1560.