### PR TITLE
Make Request#params not rescue EOFError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Changed
 
+- `Request#params` no longer rescues EOFError. ([@jeremyevans](https://github.com/jeremyevans))
 - `Directory` uses a streaming approach, significantly improving time to first byte for large directories. ([@jeremyevans](https://github.com/jeremyevans))
-- `Directory` no longer include a Parent directory link in the root directory index. ([@jeremyevans](https://github.com/jeremyevans))
+- `Directory` no longer includes a Parent directory link in the root directory index. ([@jeremyevans](https://github.com/jeremyevans))
 - `QueryParser#parse_nested_query` uses original backtrace when reraising exception with new class. ([@jeremyevans](https://github.com/jeremyevans))
 - `ConditionalGet` follows RFC 7232 precedence if both If-None-Match and If-Modified-Since headers are provided. ([@jeremyevans](https://github.com/jeremyevans))
 - `.ru` files supports the `frozen-string-literal` magic comment. ([@eregon](https://github.com/eregon))

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -374,8 +374,6 @@ module Rack
       # Note that modifications will not be persisted in the env. Use update_param or delete_param if you want to destructively modify params.
       def params
         self.GET.merge(self.POST)
-      rescue EOFError
-        self.GET.dup
       end
 
       # Destructively update a parameter, whether it's in GET and/or POST. Returns nil.

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -485,16 +485,6 @@ class RackRequestTest < Minitest::Spec
     req.POST.must_equal "foo" => "bar", "quux" => "bla"
   end
 
-  it "have params only return GET if POST cannot be processed" do
-    obj = Object.new
-    def obj.read(*) raise EOFError end
-    def obj.set_encoding(*) end
-    def obj.rewind(*) end
-    req = make_request Rack::MockRequest.env_for("/", 'REQUEST_METHOD' => 'POST', :input => obj)
-    req.params.must_equal req.GET
-    req.params.wont_be_same_as req.GET
-  end
-
   it "get value by key from params with #[]" do
     req = make_request \
       Rack::MockRequest.env_for("?foo=quux")


### PR DESCRIPTION
There was no indication why this was done originally, and it is
possible that it will rely in silent data loss.

Fixes #761