### PR TITLE
Ruby 3

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.4, 2.5, 2.6, 2.7, jruby, truffleruby-head]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, jruby, truffleruby-head]
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem "webrick"
 gem "rubocop", require: false
 gem "rubocop-packaging", require: false
 


### PR DESCRIPTION
This adds Ruby 3 to GitHub Actions.

`webrick` is no longer bundled and need to be specified in the Gemfile.

> The following libraries are no longer bundled gems or standard libraries. Install the corresponding gems to use these features.
> sdbm
> webrick
> net-telnet
> xmlrpc

source: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/