### PR TITLE
Fix MockResponse#body encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Fixed
 
+- Fix encoding of `MockResponse#body` to match input body encoding.([#1702](https://github.com/rack/rack/pull/1702), [@Quiwin](https://github.com/quiwin))
 - TempfileReaper now deletes temp files if application raises an exception. ([#1679](https://github.com/rack/rack/issues/1679), [@jeremyevans](https://github.com/jeremyevans))
 - Fix using Rack::Session::Cookie with coder: Rack::Session::Cookie::Base64::{JSON,Zip}. ([#1666](https://github.com/rack/rack/issues/1666), [@jeremyevans](https://github.com/jeremyevans))
 - Avoid NoMethodError when accessing Rack::Session::Cookie without requiring delegate first. ([#1610](https://github.com/rack/rack/issues/1610), [@onigra](https://github.com/onigra))
@@ -119,7 +120,7 @@ All notable changes to this project will be documented in this file. For info on
 - Support for using `:SSLEnable` option when using WEBrick handler. (Gregor Melhorn)
 - Close response body after buffering it when buffering. ([@ioquatix](https://github.com/ioquatix))
 - Only accept `;` as delimiter when parsing cookies. ([@mrageh](https://github.com/mrageh))
-- `Utils::HeaderHash#clear` clears the name mapping as well. ([@raxoft](https://github.com/raxoft)) 
+- `Utils::HeaderHash#clear` clears the name mapping as well. ([@raxoft](https://github.com/raxoft))
 - Support for passing `nil` `Rack::Files.new`, which notably fixes Rails' current `ActiveStorage::FileServer` implementation. ([@ioquatix](https://github.com/ioquatix))
 
 ### Documentation

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -210,9 +210,10 @@ module Rack
       #     ...
       #     res.body.should == "foo!"
       #   end
-      buffer = String.new
+      enum = super.each
+      buffer = String.new(encoding: enum.first&.encoding)
 
-      super.each do |chunk|
+      enum.each do |chunk|
         buffer << chunk
       end
 

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -256,6 +256,13 @@ describe Rack::MockResponse do
     response.body.must_equal body.join
   end
 
+  it 'keep original body encoding' do
+    body = ["body"]
+    response = Rack::MockResponse[200, {}, body]
+
+    response.body.encoding.must_equal body.first.encoding
+  end
+
   it "provide access to the HTTP status" do
     res = Rack::MockRequest.new(app).get("")
     res.must_be :successful?


### PR DESCRIPTION
Hello,

This pr fix the following issue:

Since 2.1.0, `MockResponse#body` ignores the original encoding of the body and always returns with `ASCII-8BIT` encoding.
```ruby
body = ["pong"]
body.first.encoding
=> #<Encoding:UTF-8>
Rack::MockResponse.new(200, {}, body).body.encoding
=> #<Encoding:ASCII-8BIT>
```
This issue stems from the use of `String.new` when joining the body, which by default produces a String encoded in `ASCII-8BIT`.

https://github.com/rack/rack/blob/649c72bab9e7b50d657b5b432d0c205c95c2be07/lib/rack/mock.rb#L213

