### PR TITLE
Specify rack.provisional_response to send 1xx responses

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -138,6 +138,7 @@ There are the following restrictions:
 * There must be a valid input stream in <tt>rack.input</tt>.
 * There must be a valid error stream in <tt>rack.errors</tt>.
 * There may be a valid hijack stream in <tt>rack.hijack_io</tt>
+* There may be a valid provisional response callback in <tt>rack.provisional_response</tt>
 * The <tt>REQUEST_METHOD</tt> must be a valid token.
 * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
 * The <tt>PATH_INFO</tt>, if non-empty, must start with <tt>/</tt>
@@ -244,6 +245,22 @@ if the request env has <tt>rack.hijack?</tt> <tt>true</tt>.
 * Middleware may wrap the IO object for the response pattern.
 * Middleware should not wrap the IO object for the request pattern. The
   request pattern is intended to provide the hijacker with "raw tcp".
+=== Provisional Response
+
+The application or any middleware may call the <tt>rack.provisional_response</tt>
+with a response code and headers that will be sent as a 1xx provisional response.
+
+If rack.early_hints is present it must respond to #call.
+This is an HTTP status. It must be an Integer greater than or equal to
+100 and lower than 200.
+The header must respond to +each+, and yield values of key and value.
+The header keys must be Strings.
+The header must conform to RFC7230 token specification, i.e. cannot
+contain non-printable ASCII, DQUOTE or "(),/:;<=>?@[\]{}".
+The values of the header must be Strings,
+consisting of lines (for multiple header values, e.g. multiple
+<tt>Set-Cookie</tt> values) separated by "\\n".
+The lines must not contain characters below 037.
 == The Response
 === The Status
 This is an HTTP status. It must be an Integer greater than or equal to

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -62,6 +62,7 @@ module Rack
   RACK_HIJACK                         = 'rack.hijack'
   RACK_IS_HIJACK                      = 'rack.hijack?'
   RACK_HIJACK_IO                      = 'rack.hijack_io'
+  RACK_PROVISIONAL_RESPONSE           = 'rack.provisional_response'
   RACK_RECURSIVE_INCLUDE              = 'rack.recursive.include'
   RACK_MULTIPART_BUFFER_SIZE          = 'rack.multipart.buffer_size'
   RACK_MULTIPART_TEMPFILE_FACTORY     = 'rack.multipart.tempfile_factory'

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -335,6 +335,8 @@ module Rack
       check_error env[RACK_ERRORS]
       ## * There may be a valid hijack stream in <tt>rack.hijack_io</tt>
       check_hijack env
+      ## * There may be a valid provisional response callback in <tt>rack.provisional_response</tt>
+      check_provisional_response env
 
       ## * The <tt>REQUEST_METHOD</tt> must be a valid token.
       assert("REQUEST_METHOD unknown: #{env[REQUEST_METHOD]}") {
@@ -654,6 +656,55 @@ module Rack
     ## * Middleware may wrap the IO object for the response pattern.
     ## * Middleware should not wrap the IO object for the request pattern. The
     ##   request pattern is intended to provide the hijacker with "raw tcp".
+
+    ## === Provisional Response
+    ##
+    ## The application or any middleware may call the <tt>rack.provisional_response</tt>
+    ## with a response code and headers that will be sent as a 1xx provisional response.
+    def check_provisional_response(env)
+      if env[RACK_PROVISIONAL_RESPONSE]
+        ##
+        ## If rack.early_hints is present it must respond to #call.
+        assert("rack.early_hints must respond to call") { env[RACK_PROVISIONAL_RESPONSE].respond_to?(:call) }
+        original_callback = env[RACK_PROVISIONAL_RESPONSE]
+        env[RACK_PROVISIONAL_RESPONSE] = lambda do |status, headers|
+          ## This is an HTTP status. It must be an Integer greater than or equal to
+          ## 100 and lower than 200.
+          assert("Status must be an Integer >=100 and < 200") {
+            status.is_a?(Integer) && status >= 100 && status < 200
+          }
+          
+          ## The header must respond to +each+, and yield values of key and value.
+          assert("headers object should respond to #each, but doesn't (got #{header.class} as headers)") {
+             header.respond_to? :each
+          }
+
+          header.each { |key, value|
+            ## The header keys must be Strings.
+            assert("header key must be a string, was #{key.class}") {
+              key.kind_of? String
+            }
+
+            ## The header must conform to RFC7230 token specification, i.e. cannot
+            ## contain non-printable ASCII, DQUOTE or "(),/:;<=>?@[\]{}".
+            assert("invalid header name: #{key}") { key !~ /[\(\),\/:;<=>\?@\[\\\]{}[:cntrl:]]/ }
+
+            ## The values of the header must be Strings,
+            assert("a header value must be a String, but the value of " +
+              "'#{key}' is a #{value.class}") { value.kind_of? String }
+            ## consisting of lines (for multiple header values, e.g. multiple
+            ## <tt>Set-Cookie</tt> values) separated by "\\n".
+            value.split("\n").each { |item|
+              ## The lines must not contain characters below 037.
+              assert("invalid header value #{key}: #{item.inspect}") {
+                item !~ /[\000-\037]/
+              }
+            }
+          }
+          original_callback.call(status, headers)
+        end
+      end
+    end
 
     ## == The Response
 


### PR DESCRIPTION
As discussed in https://github.com/rack/rack/issues/1692

### Context 

Three years ago [the `rack.early_hints` callback was added to puma](https://github.com/puma/puma/pull/1403). Since then Falcon and Unicorn followed suit, and frameworks such as Rails and Hanami started using it, so I wanted to make it part of the spec in https://github.com/rack/rack/issues/1692.

However after discussing it, I believe that interface is a bit too narrow, and we might as well allow to return any 1xx status code, with arbitrary headers.

### This spec.

The naming is based on [the HTTP/1.1 RFC](https://tools.ietf.org/html/rfc2616#section-10.1), the 1xx section is named "Informational", but then says:

> This class of status code indicates a provisional response

I think `rack.provisional_response` is the better name in Rack context, but I'd be happy to rename to `rack.informational_response` or something else.

The callback signature is `call(status, headers)`, it should only be called with `1xx` statuses.

The callback doesn't accept a body as the spec is pretty clear that it's not valid:

> consisting only of the Status-Line and optional headers

### Early Hints

Server which wish to sill expose `rack.early_hints` can easily redefine it as `->(headers) { env['rack.provisional_response'].call(103, headers) }`.

### Interested parties and Refs:

- Original puma PR: https://github.com/puma/puma/pull/1403 @eileencodes @tenderlove @nateberkopec 
- Falcon commit: https://github.com/socketry/falcon/commit/248d0a458294914f0d694b26540afccfea7b5b18 @ioquatix 
- Rails PR: https://github.com/rails/rails/pull/30744
- Hanami https://github.com/hanami/hanami/pull/905 @jodosha 

### Implementation details

I didn't delegate to `check_headers` because there are two assertions that I don't think make sense in this context:

```ruby
        ## Special headers starting "rack." are for communicating with the
        ## server, and must not be sent back to the client.
        next if key =~ /^rack\..+$/

        ## The header must not contain a +Status+ key.
        assert("header must not contain Status") { key.downcase != "status" }
```

cc @jeremyevans 