### PR TITLE
Require the response headers be an unfrozen hash in SPEC

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -268,7 +268,7 @@ This is an HTTP status. It must be an Integer greater than or equal to
 
 === The Headers
 
-The header must respond to +each+, and yield values of key and value.
+The headers must be a unfrozen Hash.
 The header keys must be Strings.
 Special headers starting "rack." are for communicating with the
 server, and must not be sent back to the client.

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -676,13 +676,17 @@ module Rack
       ##
       ## === The Headers
       ##
-      def check_headers(header)
-        ## The header must respond to +each+, and yield values of key and value.
-        unless header.respond_to? :each
-          raise LintError, "headers object should respond to #each, but doesn't (got #{header.class} as headers)"
+      def check_headers(headers)
+        ## The headers must be a unfrozen Hash.
+        unless headers.kind_of?(Hash)
+          raise LintError, "headers object should be a hash, but isn't (got #{headers.class} as headers)"
+        end
+        
+        if headers.frozen?
+          raise LintError, "headers object should not be frozen, but is"
         end
 
-        header.each { |key, value|
+        headers.each { |key, value|
           ## The header keys must be Strings.
           unless key.kind_of? String
             raise LintError, "header key must be a string, was #{key.class}"

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -284,15 +284,24 @@ describe Rack::Lint do
   end
 
   it "notice header errors" do
+    obj = Object.new
+    def obj.each; end
     lambda {
       io = StringIO.new('a')
       io.binmode
       Rack::Lint.new(lambda { |env|
                        env['rack.input'].each{ |x| }
-                       [200, Object.new, []]
+                       [200, obj, []]
                      }).call(env({ "rack.input" => io }))
     }.must_raise(Rack::Lint::LintError).
-      message.must_equal "headers object should respond to #each, but doesn't (got Object as headers)"
+      message.must_equal "headers object should be a hash, but isn't (got Object as headers)"
+    lambda {
+      Rack::Lint.new(lambda { |env|
+                       [200, {}.freeze, []]
+                     }).call(env({}))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "headers object should not be frozen, but is"
+
 
     lambda {
       Rack::Lint.new(lambda { |env|
@@ -364,10 +373,13 @@ describe Rack::Lint do
                      [200, { "Foo-Bar" => "one\ntwo\nthree", "Content-Length" => "0", "Content-Type" => "text/plain" }, []]
                    }).call(env({})).first.must_equal 200
 
-    # non-Hash header responses.must_be :allowed?
-    Rack::Lint.new(lambda { |env|
+    lambda {
+      Rack::Lint.new(lambda { |env|
                      [200, [%w(Content-Type text/plain), %w(Content-Length 0)], []]
-                   }).call(env({})).first.must_equal 200
+                     }).call(env({}))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal "headers object should be a hash, but isn't (got Array as headers)"
+
   end
 
   it "notice content-type errors" do

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -178,7 +178,7 @@ describe Rack::Handler::WEBrick do
     Rack::Lint.new(lambda{ |req|
       [
         200,
-        [ [ "rack.hijack", io_lambda ] ],
+        { "rack.hijack" => io_lambda },
         [""]
       ]
     })


### PR DESCRIPTION
This is stricter than what was previously required.  However,
non-hash response headers would break most of the middleware
that accesses response headers.

Middleware in many cases adds or removes headers, so require
the hash not be frozen, so that this can be done efficiently.

Fixes #1222