### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-packaging
+
 AllCops:
   TargetRubyVersion: 2.4
   DisabledByDefault: true

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "rubocop", require: false
+gem "rubocop-packaging", require: false
 
 group :doc do
   gem 'rdoc'

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -537,7 +537,7 @@ class RackRequestTest < Minitest::Spec
     begin
       $VERBOSE = true
       req['foo'].must_equal 'quux'
-      warn_arg.must_equal ["Request#[] is deprecated and will be removed in a future version of Rack. Please use request.params[] instead", {uplevel: 1}]
+      warn_arg.must_equal ["Request#[] is deprecated and will be removed in a future version of Rack. Please use request.params[] instead", { uplevel: 1 }]
     ensure
       $VERBOSE = verbose
     end
@@ -582,7 +582,7 @@ class RackRequestTest < Minitest::Spec
     begin
       $VERBOSE = true
       req['foo'] = 'quux'
-      warn_arg.must_equal ["Request#[]= is deprecated and will be removed in a future version of Rack. Please use request.params[]= instead", {uplevel: 1}]
+      warn_arg.must_equal ["Request#[]= is deprecated and will be removed in a future version of Rack. Please use request.params[]= instead", { uplevel: 1 }]
       req.params['foo'].must_equal 'quux'
     ensure
       $VERBOSE = verbose


### PR DESCRIPTION
Hey,

Thanks all for your work in maintaining rack in such a great way! ❤️ 

However, whilst maintaining this in Debian, I found a couple of remaining RuboCop offenses that were left unfixed.
This PR fixes the same and makes the `Layout/SpaceInsideHashLiteralBraces` cop happy.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>