### PR TITLE
Backport (1.6) fix for CVE-2020-8184

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -304,8 +304,12 @@ module Rack
       #   the Cookie header such that those with more specific Path attributes
       #   precede those with less specific.  Ordering with respect to other
       #   attributes (e.g., Domain) is unspecified.
-      cookies = Utils.parse_query(string, ';,') { |s| Rack::Utils.unescape(s) rescue s }
-      cookies.each { |k,v| hash[k] = Array === v ? v.first : v }
+      return {} unless string
+      string.split(/[;,] */n).each do |cookie|
+        next if cookie.empty?
+        key, value = cookie.split('=', 2)
+        hash[key] = (Rack::Utils.unescape(value) rescue value) unless hash.key?(key)
+      end
       @env["rack.request.cookie_string"] = string
       hash
     end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -558,6 +558,11 @@ describe Rack::Request do
     req.cookies["foo"].should == "%"
   end
 
+  should "parsing cookies should only decode the values" do
+    req = Rack::Request.new Rack::MockRequest.env_for("", "HTTP_COOKIE" => "%66oo=baz;foo=bar")
+    req.cookies.should.equal '%66oo' => 'baz', 'foo' => 'bar'
+  end
+
   should "parse cookies according to RFC 2109" do
     req = Rack::Request.new \
       Rack::MockRequest.env_for('', 'HTTP_COOKIE' => 'foo=bar;foo=car')


### PR DESCRIPTION
Not sure what your policies are about backporting to < 2 but thought I'd give it a stab with the fix for CVE-2020-8184.