### PR TITLE
Stop using deprecated OpenSSL constants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,6 @@ Layout/IndentationStyle:
 
 Layout/TrailingWhitespace:
   Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. For info on
 - Relax validations around `Rack::Request#host` and `Rack::Request#hostname`. ([#1606](https://github.com/rack/rack/issues/1606), [@pvande](https://github.com/pvande))
 - Removed antiquated handlers: FCGI, LSWS, SCGI, Thin. ([#1658](https://github.com/rack/rack/pull/1658), [@ioquatix](https://github.com/ioquatix))
 - Removed options from `Rack::Builder.parse_file` and `Rack::Builder.load_file`. ([#1663](https://github.com/rack/rack/pull/1663), [@ioquatix](https://github.com/ioquatix))
+- HMAC argument for `Rack::Session::Cookie` doesn't accept a class constant anymore, but only a string recognized by OpenSSL (e.g. `"SHA256"`) or compatible instance (e.g. `OpenSSL::Digest.new("SHA256")`) ([#1676](https://github.com/rack/rack/pull/1676), [@bdewater](https://github.com/bdewater))
 
 ### Fixed
 

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -107,7 +107,7 @@ module Rack
 
       def initialize(app, options = {})
         @secrets = options.values_at(:secret, :old_secret).compact
-        @hmac = options.fetch(:hmac, OpenSSL::Digest::SHA1)
+        @hmac = options.fetch(:hmac, "SHA1")
 
         warn <<-MSG unless secure?(options)
         SECURITY WARNING: No secret option provided to Rack::Session::Cookie.
@@ -191,7 +191,7 @@ module Rack
       end
 
       def generate_hmac(data, secret)
-        OpenSSL::HMAC.hexdigest(@hmac.new, secret, data)
+        OpenSSL::HMAC.hexdigest(@hmac, secret, data)
       end
 
       def secure?(options)

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -333,8 +333,8 @@ describe Rack::Session::Cookie do
     response.body.must_equal '{"counter"=>2}'
   end
 
-  it "supports custom digest class" do
-    app = [incrementor, { secret: "test", hmac: OpenSSL::Digest::SHA256 }]
+  it "supports custom digest instance" do
+    app = [incrementor, { secret: "test", hmac: OpenSSL::Digest.new("SHA256") }]
 
     response = response_for(app: app)
     response = response_for(app: app, cookie: response)


### PR DESCRIPTION
See https://github.com/rubocop-hq/rubocop/pull/7950 for details.