### PR TITLE
Ensure that multiline input doesn't cause Rack::Request to break

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -612,7 +612,7 @@ module Rack
         )
         (:(?<port>\d+))?
         \Z
-      /x
+      /mx
 
       private_constant :AUTHORITY
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -603,6 +603,9 @@ module Rack
       AUTHORITY = /
         \A
         (?<host>
+          # Match IPvFuture as per RFC 3986
+          \[(?<address>(?<ipvfuture>v\h+ [[:alnum:]._~\-!$&'()*+,;=:]+))\]
+          |
           # Match IPv6 as a string of non-blank characters in square brackets
           \[(?<address>(?<ipv6>[[:graph:]]*))\]
           |

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -152,6 +152,16 @@ class RackRequestTest < Minitest::Spec
     req.hostname.must_equal "technically_invalid.example.com"
 
     req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "why-keep-trailing-newlines.co.uk\n")
+    req.host.must_equal "why-keep-trailing-newlines.co.uk"
+    req.hostname.must_equal "why-keep-trailing-newlines.co.uk"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "really\nbad\ninput")
+    req.host.must_equal "really\nbad\ninput"
+    req.hostname.must_equal "really\nbad\ninput"
+
+    req = make_request \
       Rack::MockRequest.env_for("/", "SERVER_NAME" => "example.org", "SERVER_PORT" => "9292")
     req.host.must_equal "example.org"
     req.hostname.must_equal "example.org"

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -167,6 +167,11 @@ class RackRequestTest < Minitest::Spec
     req.hostname.must_equal "example.org"
 
     req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[v00000.fe80::a+en1]:47011")
+    req.host.must_equal "[v00000.fe80::a+en1]"
+    req.hostname.must_equal "v00000.fe80::a+en1"
+
+    req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[2001:db8:cafe::17]:47011")
     req.host.must_equal "[2001:db8:cafe::17]"
     req.hostname.must_equal "2001:db8:cafe::17"

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -157,11 +157,6 @@ class RackRequestTest < Minitest::Spec
     req.hostname.must_equal "why-keep-trailing-newlines.co.uk"
 
     req = make_request \
-      Rack::MockRequest.env_for("/", "HTTP_HOST" => "really\nbad\ninput")
-    req.host.must_equal "really\nbad\ninput"
-    req.hostname.must_equal "really\nbad\ninput"
-
-    req = make_request \
       Rack::MockRequest.env_for("/", "SERVER_NAME" => "example.org", "SERVER_PORT" => "9292")
     req.host.must_equal "example.org"
     req.hostname.must_equal "example.org"
@@ -180,6 +175,71 @@ class RackRequestTest < Minitest::Spec
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "2001:db8:cafe::17")
     req.host.must_equal "[2001:db8:cafe::17]"
     req.hostname.must_equal "2001:db8:cafe::17"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[::]:47011")
+    req.host.must_equal "[::]"
+    req.hostname.must_equal "::"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[1111:2222:3333:4444:5555:6666:123.123.123.123]")
+    req.host.must_equal "[1111:2222:3333:4444:5555:6666:123.123.123.123]"
+    req.hostname.must_equal "1111:2222:3333:4444:5555:6666:123.123.123.123"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[1111:2222:3333:4444:5555:6666:123.123.123.123]:47011")
+    req.host.must_equal "[1111:2222:3333:4444:5555:6666:123.123.123.123]"
+    req.hostname.must_equal "1111:2222:3333:4444:5555:6666:123.123.123.123"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "0.0.0.0")
+    req.host.must_equal "0.0.0.0"
+    req.hostname.must_equal "0.0.0.0"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "0.0.0.0:47011")
+    req.host.must_equal "0.0.0.0"
+    req.hostname.must_equal "0.0.0.0"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "255.255.255.255")
+    req.host.must_equal "255.255.255.255"
+    req.hostname.must_equal "255.255.255.255"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "255.255.255.255:47011")
+    req.host.must_equal "255.255.255.255"
+    req.hostname.must_equal "255.255.255.255"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "really\nbad\ninput")
+    req.host.must_be_nil
+    req.hostname.must_be_nil
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[0]")
+    req.host.must_be_nil
+    req.hostname.must_be_nil
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[:::]")
+    req.host.must_be_nil
+    req.hostname.must_be_nil
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[1111:2222:3333:4444:5555:6666:7777:88888]")
+    req.host.must_be_nil
+    req.hostname.must_be_nil
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "0.0..0.0")
+    req.host.must_be_nil
+    req.hostname.must_be_nil
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "255.255.255.0255")
+    req.host.must_be_nil
+    req.hostname.must_be_nil
 
     env = Rack::MockRequest.env_for("/")
     env.delete("SERVER_NAME")


### PR DESCRIPTION
As written, the `AUTHORITY` regex intends to match the entire input string, and the sole usage of it expects that it will always return a match.  After some consideration, there *is* a way to feed it input that will not match, causing errors on the subsequent line.

The issue at hand is that `.` in a regular expression matches everything *except newlines* by default, meaning that even the most generous regular expression with start- and end-of-string anchors (`/\A.*\z/`) cannot match a multiline string.  The solution, then, is to use the `m` (multiline) flag on the regex, which allows `.` to match newlines as well.

This change also adds a test for the behavior of the `\Z` anchor (end-of-chomped-string) vs the `\z` anchor (actual end-of-string).