### PR TITLE
Double assignment is still needed to prevent an "unused variable" warning

### DIFF
--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -63,9 +63,13 @@ module Rack
     def pretty(env, exception)
       req = Rack::Request.new(env)
 
-      path = (req.script_name + req.path_info).squeeze("/")
+      # This double assignment is to prevent an "unused variable" warning.
+      # Yes, it is dumb, but I don't like Ruby yelling at me.
+      path = path = (req.script_name + req.path_info).squeeze("/")
 
-      frames = exception.backtrace.map { |line|
+      # This double assignment is to prevent an "unused variable" warning.
+      # Yes, it is dumb, but I don't like Ruby yelling at me.
+      frames = frames = exception.backtrace.map { |line|
         frame = OpenStruct.new
         if line =~ /(.*?):(\d+)(:in `(.*)')?/
           frame.filename = $1

--- a/lib/rack/show_status.rb
+++ b/lib/rack/show_status.rb
@@ -23,11 +23,15 @@ module Rack
 
       # client or server error, or explicit message
       if (status.to_i >= 400 && empty) || env[RACK_SHOWSTATUS_DETAIL]
-        req = Rack::Request.new(env)
+        # This double assignment is to prevent an "unused variable" warning.
+        # Yes, it is dumb, but I don't like Ruby yelling at me.
+        req = req = Rack::Request.new(env)
 
         message = Rack::Utils::HTTP_STATUS_CODES[status.to_i] || status.to_s
 
-        detail = env[RACK_SHOWSTATUS_DETAIL] || message
+        # This double assignment is to prevent an "unused variable" warning.
+        # Yes, it is dumb, but I don't like Ruby yelling at me.
+        detail = detail = env[RACK_SHOWSTATUS_DETAIL] || message
 
         body = @template.result(binding)
         size = body.bytesize


### PR DESCRIPTION
That warning is still raised on latest Ruby.

```
% bundle exec ruby -w -Itest test/spec_show_exceptions.rb test/spec_show_status.rb
/Users/kamipo/src/github.com/rack/rack/lib/rack/show_exceptions.rb:66: warning: assigned but unused variable - path
/Users/kamipo/src/github.com/rack/rack/lib/rack/show_exceptions.rb:68: warning: assigned but unused variable - frames
Run options: --seed 23328

# Running:

........

Finished in 0.240203s, 33.3052 runs/s, 374.6831 assertions/s.

8 runs, 90 assertions, 0 failures, 0 errors, 0 skips

% bundle exec ruby -w -Itest test/spec_show_status.rb
/Users/kamipo/src/github.com/rack/rack/lib/rack/show_status.rb:26: warning: assigned but unused variable - req
/Users/kamipo/src/github.com/rack/rack/lib/rack/show_status.rb:30: warning: assigned but unused variable - detail
Run options: --seed 41036

# Running:

.......

Finished in 0.061453s, 113.9082 runs/s, 829.9025 assertions/s.

7 runs, 51 assertions, 0 failures, 0 errors, 0 skips
```