### PR TITLE
Raise Rack::Multipart::EmptyContentError instead of EOFError for parsing empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::HTTP_VERSION` has been removed and the `HTTP_VERSION` env setting is no longer set in the CGI and Webrick handlers . ([#970](https://github.com/rack/rack/issues/970), [@jeremyevans](https://github.com/jeremyevans))
 - `Rack::Request#[]` and `#[]=` now warn even in non-verbose mode. ([#1277](https://github.com/rack/rack/issues/1277), [@jeremyevans](https://github.com/jeremyevans))
 - Decrease default allowed parameter recursion level from 100 to 32. ([#1640](https://github.com/rack/rack/issues/1640), [@jeremyevans](https://github.com/jeremyevans))
+- Attempting to parse a multipart response with an empty body now raises Rack::Multipart::EmptyContentError. ([#1603](https://github.com/rack/rack/issues/1603), [@jeremyevans](https://github.com/jeremyevans))
 
 ### Fixed
 

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -6,6 +6,10 @@ module Rack
   module Multipart
     class MultipartPartLimitError < Errno::EMFILE; end
 
+    # Use specific error class when parsing multipart request
+    # that ends early.
+    class EmptyContentError < ::EOFError; end
+
     class Parser
       (require_relative '../core_ext/regexp'; using ::Rack::RegexpExtensions) if RUBY_VERSION < '2.4'
 
@@ -356,7 +360,7 @@ module Rack
 
       def handle_empty_content!(content)
         if content.nil? || content.empty?
-          raise EOFError
+          raise EmptyContentError
         end
       end
     end

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -151,7 +151,7 @@ describe Rack::Multipart do
     env = Rack::MockRequest.env_for '/', fixture
     lambda {
       Rack::Multipart.parse_multipart(env)
-    }.must_raise EOFError
+    }.must_raise Rack::Multipart::EmptyContentError
     rd.close
 
     err = thr.value


### PR DESCRIPTION
This makes it simpler to catch this specific error.

Fixes #1603