### PR TITLE
Ensure some cookies don't cause failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Fixed
 
 - Avoid NoMethodError when accessing Rack::Session::Cookie without requiring delegate first. ([#1610](https://github.com/rack/rack/issues/1610), [@onigra](https://github.com/onigra))
+- Handle cookies with values that end in '=' ([#1645](https://github.com/rack/rack/pull/1645), [@lukaso](https://github.com/lukaso))
 
 ## [2.2.2] - 2020-02-11
 

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -254,7 +254,7 @@ module Rack
       cookie_bits = cookie_filling.split(';')
       cookie_attributes = Hash.new
       cookie_attributes.store('value', cookie_bits[0].strip)
-      cookie_bits[1..].each do |bit|
+      cookie_bits.drop(1).each do |bit|
         if bit.include? '='
           cookie_attribute, attribute_value = bit.split('=',2)
           cookie_attributes.store(cookie_attribute.strip, attribute_value.strip)

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -254,10 +254,10 @@ module Rack
       cookie_bits = cookie_filling.split(';')
       cookie_attributes = Hash.new
       cookie_attributes.store('value', cookie_bits[0].strip)
-      cookie_bits.each do |bit|
+      cookie_bits[1..].each do |bit|
         if bit.include? '='
-          cookie_attribute, attribute_value = bit.split('=')
-          cookie_attributes.store(cookie_attribute.strip, attribute_value&.strip)
+          cookie_attribute, attribute_value = bit.split('=',2)
+          cookie_attributes.store(cookie_attribute.strip, attribute_value.strip)
           if cookie_attribute.include? 'max-age'
             cookie_attributes.store('expires', Time.now + attribute_value.strip.to_i)
           end

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -257,7 +257,7 @@ module Rack
       cookie_bits.each do |bit|
         if bit.include? '='
           cookie_attribute, attribute_value = bit.split('=')
-          cookie_attributes.store(cookie_attribute.strip, attribute_value.strip)
+          cookie_attributes.store(cookie_attribute.strip, attribute_value&.strip)
           if cookie_attribute.include? 'max-age'
             cookie_attributes.store('expires', Time.now + attribute_value.strip.to_i)
           end

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -319,6 +319,12 @@ describe Rack::MockResponse do
     secure_cookie.expires.must_be_nil
   end
 
+  it "parses cookie headers with equals sign at the end" do
+    res = Rack::MockRequest.new(->(env) { [200, {"Set-Cookie" => "__cf_bm=_somebase64encodedstringwithequalsatthened=; array=awesome"}, [""]] }).get("")
+    cookie = res.cookie("__cf_bm")
+    cookie.value[0].must_equal "_somebase64encodedstringwithequalsatthened="
+  end
+
   it "return nil if a non existent cookie is requested" do
     res = Rack::MockRequest.new(app).get("")
     res.cookie("i_dont_exist").must_be_nil


### PR DESCRIPTION
Cookies can on occasion have base 64 encoded strings as their value. Base 64 encoded strings tend to end in '=' as this is a filler character. Cookies of this form cause rack to fail.

An example is `__cf_bm=_somebase64encodedstringwithequalsatthened=; array=awesome`.

This fixes the bug.

Alternative approach would be that in the function I've patched, to only parse the headers required  in the enclosing function.