### PR TITLE
Make query string parsing conform to URL spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Changed
 
 - BREAKING CHANGE: Require `status` to be an Integer. ([#1662](https://github.com/rack/rack/pull/1662), [@olleolleolle](https://github.com/olleolleolle))
+- BREAKING CHANGE: Query parsing now treats parameters without `=` as having the empty string value instead of nil value, to conform to the URL spec. ([#1696](https://github.com/rack/rack/issues/1696), [@jeremyevans](https://github.com/jeremyevans))
 - Relax validations around `Rack::Request#host` and `Rack::Request#hostname`. ([#1606](https://github.com/rack/rack/issues/1606), [@pvande](https://github.com/pvande))
 - Removed antiquated handlers: FCGI, LSWS, SCGI, Thin. ([#1658](https://github.com/rack/rack/pull/1658), [@ioquatix](https://github.com/ioquatix))
 - Removed options from `Rack::Builder.parse_file` and `Rack::Builder.load_file`. ([#1663](https://github.com/rack/rack/pull/1663), [@ioquatix](https://github.com/ioquatix))

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -83,6 +83,7 @@ module Rack
       name =~ %r(\A[\[\]]*([^\[\]]+)\]*)
       k = $1 || ''
       after = $' || ''
+      v ||= String.new
 
       if k.empty?
         if !v.nil? && name == "[]"

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -135,7 +135,7 @@ describe Rack::Utils do
 
   it "parse nested query strings correctly" do
     Rack::Utils.parse_nested_query("foo").
-      must_equal "foo" => nil
+      must_equal "foo" => ""
     Rack::Utils.parse_nested_query("foo=").
       must_equal "foo" => ""
     Rack::Utils.parse_nested_query("foo=bar").
@@ -152,7 +152,7 @@ describe Rack::Utils do
     Rack::Utils.parse_nested_query("&foo=1&&bar=2").
       must_equal "foo" => "1", "bar" => "2"
     Rack::Utils.parse_nested_query("foo&bar=").
-      must_equal "foo" => nil, "bar" => ""
+      must_equal "foo" => "", "bar" => ""
     Rack::Utils.parse_nested_query("foo=bar&baz=").
       must_equal "foo" => "bar", "baz" => ""
     Rack::Utils.parse_nested_query("my+weird+field=q1%212%22%27w%245%267%2Fz8%29%3F").
@@ -162,19 +162,19 @@ describe Rack::Utils do
       must_equal "pid=1234" => "1023", "a" => "b"
 
     Rack::Utils.parse_nested_query("foo[]").
-      must_equal "foo" => [nil]
+      must_equal "foo" => [""]
     Rack::Utils.parse_nested_query("foo[]=").
       must_equal "foo" => [""]
     Rack::Utils.parse_nested_query("foo[]=bar").
       must_equal "foo" => ["bar"]
     Rack::Utils.parse_nested_query("foo[]=bar&foo").
-      must_equal "foo" => nil
+      must_equal "foo" => ""
     Rack::Utils.parse_nested_query("foo[]=bar&foo[").
-      must_equal "foo" => ["bar"], "foo[" => nil
+      must_equal "foo" => ["bar"], "foo[" => ""
     Rack::Utils.parse_nested_query("foo[]=bar&foo[=baz").
       must_equal "foo" => ["bar"], "foo[" => "baz"
     Rack::Utils.parse_nested_query("foo[]=bar&foo[]").
-      must_equal "foo" => ["bar", nil]
+      must_equal "foo" => ["bar", ""]
     Rack::Utils.parse_nested_query("foo[]=bar&foo[]=").
       must_equal "foo" => ["bar", ""]
 
@@ -185,6 +185,8 @@ describe Rack::Utils do
     Rack::Utils.parse_nested_query("foo[]=bar&baz[]=1&baz[]=2&baz[]=3").
       must_equal "foo" => ["bar"], "baz" => ["1", "2", "3"]
 
+    Rack::Utils.parse_nested_query("x[y][z]").
+      must_equal "x" => { "y" => { "z" => "" } }
     Rack::Utils.parse_nested_query("x[y][z]=1").
       must_equal "x" => { "y" => { "z" => "1" } }
     Rack::Utils.parse_nested_query("x[y][z][]=1").
@@ -338,7 +340,7 @@ describe Rack::Utils do
   end
 
   it 'performs the inverse function of #parse_nested_query' do
-    [{ "foo" => nil, "bar" => "" },
+    [{ "bar" => "" },
       { "foo" => "bar", "baz" => "" },
       { "foo" => ["1", "2"] },
       { "foo" => "bar", "baz" => ["1", "2", "3"] },


### PR DESCRIPTION
The URL spec section 5.1.3.3 specifies that if = is not present
in the byte sequence, it should be treated as if the byte sequence
is the name of the tuple and the value is the empty string.

This affects all parameters without =, not just arrays:

```ruby
Rack::Utils.parse_nested_query("foo[bar]&baz[]&quux")
{"foo"=>{"bar"=>nil}, "baz"=>[nil], "quux"=>nil} # Before
{"foo"=>{"bar"=>""}, "baz"=>[""], "quux"=>""}    # After
```

Fixes #1696