### PR TITLE
Fix warning

### DIFF
--- a/lib/rack/media_type.rb
+++ b/lib/rack/media_type.rb
@@ -15,7 +15,7 @@ module Rack
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7
       def type(content_type)
         return nil unless content_type
-        content_type.split(SPLIT_PATTERN, 2).first.tap &:downcase!
+        content_type.split(SPLIT_PATTERN, 2).first.tap(&:downcase!)
       end
 
       # The media type parameters provided in CONTENT_TYPE as a Hash, or


### PR DESCRIPTION
Running specs against JRuby 9.2.13.0 got the warning:

```
/Users/mike/.asdf/installs/ruby/jruby-9.2.13.0/lib/ruby/gems/shared/gems/rack-2.2.3/lib/rack/media_type.rb:18: warning: `&' interpreted as argument prefix
```

This PR should fix it.

UDP: CI was red before this PR