### PR TITLE
Refactor and document Directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Changed
 
-- `QueryParser#parse_nested_query` uses original backtrace when reraising exception with new class ([@jeremyevans](https://github.com/jeremyevans))
+- `Directory` uses a streaming approach, significantly improving time to first byte for large directories. ([@jeremyevans](https://github.com/jeremyevans))
+- `Directory` no longer include a Parent directory link in the root directory index. ([@jeremyevans](https://github.com/jeremyevans))
+- `QueryParser#parse_nested_query` uses original backtrace when reraising exception with new class. ([@jeremyevans](https://github.com/jeremyevans))
 - `ConditionalGet` follows RFC 7232 precedence if both If-None-Match and If-Modified-Since headers are provided. ([@jeremyevans](https://github.com/jeremyevans))
 - `.ru` files supports the `frozen-string-literal` magic comment. ([@eregon](https://github.com/eregon))
 - Rely on autoload to load constants instead of requiring internal files, make sure to require 'rack' and not just 'rack/...'. ([@jeremyevans](https://github.com/jeremyevans))
@@ -40,6 +42,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Removed
 
+- `Directory#path` as it was not used and always returned nil. ([@jeremyevans](https://github.com/jeremyevans))
 - `BodyProxy#each` as it was only needed to work around a bug in Ruby <1.9.3. ([@jeremyevans](https://github.com/jeremyevans))
 - `Session::Abstract::SessionHash#transform_keys`, no longer needed. (pavel)
 - `URLMap::INFINITY` and `URLMap::NEGATIVE_INFINITY`, in favor of `Float::INFINITY`. ([@ch1c0t](https://github.com/ch1c0t))
@@ -49,6 +52,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Fixed
 
+- `Directory` correctly handles root paths containing glob metacharacters. ([@jeremyevans](https://github.com/jeremyevans))
 - `Cascade` uses a new response object for each call if initialized with no apps. ([@jeremyevans](https://github.com/jeremyevans))
 - `BodyProxy` correctly delegates keyword arguments to the body object on Ruby 2.7+. ([@jeremyevans](https://github.com/jeremyevans))
 - `BodyProxy#method` correctly handles methods delegated to the body object. ([@jeremyevans](https://github.com/jeremyevans))


### PR DESCRIPTION
The previous implementation of directory listings was inefficient for large
directories.  First it built a bunch of file entry strings, then it joined
them into a large string containing all entries, then that was interpolated
into the header and footer creating another large string.  Then each_line was
called on the large string, creating one string per line.

This switches to a streaming approach for directory listings.  We yield the
header, then one string for each listing, then the footer.

Testing with puma with a directory with 10,000 files with 100 byte file
names, directory listing before took 3.5 seconds, with 900ms before
first byte.  After this commit, it takes 2.1 seconds, with 10ms before
the first byte.  Note that total time is not hugely different, because
most of the time is probably taken in stat(2) calls.  Time to first byte is
greatly improved, though.

Remove Directory#path.  path is used as a local variable, but the instance
variable is never set, so the value would always be nil.

The previous approach used a glob for getting files.  That resulted in
broken behavior when the path being served includes glob metacharacters.
Switch to a `Dir.foreach` approach to avoid that issue.  Because the glob
skips hidden files, continue to skip files starting with a period.  Note
that Directory will still serve hidden files and display directory listings
for hidden directories, so this should not be considered a security feature.

As a small behavior change, do not show a Parent directory link for the
root directory, since it takes you to the same page.

Switch list_path to not use exceptions for flow control.  Remove all
exception handling, and switch to using Directory#stat, which already handles
the same exceptions.  This has the advantage so that if a non-file,
non-directory is requested, you get a valid 404 rack response instead of
nil.