### PR TITLE
Fix generation of multipart filename with space.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file. For info on
 - Fix using Rack::Session::Cookie with coder: Rack::Session::Cookie::Base64::{JSON,Zip}. ([#1666](https://github.com/rack/rack/issues/1666), [@jeremyevans](https://github.com/jeremyevans))
 - Avoid NoMethodError when accessing Rack::Session::Cookie without requiring delegate first. ([#1610](https://github.com/rack/rack/issues/1610), [@onigra](https://github.com/onigra))
 - Handle cookies with values that end in '=' ([#1645](https://github.com/rack/rack/pull/1645), [@lukaso](https://github.com/lukaso))
+- Fix multipart filename generation for filenames that contain spaces. Encode spaces as "%20" instead of "+" which will be decoded properly by the mulitpart parser. ([#1736](https://github.com/rack/rack/pull/1645), [@muirdm](https://github.com/muirdm))
 
 ## [2.2.3] - 2020-06-15
 
@@ -130,7 +131,7 @@ All notable changes to this project will be documented in this file. For info on
 - Support for using `:SSLEnable` option when using WEBrick handler. (Gregor Melhorn)
 - Close response body after buffering it when buffering. ([@ioquatix](https://github.com/ioquatix))
 - Only accept `;` as delimiter when parsing cookies. ([@mrageh](https://github.com/mrageh))
-- `Utils::HeaderHash#clear` clears the name mapping as well. ([@raxoft](https://github.com/raxoft)) 
+- `Utils::HeaderHash#clear` clears the name mapping as well. ([@raxoft](https://github.com/raxoft))
 - Support for passing `nil` `Rack::Files.new`, which notably fixes Rails' current `ActiveStorage::FileServer` implementation. ([@ioquatix](https://github.com/ioquatix))
 
 ### Documentation

--- a/lib/rack/multipart/generator.rb
+++ b/lib/rack/multipart/generator.rb
@@ -74,7 +74,7 @@ module Rack
 
       def content_for_tempfile(io, file, name)
         length = ::File.stat(file.path).size if file.path
-        filename = "; filename=\"#{Utils.escape(file.original_filename)}\"" if file.original_filename
+        filename = "; filename=\"#{Utils.escape_path(file.original_filename)}\"" if file.original_filename
 <<-EOF
 --#{MULTIPART_BOUNDARY}\r
 Content-Disposition: form-data; name="#{name}"#{filename}\r

--- a/test/multipart/space case.txt
+++ b/test/multipart/space case.txt
@@ -1,0 +1,1 @@
+contents

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -532,6 +532,22 @@ Content-Type: image/jpeg\r
     params["files"][:tempfile].read.must_equal "contents"
   end
 
+  it "builds multipart filename with space" do
+    files = Rack::Multipart::UploadedFile.new(multipart_file("space case.txt"))
+    data  = Rack::Multipart.build_multipart("submit-name" => "Larry", "files" => files)
+
+    options = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+      "CONTENT_LENGTH" => data.length.to_s,
+      :input => StringIO.new(data)
+    }
+    env = Rack::MockRequest.env_for("/", options)
+    params = Rack::Multipart.parse_multipart(env)
+    params["submit-name"].must_equal "Larry"
+    params["files"][:filename].must_equal "space case.txt"
+    params["files"][:tempfile].read.must_equal "contents"
+  end
+
   it "builds nested multipart body using array" do
     files = Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"))
     data  = Rack::Multipart.build_multipart("people" => [{ "submit-name" => "Larry", "files" => files }])


### PR DESCRIPTION
The multipart generator was escaping filenames using
Rack::Utils.escape, but the parser was using Rack::Utils.unescape_path.
If the file name contained spaces such as "foo bar.txt",
escape would encode as "foo+bar.txt" and then unescape_path would
decode to "foo+bar.txt", incorrectly leaving the plus sign. Fix by
changing the generator to use escape_path to match the parser.