### PR TITLE
Parse the expiry as a time object. 

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -222,7 +222,7 @@ module Rack
         domain  = "; domain=#{value[:domain]}"   if value[:domain]
         path    = "; path=#{value[:path]}"       if value[:path]
         max_age = "; max-age=#{value[:max_age]}" if value[:max_age]
-        expires = "; expires=#{value[:expires].httpdate}" if value[:expires]
+        expires = "; expires=#{Time.at(value[:expires]).httpdate}" if value[:expires]
         secure = "; secure"  if value[:secure]
         httponly = "; HttpOnly" if (value.key?(:httponly) ? value[:httponly] : value[:http_only])
         same_site =


### PR DESCRIPTION
I noticed an error

```
NoMethodError (undefined method `httpdate' for 14400:Integer):

rack (2.2.2) lib/rack/utils.rb:225:in `add_cookie_to_header'
actionpack (6.0.2.1) lib/action_dispatch/middleware/cookies.rb:439:in `block in make_set_cookie_header'
actionpack (6.0.2.1) lib/action_dispatch/middleware/cookies.rb:437:in `each'
actionpack (6.0.2.1) lib/action_dispatch/middleware/cookies.rb:437:in `inject'
actionpack (6.0.2.1) lib/action_dispatch/middleware/cookies.rb:437:in `make_set_cookie_header'
actionpack (6.0.2.1) lib/action_dispatch/middleware/cookies.rb:423:in `write'
```

In a rails 6 project that has 

`Rails.application.config.action_dispatch.cookies_serializer = :json`

set. 

This PR parses the value at `:expires` into a time object regardless of if it's an integer. `Time.at(Time.now)` returns the correct thing. 