### PR TITLE
Fully qualify ::Rack::Utils usages

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -261,7 +261,7 @@ module Rack
         string = get_header(HTTP_COOKIE)
 
         unless string == get_header(RACK_REQUEST_COOKIE_STRING)
-          hash.replace Utils.parse_cookies_header(string)
+          hash.replace ::Rack::Utils.parse_cookies_header(string)
           set_header(RACK_REQUEST_COOKIE_STRING, string)
         end
 
@@ -583,7 +583,7 @@ module Rack
       end
 
       def query_parser
-        Utils.default_query_parser
+        ::Rack::Utils.default_query_parser
       end
 
       def parse_query(qs, d = '&')

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -21,7 +21,7 @@ module Rack
     end
 
     CHUNKED = 'chunked'
-    STATUS_WITH_NO_ENTITY_BODY = Utils::STATUS_WITH_NO_ENTITY_BODY
+    STATUS_WITH_NO_ENTITY_BODY = ::Rack::Utils::STATUS_WITH_NO_ENTITY_BODY
 
     attr_accessor :length, :status, :body
     attr_reader :headers
@@ -41,7 +41,7 @@ module Rack
     # Providing a body which responds to #to_str is legacy behaviour.
     def initialize(body = nil, status = 200, headers = {})
       @status = status.to_i
-      @headers = Utils::HeaderHash[headers]
+      @headers = ::Rack::Utils::HeaderHash[headers]
 
       @writer = self.method(:append)
 


### PR DESCRIPTION
As of ab41dccfe287b7d2589778308cb297eb039e88c6 it's expected that consumers of Rack require the full library so that `lib/rack.rb` can properly setup autoloading of constants. However, there exist apps and other libraries with dependencies on Rack which do not do that. They instead require in only the bits they think they need, e.g., `require "rack/response"`. Those consumers need to update their usage so that autoloading works as expected. But in the meantime, they can raise confusing errors like `uninitialized constant Rack::Response::Utils` because we're not fully-qualifying the usage of the `Utils` constant.

Changing these instances to also fully qualify means downstream consumer will at least get a more meaningful error: `uninitialized constant Rack::Utils`. They still need to make a change, but hopefully with a little less confusion as to why they're seeing the message in the first place.

_NOTE:_ There are a number of non-qualified usages of the `Utils` constant throughout `lib/`. I've only fully-qualified the usages in `lib/rack/request.rb` and `lib/rack/response.rb` because those are two specific modules that I've seen directly required into various apps and libraries. Perhaps we should update all usages of the `Utils` constant? Or... perhaps this entire idea is not desired and we should remove existing fully-qualified usages? I'm open to either, but we should probably shoot for consistency, which ever route we choose.

See also: https://github.com/cvonkleist/encrypted_cookie/pull/16