### PR TITLE
Cleanups since master is 2.3+

### DIFF
--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -25,7 +25,7 @@ module Rack
       end
 
       def scheme
-        @scheme ||= parts.first && parts.first.downcase
+        @scheme ||= parts.first&.downcase
       end
 
       def params

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -63,13 +63,9 @@ module Rack
     def pretty(env, exception)
       req = Rack::Request.new(env)
 
-      # This double assignment is to prevent an "unused variable" warning on
-      # Ruby 1.9.3.  Yes, it is dumb, but I don't like Ruby yelling at me.
-      path = path = (req.script_name + req.path_info).squeeze("/")
+      path = (req.script_name + req.path_info).squeeze("/")
 
-      # This double assignment is to prevent an "unused variable" warning on
-      # Ruby 1.9.3.  Yes, it is dumb, but I don't like Ruby yelling at me.
-      frames = frames = exception.backtrace.map { |line|
+      frames = exception.backtrace.map { |line|
         frame = OpenStruct.new
         if line =~ /(.*?):(\d+)(:in `(.*)')?/
           frame.filename = $1

--- a/lib/rack/show_status.rb
+++ b/lib/rack/show_status.rb
@@ -23,15 +23,11 @@ module Rack
 
       # client or server error, or explicit message
       if (status.to_i >= 400 && empty) || env[RACK_SHOWSTATUS_DETAIL]
-        # This double assignment is to prevent an "unused variable" warning on
-        # Ruby 1.9.3.  Yes, it is dumb, but I don't like Ruby yelling at me.
-        req = req = Rack::Request.new(env)
+        req = Rack::Request.new(env)
 
         message = Rack::Utils::HTTP_STATUS_CODES[status.to_i] || status.to_s
 
-        # This double assignment is to prevent an "unused variable" warning on
-        # Ruby 1.9.3.  Yes, it is dumb, but I don't like Ruby yelling at me.
-        detail = detail = env[RACK_SHOWSTATUS_DETAIL] || message
+        detail = env[RACK_SHOWSTATUS_DETAIL] || message
 
         body = @template.result(binding)
         size = body.bytesize

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -152,7 +152,7 @@ module Rack
       end.compact.sort_by do |match, quality|
         (match.split('/', 2).count('*') * -10) + quality
       end.last
-      matches && matches.first
+      matches&.first
     end
 
     ESCAPE_HTML = {


### PR DESCRIPTION
- Use some safe navigation operator(Not sure if this is considered cosmetic)
- Cleanup old "unused variable" comments and hack, this doesn't seem to warn 2.3 onwards