### PR TITLE
Make Rack::ETag not set ETag for no-cache responses by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. For info on
 - Relax validations around `Rack::Request#host` and `Rack::Request#hostname`. ([#1606](https://github.com/rack/rack/issues/1606), [@pvande](https://github.com/pvande))
 - Removed antiquated handlers: FCGI, LSWS, SCGI, Thin. ([#1658](https://github.com/rack/rack/pull/1658), [@ioquatix](https://github.com/ioquatix))
 - Removed options from `Rack::Builder.parse_file` and `Rack::Builder.load_file`. ([#1663](https://github.com/rack/rack/pull/1663), [@ioquatix](https://github.com/ioquatix))
+- Rack::ETag will no longer set ETag for no-cache responses, unless skip_etag_if_no_cache: false keyword is used. ([#1619](https://github.com/rack/rack/issues/1619), [@jeremyevans](https://github.com/jeremyevans))
 
 ### Fixed
 

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -7,6 +7,7 @@ describe Rack::ETag do
   def etag(app, *args)
     Rack::Lint.new Rack::ETag.new(app, *args)
   end
+  ruby2_keywords :etag if respond_to?(:ruby2_keywords, true)
 
   def request
     Rack::MockRequest.env_for
@@ -90,10 +91,16 @@ describe Rack::ETag do
     response[1]['ETag'].must_be_nil
   end
 
-  it "set ETag even if no-cache is given" do
+  it "set ETag even if no-cache is given if skip_etag_if_no_cache: false keyword is used" do
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Cache-Control' => 'no-cache, must-revalidate' }, ['Hello, World!']] }
+    response = etag(app, skip_etag_if_no_cache: false).call(request)
+    response[1]['ETag'].must_equal "W/\"dffd6021bb2bd5b0af676290809ec3a5\""
+  end
+
+  it "not set ETag if no-cache is given" do
     app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Cache-Control' => 'no-cache, must-revalidate' }, ['Hello, World!']] }
     response = etag(app).call(request)
-    response[1]['ETag'].must_equal "W/\"dffd6021bb2bd5b0af676290809ec3a5\""
+    response[1]['ETag'].must_be_nil
   end
 
   it "close the original body" do


### PR DESCRIPTION
This reverts commit 0371c69a0850e1b21448df96698e2926359f17fe,
"Remove check for Cache-Control: no-cache when generating etag".

It makes the previous behavior opt-in using a skip_etag_if_no_cache: false
keyword argument to Rack::ETag, and defaults to the historical behavior of
not setting the ETag if Cache-Control contians no-cache.

Fixes #1619