### PR TITLE
Fix possible thread safety issue in Rack::Session::Pool

### DIFF
--- a/lib/rack/session/pool.rb
+++ b/lib/rack/session/pool.rb
@@ -36,17 +36,17 @@ module Rack
         @mutex = Mutex.new
       end
 
-      def generate_sid
+      def generate_sid(*args, use_mutex: true)
         loop do
-          sid = super
-          break sid unless @pool.key? sid.private_id
+          sid = super(*args)
+          break sid unless use_mutex ? @mutex.synchronize { @pool.key? sid.private_id } : @pool.key?(sid.private_id)
         end
       end
 
       def find_session(req, sid)
         with_lock(req) do
           unless sid and session = get_session_with_fallback(sid)
-            sid, session = generate_sid, {}
+            sid, session = generate_sid(use_mutex: false), {}
             @pool.store sid.private_id, session
           end
           [sid, session]
@@ -64,7 +64,7 @@ module Rack
         with_lock(req) do
           @pool.delete(session_id.public_id)
           @pool.delete(session_id.private_id)
-          generate_sid unless options[:drop]
+          generate_sid(use_mutex: false) unless options[:drop]
         end
       end
 


### PR DESCRIPTION
Internal use in Rack::Session::Pool is already thread-safe.
However, this can be called from commit_session and is a public
method, so make those calls thread-safe.

Note that Rack::Session::Pool#generate_sid did no support taking
the same arguments as the superclass #generate_sid did.  This
overrides the method to support the same arguments, but adds a
keyword argument for whether to use a mutex, which defaults to
true.