### PR TITLE
Update test command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,11 @@ We definitely appreciate pull requests that highlight or reproduce a problem, ev
 
 Implement your feature or bug fix.
 
-Make sure that `bundle exec rake fulltest` completes without errors.
+Make sure that all tests pass:
+
+```
+bundle exec rake test
+```
 
 #### Write Documentation
 


### PR DESCRIPTION
When following the CONTRIBUTING.md steps, the `fulltest` rake task wasn't found.

```
rake --tasks                                        
rake build            # Build rack-2.3.0.gem into the pkg directory
rake changelog        # Generate a ChangeLog
rake chmod            # Make binaries executable
rake ci               # Run all the tests we run on CI
rake clean            # Remove any temporary products
rake clobber          # Remove any generated files
rake default          # Run all the tests
rake deps             # Install gem dependencies
rake dist             # Make an archive as .tar.gz
rake install          # Build and install rack-2.3.0.gem into system gems
rake install:local    # Build and install rack-2.3.0.gem into system gems without network access
rake officialrelease  # Make an official release
rake rdoc             # Generate RDoc documentation
rake release[remote]  # Create tag v2.3.0 and build and push rack-2.3.0.gem to rubygems.org
rake spec             # Generate Rack Specification
rake test             # Run all the fast + platform agnostic tests
rake test:regular     # Run tests for test:regular
rake test_cov         # Run tests with coverage
```

After digging through the commits, it looks to have been replaced by `test` in https://github.com/rack/rack/commit/0c5647799d4fa2528445c50f83a5bf9b1c459d0a

This change updates the doc to use `test` instead of `fulltest`.