### PR TITLE
Update to RuboCop 0.84.0: Use new name for a rule; auto-correct issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisabledByDefault: true
   Exclude:
     - '**/vendor/**/*'
@@ -50,7 +50,7 @@ Layout/SpaceBeforeFirstArg:
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
 
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
 
 Layout/TrailingWhitespace:

--- a/Rakefile
+++ b/Rakefile
@@ -147,7 +147,7 @@ end
 task :external do
   Bundler.with_clean_env do
     clone_and_test("https://github.com/kickstarter/rack-attack", "rack-attack", "bundle exec rake")
-    clone_and_test("https://github.com/rtomayko/rack-cache", "rack-cache","bundle exec rake")
+    clone_and_test("https://github.com/rtomayko/rack-cache", "rack-cache", "bundle exec rake")
     clone_and_test("https://github.com/socketry/falcon", "falcon", "bundle exec rspec")
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -145,6 +145,9 @@ def clone_and_test(url, name, command)
 end
 
 task :external do
+  # In order not to interfere with external tests: rename our config file
+  FileUtils.mv ".rubocop.yml", ".rack.rubocop.yml.disabled"
+
   Bundler.with_clean_env do
     clone_and_test("https://github.com/kickstarter/rack-attack", "rack-attack", "bundle exec rake")
     clone_and_test("https://github.com/rtomayko/rack-cache", "rack-cache", "bundle exec rake")

--- a/lib/rack/handler/cgi.rb
+++ b/lib/rack/handler/cgi.rb
@@ -55,7 +55,7 @@ module Rack
         }
       end
     end
-    
+
     register 'cgi', 'Rack::Handler::CGI'
   end
 end

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -256,7 +256,7 @@ module Rack
       cookie_attributes.store('value', cookie_bits[0].strip)
       cookie_bits.drop(1).each do |bit|
         if bit.include? '='
-          cookie_attribute, attribute_value = bit.split('=',2)
+          cookie_attribute, attribute_value = bit.split('=', 2)
           cookie_attributes.store(cookie_attribute.strip, attribute_value.strip)
           if cookie_attribute.include? 'max-age'
             cookie_attributes.store('expires', Time.now + attribute_value.strip.to_i)

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -320,7 +320,7 @@ describe Rack::MockResponse do
   end
 
   it "parses cookie headers with equals sign at the end" do
-    res = Rack::MockRequest.new(->(env) { [200, {"Set-Cookie" => "__cf_bm=_somebase64encodedstringwithequalsatthened=; array=awesome"}, [""]] }).get("")
+    res = Rack::MockRequest.new(->(env) { [200, { "Set-Cookie" => "__cf_bm=_somebase64encodedstringwithequalsatthened=; array=awesome" }, [""]] }).get("")
     cookie = res.cookie("__cf_bm")
     cookie.value[0].must_equal "_somebase64encodedstringwithequalsatthened="
   end


### PR DESCRIPTION
This PR makes RuboCop 0.84.0 pass on master.

## Background

I ran `bundle install`, then looked in the Gemfile, saw RuboCop there, and tried to run it.

- Use a new name for one of the rules
- Run `rubocop -a` to auto-fix outstanding issues

Why this didn't work at first: external tests - the external projects may run a `rubocop` Rake task, which looks for additional .rubocop.yml files in parent directories.

**Workaround:** To work around that, I added a commit which renames Rack's `.rubocop.yml` (for the duration of the external tests).

## Notes

- 🔧  **2.3 syntax** is **no longer supported** by RuboCop. Perhaps hastily, I picked 2.4, to be able to run the check with that latest RuboCop release