### PR TITLE
Add missing Logger methods to Rack::NullLogger

### DIFF
--- a/lib/rack/null_logger.rb
+++ b/lib/rack/null_logger.rb
@@ -22,6 +22,11 @@ module Rack
     def warn? ;  end
     def error? ; end
     def fatal? ; end
+    def debug! ; end
+    def error! ; end
+    def fatal ; end
+    def info! ; end
+    def warn! ; end
     def level ; end
     def progname ; end
     def datetime_format ; end
@@ -34,6 +39,8 @@ module Rack
     def sev_threshold=(sev_threshold); end
     def close ; end
     def add(severity, message = nil, progname = nil, &block); end
+    def log(severity, message = nil, progname = nil, &block); end
     def <<(msg); end
+    def reopen(logdev = nil); end
   end
 end


### PR DESCRIPTION
Despite `Rack::NullLogger` should implement the interface of `rack.logger` only currently it implements the full `Logger` interface (in was introduced [here](https://github.com/rack/rack/pull/717)).

The [interface](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) of `Logger` was changed since 2014 so it makes sense to update `Rack::NullLogger` as well.

Added following empty methods to the Rack::NullLogger:
- debug!
- error!
- fatal
- info!
- warn!
- log
- reopen