### PR TITLE
Gracefully handle nil values in ETag middleware

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -66,6 +66,7 @@ module Rack
         digest = nil
 
         body.each do |part|
+          part = part.to_s unless part.is_a?(String)
           parts << part
           (digest ||= Digest::SHA256.new) << part unless part.empty?
         end

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -72,6 +72,12 @@ describe Rack::ETag do
     response[1]['ETag'].must_be_nil
   end
 
+  it "not set ETag if body has nil values" do
+    app = lambda { |env| [200, { 'Content-Type' => 'text/plain' }, [nil]] }
+    response = etag(app).call(request)
+    response[1]['ETag'].must_be_nil
+  end
+
   it "not set ETag if Last-Modified is set" do
     app = lambda { |env| [200, { 'Content-Type' => 'text/plain', 'Last-Modified' => Time.now.httpdate }, ["Hello, World!"]] }
     response = etag(app).call(request)


### PR DESCRIPTION
Prior to Rack v2.1.0, a `Rack::Response` initialized with `[nil]` would
be handled gracefully because `to_s` would be run on each element:
https://github.com/rack/rack/blob/85684323f8f58409e717af91e446d257d496f8b8/lib/rack/response.rb#L40-L43

Now that https://github.com/rack/rack/pull/1434/files has been merged,
if `[nil]` is used, the ETag calculations fails with:

```
NoMethodError (undefined method `empty?' for nil:NilClass):
rack (2.1.4) lib/rack/etag.rb:70:in `block in digest_body'
rack (2.1.4) lib/rack/body_proxy.rb:34:in `block in each'
rack (2.1.4) lib/rack/body_proxy.rb:34:in `each'
rack (2.1.4) lib/rack/body_proxy.rb:34:in `each'
rack (2.1.4) lib/rack/etag.rb:68:in `digest_body'
rack (2.1.4) lib/rack/etag.rb:31:in `call'
rack (2.1.4) lib/rack/conditional_get.rb:40:in `call'
rack (2.1.4) lib/rack/head.rb:14:in `call'
actionpack (6.0.3.3) lib/action_dispatch/http/content_security_policy.rb:18:in `call'
```

We restore the original behavior by calling `to_str` on each body part.

Fixes https://github.com/rack/rack/issues/1712