### PR TITLE
SPEC: Require "status" to be Integer and >= 100 (BREAKING CHANGE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Changed
 
+- BREAKING CHANGE: Require `status` to be an Integer. ([#1662](https://github.com/rack/rack/pull/1662), [@olleolleolle](https://github.com/olleolleolle))
 - Relax validations around `Rack::Request#host` and `Rack::Request#hostname`. ([#1606](https://github.com/rack/rack/issues/1606), [@pvande](https://github.com/pvande))
 
 ### Fixed

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -246,8 +246,8 @@ if the request env has <tt>rack.hijack?</tt> <tt>true</tt>.
   request pattern is intended to provide the hijacker with "raw tcp".
 == The Response
 === The Status
-This is an HTTP status. When parsed as integer (+to_i+), it must be
-greater than or equal to 100.
+This is an HTTP status. It must be an Integer greater than or equal to
+100.
 === The Headers
 The header must respond to +each+, and yield values of key and value.
 The header keys must be Strings.

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -659,9 +659,11 @@ module Rack
 
     ## === The Status
     def check_status(status)
-      ## This is an HTTP status. When parsed as integer (+to_i+), it must be
-      ## greater than or equal to 100.
-      assert("Status must be >=100 seen as integer") { status.to_i >= 100 }
+      ## This is an HTTP status. It must be an Integer greater than or equal to
+      ## 100.
+      assert("Status must be an Integer >=100") {
+        status.is_a?(Integer) && status >= 100
+      }
     end
 
     ## === The Headers

--- a/test/spec_content_type.rb
+++ b/test/spec_content_type.rb
@@ -44,12 +44,4 @@ describe Rack::ContentType do
       response[1]['Content-Type'].must_be_nil
     end
   end
-
-  ['100', '204', '304'].each do |code|
-    it "not set Content-Type on #{code} responses if status is a string" do
-      app = lambda { |env| [code, {}, []] }
-      response = content_type(app, "text/html").call(request)
-      response[1]['Content-Type'].must_be_nil
-    end
-  end
 end

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -266,14 +266,21 @@ describe Rack::Lint do
                        ["cc", {}, ""]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
-      message.must_match(/must be >=100 seen as integer/)
+      message.must_match(/must be an Integer >=100/)
 
     lambda {
       Rack::Lint.new(lambda { |env|
                        [42, {}, ""]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
-      message.must_match(/must be >=100 seen as integer/)
+      message.must_match(/must be an Integer >=100/)
+
+    lambda {
+      Rack::Lint.new(lambda { |env|
+                       ["200", {}, ""]
+                     }).call(env({}))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_match(/must be an Integer >=100/)
   end
 
   it "notice header errors" do


### PR DESCRIPTION
This PR adds a SPEC change: "require Status to be an Integer >100".

The change is: check `status.is_a?(Integer)` before trying the >=.

- Tests which tested the previous, lenient `#to_i`-accepting behavior: dropped

See comment in #1644
