### PR TITLE
Case insensitive fetch on HeaderHash

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -474,6 +474,10 @@ module Rack
       alias_method :member?, :include?
       alias_method :key?, :include?
 
+      def fetch(*args)
+        super(@names[args.first.downcase] || args.first, *(args.drop(1)))
+      end
+
       def merge!(other)
         other.each { |k, v| self[k] = v }
         self

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -474,8 +474,8 @@ module Rack
       alias_method :member?, :include?
       alias_method :key?, :include?
 
-      def fetch(*args)
-        super(@names[args.first.downcase] || args.first, *(args.drop(1)))
+      def fetch(k, *args)
+        super(@names[k.downcase] || k, *args)
       end
 
       def merge!(other)

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -639,6 +639,38 @@ describe Rack::Utils::HeaderHash do
     h.wont_include 'ETag'
   end
 
+  it "fetches values via case-insensitive keys" do
+    h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+    v = h.fetch("content-MD5", "nope")
+    v.must_equal "d5ff4e2a0 ..."
+  end
+
+  it "fetches values via case-insensitive keys without defaults" do
+    h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+    v = h.fetch("content-MD5")
+    v.must_equal "d5ff4e2a0 ..."
+  end
+
+  it "correctly raises an exception on fetch for a non-existent key" do
+    h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+
+	  -> { h.fetch("Set-Cookie") }.must_raise(KeyError)
+  end
+
+  it "returns default on fetch miss" do
+    h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+
+    v = h.fetch("Missing-Header", "default")
+    v.must_equal "default"
+  end
+
+  it "returns default on fetch miss using block" do
+    h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
+
+    v = h.fetch("Missing-Header") { |el| "Didn't find #{el}" }
+    v.must_equal "Didn't find Missing-Header"
+  end
+
   it "create deep HeaderHash copy on dup" do
     h1 = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
     h2 = h1.dup

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -654,7 +654,7 @@ describe Rack::Utils::HeaderHash do
   it "correctly raises an exception on fetch for a non-existent key" do
     h = Rack::Utils::HeaderHash.new("Content-MD5" => "d5ff4e2a0 ...")
 
-	  -> { h.fetch("Set-Cookie") }.must_raise(KeyError)
+    -> { h.fetch("Set-Cookie") }.must_raise(KeyError)
   end
 
   it "returns default on fetch miss" do


### PR DESCRIPTION
Extracts just the case insensitive header hash code from #1630 and addresses @tenderlove comments (https://github.com/rack/rack/pull/1630#pullrequestreview-417023992).

> I think Hash#fetch can take a block, so we need to support that too.

New test added

> I noticed this implementation rescues a KeyError rather than checking key?. Do we expect fetch to typically succeed? I'd rather not rescue exceptions as part of our logic, but I could understand for performance (though I'm not sure HeaderHash#fetch is a hotspot).

Eliminates `KeyError`. Now attempts downcased variant first, which might affect performance.

> Finally I think we can use Array#drop to eliminate range allocation.

Used destructuring instead.