### PR TITLE
Wrap response headers with HeaderHash where it's missing

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -25,6 +25,7 @@ module Rack
 
     def call(env)
       status, headers, body = @app.call(env)
+      headers = Utils::HeaderHash[headers]
 
       if etag_status?(status) && etag_body?(body) && !skip_caching?(headers)
         original_body = body

--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -108,6 +108,8 @@ module Rack
 
     def call(env)
       status, headers, body = @app.call(env)
+      headers = Utils::HeaderHash[headers]
+
       if body.respond_to?(:to_path)
         case type = variation(env)
         when 'X-Accel-Redirect'


### PR DESCRIPTION
Wrap headers of an app response with `Rack::Utils::HeaderHash` in order to ignore the case of the headers values.

Changes:
- wrap headers in Rack::ETag
- wrap headers in Rack::Sendfile