### PR TITLE
📂 Add option for `gzip_compression_level` for `Rack::Deflater`. 

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -24,6 +24,10 @@ jobs:
         restore-keys: |
           bundle-use-ruby-${{matrix.os}}-${{matrix.ruby}}-
 
+    - name: Updating packages (ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get update
+
     - name: Installing packages (ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get install libfcgi-dev libmemcached-dev
@@ -60,6 +64,10 @@ jobs:
         key: bundle-use-ruby-${{matrix.os}}-${{matrix.ruby}}-${{hashFiles('**/Gemfile')}}
         restore-keys: |
           bundle-use-ruby-${{matrix.os}}-${{matrix.ruby}}-
+
+    - name: Updating packages (ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get update
 
     - name: Installing packages (ubuntu)
       if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Added
 
 - `Rack::RewindableInput` supports size. ([@ahorek](https://github.com/ahorek))
+- `Rack::Deflater` supports `gzip_compression_level`. ([@bayleedev](https://github.com/bayleedev))
 
 ### Changed
 

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -402,6 +402,31 @@ describe Rack::Deflater do
     verify(200, response, 'gzip', options)
   end
 
+  it 'will change gzip level' do
+    response = 'Hello World!' * 1000
+    small_options = {
+      'deflater_options' => { gzip_compression_level: 9 },
+      'skip_body_verify' => true,
+    }
+    fast_options = {
+      'deflater_options' => { gzip_compression_level: 1 },
+      'skip_body_verify' => true,
+    }
+    verify(200, response, 'gzip', small_options) do |_, _, body_small|
+      verify(200, response, 'gzip', fast_options) do |_, _, body_fast|
+        small_bytes = 0
+        body_small.each do |part|
+          small_bytes += part.bytesize
+        end
+        fast_bytes = 0
+        body_fast.each do |part|
+          fast_bytes += part.bytesize
+        end
+        assert small_bytes < fast_bytes
+      end
+    end
+  end
+
   it 'will honor sync: false to avoid unnecessary flushing' do
     app_body = Object.new
     class << app_body


### PR DESCRIPTION
This would be useful on a system with smaller memory to be set to a lower number, and a system with higher compression needs to compress up to level 9.

`:gzip_compression_level ::` An integer from 0 to 9 controlling the
level of compression; 1 is fastest and produces the least compression,
and 9 is slowest and produces the most compression. 0 is no compression.
The default is 6. This is only needed for the `gzip` type encoding.