### PR TITLE
Skip rubocop for external tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -149,7 +149,7 @@ task :external do
   FileUtils.mv ".rubocop.yml", ".rack.rubocop.yml.disabled"
 
   Bundler.with_clean_env do
-    clone_and_test("https://github.com/kickstarter/rack-attack", "rack-attack", "bundle exec rake")
+    clone_and_test("https://github.com/rack/rack-attack", "rack-attack", "bundle exec rake test")
     clone_and_test("https://github.com/rtomayko/rack-cache", "rack-cache", "bundle exec rake")
     clone_and_test("https://github.com/socketry/falcon", "falcon", "bundle exec rspec")
   end


### PR DESCRIPTION
Rubocop [fails](https://travis-ci.org/github/rack/rack-attack/builds) on rack/rack-attack repo. This commit explicitly runs only the tests of the rack-attack repo which is what rack is concerned about.