### PR TITLE
Fix response status usage - convert it with to_i method

### DIFF
--- a/lib/rack/conditional_get.rb
+++ b/lib/rack/conditional_get.rb
@@ -26,7 +26,7 @@ module Rack
       when "GET", "HEAD"
         status, headers, body = @app.call(env)
         headers = Utils::HeaderHash[headers]
-        if status == 200 && fresh?(env, headers)
+        if status.to_i == 200 && fresh?(env, headers)
           status = 304
           headers.delete(CONTENT_TYPE)
           headers.delete(CONTENT_LENGTH)

--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -50,7 +50,7 @@ module Rack
     private
 
       def etag_status?(status)
-        status == 200 || status == 201
+        [200, 201].include?(status.to_i)
       end
 
       def etag_body?(body)


### PR DESCRIPTION
Some middleware treat response status as Integer but according to the specification it's just an object with `to_i` method which returns Integer.

Changes:
- fixed Rack::ConditionalGet
- fixed Rack::ETag