### PR TITLE
Relax parsing restrictions around host and hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. For info on
 
 ## [2.3.0] - Unreleased
 
+- Relax validations around `Rack::Request#host` and `Rack::Request#hostname`. ([#1606](https://github.com/rack/rack/issues/1606), [@pvande](https://github.com/pvande))
+
 ## [2.2.2] - 2020-02-11
 
 ### Fixed

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -598,35 +598,29 @@ module Rack
         value ? value.strip.split(/[,\s]+/) : []
       end
 
-      AUTHORITY = /^
-        # The host:
+      AUTHORITY = /
+        \A
         (?<host>
-          # An IPv6 address:
-          (\[(?<ip6>.*)\])
+          # Match IPv6 as a string of hex digits and colons in square brackets
+          \[(?<address>(?<ipv6>.*))\]
           |
-          # An IPv4 address:
-          (?<ip4>[\d\.]+)
+          # Match IPv4 as four dot-separated groups of digits
+          (?<address>(?<ipv4>[\d.]{7,}))
           |
-          # A hostname:
-          (?<name>[a-zA-Z0-9\.\-]+)
+          # Match any other string as a hostname
+          (?<address>(?<hostname>.*?))
         )
-        # The optional port:
         (:(?<port>\d+))?
-      $/x
+        \Z
+      /x
 
       private_constant :AUTHORITY
 
       def split_authority(authority)
-        if match = AUTHORITY.match(authority)
-          if address = match[:ip6]
-            return match[:host], address, match[:port]&.to_i
-          else
-            return match[:host], match[:host], match[:port]&.to_i
-          end
-        end
+        return [] if authority.nil?
 
-        # Give up!
-        return authority, authority, nil
+        match = AUTHORITY.match(authority)
+        return match[:host], match[:address], match[:port]&.to_i
       end
 
       def reject_trusted_ip_addresses(ip_addresses)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -122,6 +122,36 @@ class RackRequestTest < Minitest::Spec
     req.hostname.must_equal "123foo.example.com"
 
     req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "♡.com")
+    req.host.must_equal "♡.com"
+    req.hostname.must_equal "♡.com"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "♡.com:80")
+    req.host.must_equal "♡.com"
+    req.hostname.must_equal "♡.com"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "nic.谷歌")
+    req.host.must_equal "nic.谷歌"
+    req.hostname.must_equal "nic.谷歌"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "nic.谷歌:80")
+    req.host.must_equal "nic.谷歌"
+    req.hostname.must_equal "nic.谷歌"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "technically_invalid.example.com")
+    req.host.must_equal "technically_invalid.example.com"
+    req.hostname.must_equal "technically_invalid.example.com"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "technically_invalid.example.com:80")
+    req.host.must_equal "technically_invalid.example.com"
+    req.hostname.must_equal "technically_invalid.example.com"
+
+    req = make_request \
       Rack::MockRequest.env_for("/", "SERVER_NAME" => "example.org", "SERVER_PORT" => "9292")
     req.host.must_equal "example.org"
     req.hostname.must_equal "example.org"


### PR DESCRIPTION
This approach allows us to match and process any potential input and still meet the contractual requirements of `Request#split_authority` _without_ requiring the input to be well-formed or RFC-compliant.  In turn, this eliminates unexpected failures on invalid-but-functional inputs.

If we deemed it necessary to do validation (particularly on IP addresses), the `AUTHORITY` regex still provides enough context on which validations should apply, though doing so would require some consideration on what should be returned upon validation failure.

If validations can be ruled unnecessary – I suspect this should be the case – the implementation could be replaced by the semantically identical:

``` ruby
def split_authority(authority)
  /\A(?<host>\[\g<addr>\]|(?<addr>.*?))(:(?<port>\d+))?\Z/ =~ authority
  return host, addr, port&.to_i
end
```

This gives up differentiation between IPv6, IPv4, and DNS addresses, but is arguably simpler.

(Resolves #1604)