### PR TITLE
Fix Rack::ShowStatus and close original body

### DIFF
--- a/lib/rack/show_status.rb
+++ b/lib/rack/show_status.rb
@@ -33,9 +33,15 @@ module Rack
         # Yes, it is dumb, but I don't like Ruby yelling at me.
         detail = detail = env[RACK_SHOWSTATUS_DETAIL] || message
 
-        body = @template.result(binding)
-        size = body.bytesize
-        [status, headers.merge(CONTENT_TYPE => "text/html", CONTENT_LENGTH => size.to_s), [body]]
+        html = @template.result(binding)
+        size = html.bytesize
+
+        original_body = body
+        body = Rack::BodyProxy.new([html]) do
+          original_body.close if original_body.respond_to?(:close)
+        end
+
+        [status, headers.merge(CONTENT_TYPE => "text/html", CONTENT_LENGTH => size.to_s), body]
       else
         [status, headers, body]
       end

--- a/test/spec_show_status.rb
+++ b/test/spec_show_status.rb
@@ -117,4 +117,20 @@ describe Rack::ShowStatus do
     assert_match(res, /too meta/)
     res.body.wont_match(/foo/)
   end
+
+  it "close the original body" do
+    closed = false
+
+    body = Object.new
+    def body.each; yield 's' end
+    body.define_singleton_method(:close) { closed = true }
+
+    req = Rack::MockRequest.new(
+      show_status(lambda{|env|
+        [404, { "Content-Type" => "text/plain", "Content-Length" => "0" }, body]
+    }))
+
+    response = req.get("/", lint: true)
+    closed.must_equal true
+  end
 end


### PR DESCRIPTION
Fix the Rack::ShowStatus middleware.

Rack::ShowStatus returns error message if the origin response is empty but nevertheless the original body should be closed if it responses to `close` method.

The added test is based on the [already existing one](https://github.com/rack/rack/blob/master/test/spec_chunked.rb#L57) for Rack::Chunked. But it still looks very ugly.