### PR TITLE
CI: Workaround YAML gotcha in Actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, jruby, truffleruby-head]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', jruby, truffleruby-head]
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
To avoid unexpectedly stop testing Ruby 3.0 when Ruby 3.1 is released.

See https://github.com/actions/runner/issues/849

At https://github.com/rack/rack/runs/2041788658?check_suite_focus=true#step:3:3 we can see that the setup-ruby action ran with just `3` as the input and not `3.0`.