### PR TITLE
Add :same_site cookie option to the param docs.

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -209,8 +209,8 @@ module Rack
       # All parameters are optional.
       # * :key determines the name of the cookie, by default it is
       #   'rack.session'
-      # * :path, :domain, :expire_after, :secure, and :httponly set the related
-      #   cookie options as by Rack::Response#set_cookie
+      # * :path, :domain, :expire_after, :secure, :httponly, and :same_site set
+      #   the related cookie options as by Rack::Response#set_cookie
       # * :skip will not a set a cookie in the response nor update the session state
       # * :defer will not set a cookie in the response but still update the session
       #   state if it is used with a backend


### PR DESCRIPTION
This change adds the `:same_site` cookie option to the Rack::Session::Abstract::Persisted parameter documentation as it's a valid option, but isn't documented.