### PR TITLE
README: Link to the specification

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -13,7 +13,7 @@ the simplest way possible, it unifies and distills the API for web
 servers, web frameworks, and software in between (the so-called
 middleware) into a single method call.
 
-The exact details of this are described in the \Rack specification,
+The exact details of this are described in the {\Rack specification}[https://github.com/rack/rack/blob/master/SPEC.rdoc],
 which all \Rack applications should conform to.
 
 == Supported web servers


### PR DESCRIPTION
We could alternatively use `rdoc-ref` but then Github doesn't render it
as a link. I think it's important that people have a link to the
specification when viewing the README on Github as that is the de-facto
front page of the project.