### PR TITLE
Decrease default allowed parameter recursion level from 100 to 32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. For info on
 - HMAC argument for `Rack::Session::Cookie` doesn't accept a class constant anymore, but only a string recognized by OpenSSL (e.g. `"SHA256"`) or compatible instance (e.g. `OpenSSL::Digest.new("SHA256")`) ([#1676](https://github.com/rack/rack/pull/1676), [@bdewater](https://github.com/bdewater))
 - `Rack::HTTP_VERSION` has been removed and the `HTTP_VERSION` env setting is no longer set in the CGI and Webrick handlers . ([#970](https://github.com/rack/rack/issues/970), [@jeremyevans](https://github.com/jeremyevans))
 - `Rack::Request#[]` and `#[]=` now warn even in non-verbose mode. ([#1277](https://github.com/rack/rack/issues/1277), [@jeremyevans](https://github.com/jeremyevans))
+- Decrease default allowed parameter recursion level from 100 to 32. ([#1640](https://github.com/rack/rack/issues/1640), [@jeremyevans](https://github.com/jeremyevans))
 
 ### Fixed
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -200,7 +200,7 @@ but this query string would not be allowed:
 
 Limiting the depth prevents a possible stack overflow when parsing parameters.
 
-Defaults to 100.
+Defaults to 32.
 
 === multipart_part_limit
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -27,7 +27,7 @@ module Rack
     end
     # The default number of bytes to allow parameter keys to take up.
     # This helps prevent a rogue client from flooding a Request.
-    self.default_query_parser = QueryParser.make_default(65536, 100)
+    self.default_query_parser = QueryParser.make_default(65536, 32)
 
     module_function
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -343,14 +343,14 @@ class RackRequestTest < Minitest::Spec
   end
 
   it "limit the allowed parameter depth when parsing parameters" do
-    env = Rack::MockRequest.env_for("/?a#{'[a]' * 110}=b")
+    env = Rack::MockRequest.env_for("/?a#{'[a]' * 40}=b")
     req = make_request(env)
     lambda { req.GET }.must_raise RangeError
 
-    env = Rack::MockRequest.env_for("/?a#{'[a]' * 90}=b")
+    env = Rack::MockRequest.env_for("/?a#{'[a]' * 30}=b")
     req = make_request(env)
     params = req.GET
-    90.times { params = params['a'] }
+    30.times { params = params['a'] }
     params['a'].must_equal 'b'
 
     old, Rack::Utils.param_depth_limit = Rack::Utils.param_depth_limit, 3


### PR DESCRIPTION
Should hopefully fix stack issues on HA PARISC.  32 levels ought to
be enough for anybody.

Fixes #1640.