### PR TITLE
Bring Rack::Mock cookie parsing into SPEC (fixes #1629)

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -231,21 +231,19 @@ module Rack
 
     def parse_cookies_from_header
       cookies = Hash.new
-      if original_headers.has_key? 'Set-Cookie'
-        set_cookie_header = original_headers.fetch('Set-Cookie')
-        set_cookie_header.split("\n").each do |cookie|
-          cookie_name, cookie_filling = cookie.split('=', 2)
-          cookie_attributes = identify_cookie_attributes cookie_filling
-          parsed_cookie = CGI::Cookie.new(
-            'name' => cookie_name.strip,
-            'value' => cookie_attributes.fetch('value'),
-            'path' => cookie_attributes.fetch('path', nil),
-            'domain' => cookie_attributes.fetch('domain', nil),
-            'expires' => cookie_attributes.fetch('expires', nil),
-            'secure' => cookie_attributes.fetch('secure', false)
-          )
-          cookies.store(cookie_name, parsed_cookie)
-        end
+      hashed_headers = Rack::Utils::HeaderHash[original_headers]
+      [hashed_headers.fetch("Set-Cookie", "")].flatten.join("\n").split("\n").each do |cookie|
+        cookie_name, cookie_filling = cookie.split('=', 2)
+        cookie_attributes = identify_cookie_attributes cookie_filling
+        parsed_cookie = CGI::Cookie.new(
+          'name' => cookie_name.strip,
+          'value' => cookie_attributes.fetch('value'),
+          'path' => cookie_attributes.fetch('path', nil),
+          'domain' => cookie_attributes.fetch('domain', nil),
+          'expires' => cookie_attributes.fetch('expires', nil),
+          'secure' => cookie_attributes.fetch('secure', false)
+        )
+        cookies.store(cookie_name, parsed_cookie)
       end
       cookies
     end

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -474,6 +474,14 @@ module Rack
       alias_method :member?, :include?
       alias_method :key?, :include?
 
+      def fetch(*args)
+        begin
+          super(args.first)
+        rescue KeyError
+          super(@names[args.first.downcase], *args[1..-1])
+        end
+      end
+
       def merge!(other)
         other.each { |k, v| self[k] = v }
         self

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -324,6 +324,21 @@ describe Rack::MockResponse do
     res.cookie("i_dont_exist").must_be_nil
   end
 
+  it "parses cookie headers provided as an array" do
+    res = Rack::MockRequest.new(->(env) { [200, [["set-cookie", "array=awesome"]], [""]] }).get("")
+    array_cookie = res.cookie("array")
+    array_cookie.value[0].must_equal "awesome"
+  end
+
+  it "parses multiple set-cookie headers provided as an array" do
+    cookie_headers = [["set-cookie", "array=awesome\nmultiple=times"]]
+    res = Rack::MockRequest.new(->(env) { [200, cookie_headers, [""]] }).get("")
+    array_cookie = res.cookie("array")
+    array_cookie.value[0].must_equal "awesome"
+    second_cookie = res.cookie("multiple")
+    second_cookie.value[0].must_equal "times"
+  end
+
   it "provide access to the HTTP body" do
     res = Rack::MockRequest.new(app).get("")
     res.body.must_match(/rack/)

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -639,6 +639,24 @@ describe Rack::Utils::HeaderHash do
     h.wont_include 'ETag'
   end
 
+  it "fetches values via case-insensitive keys" do
+    h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+    v = h.fetch("content-MD5", "nope")
+    v.must_equal "d5ff4e2a0 ..."
+  end
+
+  it "fetches values via case-insensitive keys without defaults" do
+    h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+    v = h.fetch("content-MD5")
+    v.must_equal "d5ff4e2a0 ..."
+  end
+
+  it "correctly raises an exception on fetch for a non-existent key" do
+    h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+
+	 -> { h.fetch("Set-Cookie") }.must_raise(KeyError)
+  end
+
   it "create deep HeaderHash copy on dup" do
     h1 = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
     h2 = h1.dup


### PR DESCRIPTION
#has_key? isn't required to be supported by the object in the
`headers` element of the response coming back out of the app.
This replaces that call with a transmogrification into a
HeaderHash so we can use an index as normal.  The odd
`hash[] || ""` construction is necessary because HeaderHash#fetch
doesn't respect header name case insensitivity.