### PR TITLE
Output pid if the server is already running

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -438,7 +438,8 @@ module Rack
       def check_pid!
         case pidfile_process_status
         when :running, :not_owned
-          $stderr.puts "A server is already running. Check #{options[:pid]}."
+          pid = ::File.read(options[:pid])
+          $stderr.puts "A server is already running (pid: #{pid}, file: #{options[:pid]})."
           exit(1)
         when :dead
           ::File.delete(options[:pid])

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -430,8 +430,7 @@ describe Rack::Server do
       lambda { server.send(:write_pid) }.must_raise SystemExit
       err.rewind
       output = err.read
-      output.must_match(/already running/)
-      output.must_include pidfile
+      output.must_match(/already running \(pid: 1, file: #{pidfile}\)/)
     end
   end
 
@@ -442,8 +441,7 @@ describe Rack::Server do
       lambda { server.start }.must_raise SystemExit
       err.rewind
       output = err.read
-      output.must_match(/already running/)
-      output.must_include pidfile
+      output.must_match(/already running \(pid: 1, file: #{pidfile}\)/)
     end
   end
 


### PR DESCRIPTION
I sometimes find myself trying to run a duplicate server with the same pid file. When this happens, the startup fails and the path to the pid file is displayed, but it is a bit of a pain to open the file to check the pid each time.

Instead of showing the file path, how about showing the pid itself?


Before output:

```
A server is already running. Check /file/to/pid_file.
```

After output:

```
A server is already running (pid: 69431).
```