### PR TITLE
Rework `Request#ip` to handle empty `forwarded_for`.

### DIFF
--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1270,6 +1270,12 @@ EOF
 
     res = mock.get '/', 'REMOTE_ADDR' => '1.2.3.4,3.4.5.6'
     res.body.must_equal '1.2.3.4'
+
+    res = mock.get '/', 'REMOTE_ADDR' => '127.0.0.1'
+    res.body.must_equal '127.0.0.1'
+
+    res = mock.get '/', 'REMOTE_ADDR' => '127.0.0.1,127.0.0.1'
+    res.body.must_equal '127.0.0.1'
   end
 
   it 'deals with proxies' do


### PR DESCRIPTION
Fixes #1576.

This also raises the question, should we put `REMOTE_ADDR` in `lint.rb`? Because it's unclear how it should be defined. But it looks like a comma delimited list of addresses.