### PR TITLE
Enable Directly requiring Rack Components

### DIFF
--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../request'
+
 module Rack
   module Auth
     class AbstractRequest

--- a/lib/rack/auth/digest/md5.rb
+++ b/lib/rack/auth/digest/md5.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../../utils'
 require_relative '../abstract/handler'
 require_relative 'request'
 require_relative 'params'

--- a/lib/rack/auth/digest/md5.rb
+++ b/lib/rack/auth/digest/md5.rb
@@ -99,7 +99,7 @@ module Rack
 
         def valid_digest?(auth)
           pw = @authenticator.call(auth.username)
-          pw && Rack::Utils.secure_compare(digest(auth, pw), auth.response)
+          pw && Utils.secure_compare(digest(auth, pw), auth.response)
         end
 
         def md5(data)

--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'server'
+require_relative 'urlmap'
+
 module Rack
   # Rack::Builder implements a small DSL to iteratively construct Rack
   # applications.

--- a/lib/rack/chunked.rb
+++ b/lib/rack/chunked.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'utils'
+
 module Rack
 
   # Middleware that applies chunked transfer encoding to response bodies

--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'body_proxy'
+require_relative 'utils'
+
 module Rack
   # Rack::CommonLogger forwards every request to the given +app+, and
   # logs a line in the

--- a/lib/rack/conditional_get.rb
+++ b/lib/rack/conditional_get.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'body_proxy'
+require_relative 'utils'
+
 module Rack
 
   # Middleware that enables conditional GET using If-None-Match and

--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'body_proxy'
+require_relative 'utils'
+
 module Rack
 
   # Sets the Content-Length header on responses that do not specify

--- a/lib/rack/content_type.rb
+++ b/lib/rack/content_type.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'utils'
+
 module Rack
 
   # Sets the Content-Type header on responses which don't have one.

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -2,6 +2,10 @@
 
 require "zlib"
 require "time"  # for Time.httpdate
+require_relative '../rack'
+require_relative 'body_proxy'
+require_relative 'request'
+require_relative 'utils'
 
 module Rack
   # This middleware enables content encoding of http responses,

--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'time'
+require_relative '../rack'
+require_relative 'files'
+require_relative 'head'
+require_relative 'mime'
+require_relative 'utils'
 
 module Rack
   # Rack::Directory serves entries below the +root+ given, according to the

--- a/lib/rack/events.rb
+++ b/lib/rack/events.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative 'body_proxy'
+require_relative 'request'
+require_relative 'response'
+
 module Rack
   ### This middleware provides hooks to certain places in the request /
   # response lifecycle.  This is so that middleware that don't need to filter

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'time'
+require_relative '../rack'
+require_relative 'head'
+require_relative 'mime'
+require_relative 'request'
+require_relative 'utils'
 
 module Rack
   # Rack::Files serves files below the +root+ directory given, according to the

--- a/lib/rack/handler/cgi.rb
+++ b/lib/rack/handler/cgi.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative '../rewindable_input'
+require_relative '../version'
+
 module Rack
   module Handler
     class CGI

--- a/lib/rack/handler/fastcgi.rb
+++ b/lib/rack/handler/fastcgi.rb
@@ -2,6 +2,8 @@
 
 require 'fcgi'
 require 'socket'
+require_relative '../rewindable_input'
+require_relative '../version'
 
 if defined? FCGI::Stream
   class FCGI::Stream

--- a/lib/rack/handler/lsws.rb
+++ b/lib/rack/handler/lsws.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'lsapi'
+require_relative '../rewindable_input'
+require_relative '../version'
 
 module Rack
   module Handler

--- a/lib/rack/handler/scgi.rb
+++ b/lib/rack/handler/scgi.rb
@@ -2,6 +2,7 @@
 
 require 'scgi'
 require 'stringio'
+require_relative '../version'
 
 module Rack
   module Handler

--- a/lib/rack/handler/thin.rb
+++ b/lib/rack/handler/thin.rb
@@ -4,6 +4,7 @@ require "thin"
 require "thin/server"
 require "thin/logging"
 require "thin/backends/tcp_server"
+require_relative '../version'
 
 module Rack
   module Handler

--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -2,6 +2,7 @@
 
 require 'webrick'
 require 'stringio'
+require_relative '../version'
 
 # This monkey patch allows for applications to perform their own chunking
 # through WEBrick::HTTPResponse if rack is set to true.

--- a/lib/rack/head.rb
+++ b/lib/rack/head.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'body_proxy'
+
 module Rack
   # Rack::Head returns an empty body for all HEAD requests. It leaves
   # all other requests unchanged.

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require_relative '../rack'
+require_relative 'utils'
 
 module Rack
   # Rack::Lint validates your application and the requests and

--- a/lib/rack/lobster.rb
+++ b/lib/rack/lobster.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'zlib'
+require_relative '../rack'
+require_relative 'request'
+require_relative 'response'
 
 module Rack
   # Paste has a Pony, Rack has a Lobster!
@@ -62,7 +65,9 @@ end
 
 if $0 == __FILE__
   # :nocov:
-  require_relative '../rack'
+  require_relative 'lint'
+  require_relative 'server'
+  require_relative 'show_exceptions'
   Rack::Server.start(
     app: Rack::ShowExceptions.new(Rack::Lint.new(Rack::Lobster.new)), Port: 9292
   )

--- a/lib/rack/lock.rb
+++ b/lib/rack/lock.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'thread'
+require_relative '../rack'
+require_relative 'body_proxy'
 
 module Rack
   # Rack::Lock locks every request inside a mutex, so that every request

--- a/lib/rack/logger.rb
+++ b/lib/rack/logger.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger'
+require_relative '../rack'
 
 module Rack
   # Sets up rack.logger to write to rack.errors stream

--- a/lib/rack/method_override.rb
+++ b/lib/rack/method_override.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'request'
+require_relative 'utils'
+
 module Rack
   class MethodOverride
     HTTP_METHODS = %w[GET HEAD PUT POST DELETE OPTIONS PATCH LINK UNLINK]

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -2,8 +2,12 @@
 
 require 'uri'
 require 'stringio'
-require_relative '../rack'
 require 'cgi/cookie'
+require_relative '../rack'
+require_relative 'lint'
+require_relative 'multipart'
+require_relative 'response'
+require_relative 'utils'
 
 module Rack
   # Rack::MockRequest helps testing your Rack application without

--- a/lib/rack/multipart.rb
+++ b/lib/rack/multipart.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'request'
+require_relative 'utils'
+require_relative 'multipart/generator'
 require_relative 'multipart/parser'
 
 module Rack
@@ -7,9 +11,6 @@ module Rack
   #
   # Usually, Rack::Request#POST takes care of calling this.
   module Multipart
-    autoload :UploadedFile, 'rack/multipart/uploaded_file'
-    autoload :Generator, 'rack/multipart/generator'
-
     EOL = "\r\n"
     MULTIPART_BOUNDARY = "AaB03x"
     MULTIPART = %r|\Amultipart/.*boundary=\"?([^\";,]+)\"?|ni

--- a/lib/rack/multipart/generator.rb
+++ b/lib/rack/multipart/generator.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative '../multipart'
+require_relative 'uploaded_file'
+
 module Rack
   module Multipart
     class Generator

--- a/lib/rack/multipart/generator.rb
+++ b/lib/rack/multipart/generator.rb
@@ -42,7 +42,7 @@ module Rack
             value.any?(&query)
           when Hash
             value.values.any?(&query)
-          when Rack::Multipart::UploadedFile
+          when Multipart::UploadedFile
             true
           end
         }

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'strscan'
+require_relative '../multipart'
+require_relative '../utils'
 
 module Rack
   module Multipart

--- a/lib/rack/null_logger.rb
+++ b/lib/rack/null_logger.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+
 module Rack
   class NullLogger
     def initialize(app)

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'utils'
+
 module Rack
   class QueryParser
     (require_relative 'core_ext/regexp'; using ::Rack::RegexpExtensions) if RUBY_VERSION < '2.4'

--- a/lib/rack/recursive.rb
+++ b/lib/rack/recursive.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'uri'
+require_relative '../rack'
 
 module Rack
   # Rack::ForwardRequest gets caught by Rack::Recursive and redirects

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'media_type'
+require_relative 'multipart'
+require_relative 'utils'
+
 module Rack
   # Rack::Request provides a convenient interface to a Rack
   # environment.  It is stateless, the environment +env+ passed to the

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'time'
+require_relative '../rack'
+require_relative 'media_type'
+require_relative 'utils'
 
 module Rack
   # Rack::Response provides a convenient interface to create a Rack

--- a/lib/rack/runtime.rb
+++ b/lib/rack/runtime.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'utils'
+
 module Rack
   # Sets an "X-Runtime" response header, indicating the response
   # time of the request, in seconds

--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'body_proxy'
+require_relative 'utils'
+
 module Rack
 
   # = Sendfile

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -2,6 +2,15 @@
 
 require 'optparse'
 require 'fileutils'
+require_relative '../rack'
+require_relative 'builder'
+require_relative 'common_logger'
+require_relative 'content_length'
+require_relative 'handler'
+require_relative 'lint'
+require_relative 'show_exceptions'
+require_relative 'tempfile_reaper'
+
 
 module Rack
 

--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -3,10 +3,13 @@
 # AUTHOR: blink <blinketje@gmail.com>; blink#ruby-lang@irc.freenode.net
 # bugrep: Andreas Zehnder
 
-require_relative '../../../rack'
 require 'time'
 require 'securerandom'
 require 'digest/sha2'
+require_relative '../../../rack'
+require_relative '../../request'
+require_relative '../../response'
+require_relative '../../utils'
 
 module Rack
 

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -2,10 +2,11 @@
 
 require 'openssl'
 require 'zlib'
-require_relative 'abstract/id'
 require 'json'
 require 'base64'
 require 'delegate'
+require_relative '../utils'
+require_relative 'abstract/id'
 
 module Rack
 

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -2,6 +2,9 @@
 
 require 'ostruct'
 require 'erb'
+require_relative '../rack'
+require_relative 'request'
+require_relative 'utils'
 
 module Rack
   # Rack::ShowExceptions catches all exceptions raised from the app it

--- a/lib/rack/show_status.rb
+++ b/lib/rack/show_status.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'erb'
+require_relative '../rack'
+require_relative 'request'
+require_relative 'utils'
 
 module Rack
   # Rack::ShowStatus catches all empty responses and replaces them

--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'files'
+require_relative 'mime'
+require_relative 'utils'
+
 module Rack
 
   # The Rack::Static middleware intercepts requests for static files

--- a/lib/rack/tempfile_reaper.rb
+++ b/lib/rack/tempfile_reaper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative '../rack'
+require_relative 'body_proxy'
+
 module Rack
 
   # Middleware tracks and cleans Tempfiles created throughout a request (i.e. Rack::Multipart)

--- a/lib/rack/urlmap.rb
+++ b/lib/rack/urlmap.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'set'
+require_relative '../rack'
 
 module Rack
   # Rack::URLMap takes a hash mapping urls or paths to apps, and

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -6,8 +6,10 @@ require 'fileutils'
 require 'set'
 require 'tempfile'
 require 'time'
-
+require_relative '../rack'
+require_relative 'mime'
 require_relative 'query_parser'
+require_relative 'utils'
 
 module Rack
   # Rack::Utils contains a grab-bag of useful methods for writing web


### PR DESCRIPTION
## Primary Change

[As discussed in #1614](https://github.com/rack/rack/pull/1614#issuecomment-594296721), the goal here is to enable a consumer of Rack to load only a subset of Rack (e.g., `require "rack/request"`) without having to pull in all of Rack via `require "rack"`. This is a common pattern for tools built to work atop or next to Rack. A prior change (0d14bf5) was made to lean more heavily on Ruby's `autoload` feature, breaking this usage pattern. This commit aims to re-introduce the `require_relative`s necessary to allow any subset of Rack to be directly loaded.

In some cases that means a file must also effectively `require_relative 'lib/rack'` because the file has dependencies on constants defined in `lib/rack.rb`. The net effect is that no other `require_relatives` would then be needed in such a file because the `autoload` configuration of `lib/rack.rb` would be in play. We've chosen to still `require_relative` those dependencies as it helps to highlight the dependencies used within the file.

## Secondary Change

A secondary change (which perhaps we want to drop here and address in another PR) is to normalize how we reference Racks constants from within Rack itself. That is, rather than fully-qualifying a dependency (e.g., `Rack::Utils` or `::Rack::Utils`), we can leverage Ruby's constant resolution strategies to use a module-relative name. For example, from anywhere with the `Rack` module, we can say `Utils`, or `Multipart::UploadedFile`.

One downside of module-relative naming is that an unloaded constant can give a confusing error, like `uninitialized constant Rack::Response::Utils`. Whereas if that constant were fully qualified the error would be `uninitialized constant Rack::Utils`, which gives the developer a better pointer to the problem.

This secondary change is WIP; I've only done it in two spots to show what it could look like. We should either adopt this across the code base, or perhaps go the other way and fully-qualify all usages by way of `::Rack::...`. I'll adjust this commit, or remove it entirely, pending further discussion.
