### PR TITLE
YARD config: Mention SPEC.rdoc by its right name

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,2 @@
 -
-SPEC
+SPEC.rdoc


### PR DESCRIPTION
This PR changes the YARD configuration file to include the SPEC.rdoc file in the served documentation on sites that present the YARD API documentation.

  - this makes `yard` invocation **avoid a warning** about unknown file `SPEC`
  - the result is that in the "Files" listing SPEC is visible next to README

## Before

What it looks like before this change (in the served Rubydoc.info):

<img width="1044" alt="bild" src="https://user-images.githubusercontent.com/211/82755156-22289780-9dd2-11ea-9b03-e426ffba5cdb.png">

## After

<img width="935" alt="bild" src="https://user-images.githubusercontent.com/211/82755178-41272980-9dd2-11ea-920f-4a0269d1d374.png">
