### PR TITLE
Add Rack::Session::Pool :allow_fallback option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Added
 
 - `Rack::RewindableInput` supports size. ([@ahorek](https://github.com/ahorek))
+- Rack::Session::Pool now accepts `:allow_fallback` option to disable fallback to public id. ([#1431](https://github.com/rack/rack/issues/1431), [@jeremyevans](https://github.com/jeremyevans))
 
 ### Changed
 

--- a/lib/rack/session/pool.rb
+++ b/lib/rack/session/pool.rb
@@ -28,12 +28,13 @@ module Rack
 
     class Pool < Abstract::PersistedSecure
       attr_reader :mutex, :pool
-      DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge drop: false
+      DEFAULT_OPTIONS = Abstract::ID::DEFAULT_OPTIONS.merge(drop: false, allow_fallback: true)
 
       def initialize(app, options = {})
         super
         @pool = Hash.new
         @mutex = Mutex.new
+        @allow_fallback = @default_options.delete(:allow_fallback)
       end
 
       def generate_sid
@@ -78,7 +79,7 @@ module Rack
       private
 
       def get_session_with_fallback(sid)
-        @pool[sid.private_id] || @pool[sid.public_id]
+        @pool[sid.private_id] || (@pool[sid.public_id] if @allow_fallback)
       end
     end
   end


### PR DESCRIPTION
This fixes a theoretical security issue where a lookup of the session
ID uses a non-constant time algorithm (such as a database index), and
only for cases where there is a session that existed prior to an
rack version that added support for private session IDs.

This defaults :allow_fallback to true for backwards compatibility,
but we may want to make the default false in Rack 3.

Fixes #1431