### PR TITLE
Clarify streaming response body behavior in SPEC

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -283,6 +283,10 @@ to that produced by calling +each+; this may be used by the
 server as an alternative, possibly more efficient way to
 transport the response.
 
+Strings must be processed individually as they are yielded by +each+.
+However, if the Body responds to +to_ary+ it can be implicitly coerced to
+an Array, which may then be processed all at once.
+
 The Body commonly is an Array of Strings, the application
 instance itself, or a File-like object.
 == Thanks

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -273,19 +273,26 @@ and must only yield String values.
 The Body itself should not be an instance of String, as this will
 break in Ruby 1.9.
 
+Middleware must not call +each+ directly on the Body.
+Instead, middleware can return a new Body that calls +each+ on the
+original Body, yielding at least once per iteration.
+
+If the Body responds to +to_ary+, it must return an Array whose
+contents are identical to that produced by calling +each+.
+Middleware may call +to_ary+ directly on the Body and return a new Body in its place.
+In other words, middleware can only process the Body directly if it responds to +to_ary+.
+
 If the Body responds to +close+, it will be called after iteration. If
-the body is replaced by a middleware after action, the original body
-must be closed first, if it responds to close.
+the original Body is replaced by a new Body, the new Body
+must close the original Body after iteration, if it responds to +close+.
+If the Body responds to both +to_ary+ and +close+, its
+implementation of +to_ary+ must call +close+ after iteration.
 
 If the Body responds to +to_path+, it must return a String
 identifying the location of a file whose contents are identical
 to that produced by calling +each+; this may be used by the
 server as an alternative, possibly more efficient way to
 transport the response.
-
-Strings must be processed individually as they are yielded by +each+.
-However, if the Body responds to +to_ary+ it can be implicitly coerced to
-an Array, which may then be processed all at once.
 
 The Body commonly is an Array of Strings, the application
 instance itself, or a File-like object.

--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -19,17 +19,11 @@ module Rack
 
       if !STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) &&
          !headers[CONTENT_LENGTH] &&
-         !headers[TRANSFER_ENCODING]
+         !headers[TRANSFER_ENCODING] &&
+         body.respond_to?(:to_ary)
 
-        obody = body
-        body, length = [], 0
-        obody.each { |part| body << part; length += part.bytesize }
-
-        body = BodyProxy.new(body) do
-          obody.close if obody.respond_to?(:close)
-        end
-
-        headers[CONTENT_LENGTH] = length.to_s
+        body = body.to_ary
+        headers[CONTENT_LENGTH] = body.sum(&:bytesize).to_s
       end
 
       [status, headers, body]

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -13,9 +13,7 @@ describe Rack::ETag do
   end
 
   def sendfile_body
-    res = ['Hello World']
-    def res.to_path ; "/tmp/hello.txt" ; end
-    res
+    File.new(File::NULL)
   end
 
   it "set ETag if none is set if status is 200" do


### PR DESCRIPTION
This PR stems from the discussion in #1745 concerning how to distinguish between streaming and buffered bodies in the Rack interface. The proposal here adds the following two sentences to the specification:

> Strings must be processed individually as they are yielded by `each`.
However, if the Body responds to `to_ary` it can be implicitly coerced to an Array, which may then be processed all at once.

I consider this more of a 'clarification' than a breaking change to the interface, as previous discussions and implementations in the Rack project have suggested that treating `Array` bodies (or objects coercible to `Array` via `#to_ary`) as fixed-length content, in contrast to any other response bodies which may be possibly-streaming, indeterminate content, had been implicit in the interface since at least Dec 2008 (7a0476be9289b6e38dbc27946168d41894439f42).

For example, see https://github.com/rack/rack/pull/166#commitcomment-391926 from May 2011:

> While to_ary is not mentioned in the rack spec, whether a body is an array has up until now signaled the difference between bodies of known size and bodies of unknown size, at least as far as choosing between chunked and non-chunked transfer encodings is concerned.

This PR also updates `ContentLength` and `ETag` middleware to demonstrate how this spec clarification can guide a more consistent implementation of 'buffering' middleware/servers in practice. There are a few steps:

1. Check `body.respond_to?(:to_ary)`, and skips the buffering/transformation logic if the response is not coercible to `Array`
2. Call `body = body.to_ary`, which coerces the response body to ensure that it is an `Array` of `Strings`.
3. Operate on the body as needed (calculate SHA256 digest, sum bytesize of strings, etc).

Some notes:

- Note that `BodyProxy` is no longer needed in middleware using this pattern, because `Array` objects never respond to `close`. (If `#close` is required by an object that can be coerced to an `Array`, it should close as part of its `to_ary` implementation. For example, see the update to the ['close bodies that need to be closed'](https://github.com/rack/rack/compare/master...wjordan:to_ary-buffered?expand=1#diff-7f91c8639db9f03cf387d37f31c3215617aa0f595c50d2f62ebaa49357807051R56-R67) content length spec test.)
- Web servers may also adopt this pattern as an optimization to buffer content into a String before writing to the socket (or write an array of Strings with a single call to `#write`), to reduce the number of socket writes.
- This doesn't affect and is unrelated to the (partial/full) hijack APIs (#481), though the clarification allows for more well-defined behavior for one of the use-cases (streaming responses) that hijack was also originally designed for, so it may make the latter slightly more redundant.
- There is a slight but significant difference between the proposed behavior and similar historical behavior relying on `respond_to?(:ary)` in `ContentLength`. Previously, the `to_ary` coercion was never actually _performed_ on the body before eager-loading, it was assumed the content was already buffered as long as the `respond_to?` was satisfied. However, this allowed for overriding `to_ary` to return anything, even `nil` (see e.g., the workaround in rails/rails#16793), just to trigger the eager-loading behavior without actually producing the required `Array` of `String`s representing fully-buffered content. In this proposal (and implementation), the coercion is actually performed which prevents this kind of confusion.
- Updates to `Rack::Lint` are included to help enforce this new clarification.