### PR TITLE
Freeze Rack::VERSION

### DIFF
--- a/lib/rack/version.rb
+++ b/lib/rack/version.rb
@@ -13,11 +13,12 @@
 
 module Rack
   # The Rack protocol version number implemented.
-  VERSION = [1, 3]
+  VERSION = [1, 3].freeze
+  VERSION_STRING = VERSION.join(".").freeze
 
   # Return the Rack protocol version as a dotted string.
   def self.version
-    VERSION.join(".")
+    VERSION_STRING
   end
 
   RELEASE = "2.3.0"


### PR DESCRIPTION
The [Ractor primitive](https://github.com/ruby/ruby/blob/master/doc/ractor.md) from Ruby 3.0 requires all constants to be immutable and frozen.

This PR makes `Rack::VERSION` and `Rack.version` to be immutable objects.