### PR TITLE
Mark "Remove `to_ary` from Response` as breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Removed
 
-- Remove `to_ary` from Response ([@tenderlove](https://github.com/tenderlove))
+- BREAKING CHANGE: Remove `to_ary` from Response ([@tenderlove](https://github.com/tenderlove))
 - Deprecate `Rack::Session::Memcache` in favor of `Rack::Session::Dalli` from dalli gem ([@fatkodima](https://github.com/fatkodima))
 
 ### Fixed


### PR DESCRIPTION
Response `to_ary` was removed in commit 72959ebc2f300f3b2ccb7ae2aae9f199e611dfb6.

This is a breaking change if the response is used for multiple assignment of variables.

Example that worked with < 2.1.0:
```
status, headers, body = response
```
With version 2.1.0 the value of `headers` changes from a hash to `nil`.
To prevent this the response must be explicitly cast to an array with `to_a` as noted in the commit message of the change.


We had an issue with a custom rack app whose `call` method returned `Rack::Response.new(json)`. This worked fine in version 2.0.2, but caused a `NoMethodError` in [action_dispatch/journey/router.rb](https://github.com/rails/rails/blob/41139f6ba27556e710ecad93f3cd241ea6764f9d/actionpack/lib/action_dispatch/journey/router.rb#L50).

We think it's a good idea to mark this change as breaking in the changelog, so people will be able to check their code before upgrading, what do you think?