### PR TITLE
Request#port: Avoid warning about unused variable

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -307,7 +307,7 @@ module Rack
 
       def port
         if authority = self.authority
-          _, _, port = split_authority(self.authority)
+          _, _, port = split_authority(authority)
 
           if port
             return port
@@ -319,7 +319,7 @@ module Rack
         end
 
         if scheme = self.scheme
-          if port = DEFAULT_PORTS[self.scheme]
+          if port = DEFAULT_PORTS[scheme]
             return port
           end
         end


### PR DESCRIPTION
This PR avoids an emitted Ruby warning.

```
.../rack-2.2.2/lib/rack/request.rb:309: warning: assigned but unused variable - authority
.../rack-2.2.2/lib/rack/request.rb:321: warning: assigned but unused variable - scheme
```

The solution here **uses the value** of two assigned variables instead of calling its getters again.

