### PR TITLE
use @status instead of status.to_i

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -78,7 +78,7 @@ module Rack
     # @return [Array] a 3-tuple suitable of `[status, headers, body]`
     # which is suitable to be returned from the middleware `#call(env)` method.
     def finish(&block)
-      if STATUS_WITH_NO_ENTITY_BODY[status.to_i]
+      if STATUS_WITH_NO_ENTITY_BODY[@status]
         delete_header CONTENT_TYPE
         delete_header CONTENT_LENGTH
         close


### PR DESCRIPTION
`status.to_i` looks strange in `Rack::Response`. Changed to `@status`