### PR TITLE
Add AWS Lambda Supported "Web Server"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,7 +37,7 @@ These web servers include \Rack handlers in their distributions:
 * Puma[https://puma.io/]
 * Unicorn[https://yhbt.net/unicorn/]
 * uWSGI[https://uwsgi-docs.readthedocs.io/en/latest/]
-* AWS Lambda[https://lamby.custominktech.com]
+* {AWS Lambda}[https://lamby.custominktech.com]
 
 Any valid \Rack app will run the same on all these handlers, without
 changing anything.

--- a/README.rdoc
+++ b/README.rdoc
@@ -37,6 +37,7 @@ These web servers include \Rack handlers in their distributions:
 * Puma[https://puma.io/]
 * Unicorn[https://yhbt.net/unicorn/]
 * uWSGI[https://uwsgi-docs.readthedocs.io/en/latest/]
+* AWS Lambda[https://lamby.custominktech.com]
 
 Any valid \Rack app will run the same on all these handlers, without
 changing anything.

--- a/README.rdoc
+++ b/README.rdoc
@@ -37,7 +37,7 @@ These web servers include \Rack handlers in their distributions:
 * Puma[https://puma.io/]
 * Unicorn[https://yhbt.net/unicorn/]
 * uWSGI[https://uwsgi-docs.readthedocs.io/en/latest/]
-* {AWS Lambda}[https://lamby.custominktech.com]
+* Lamby[https://lamby.custominktech.com] (for AWS Lambda)
 
 Any valid \Rack app will run the same on all these handlers, without
 changing anything.


### PR DESCRIPTION
Hey y'all, hope everyone is doing well. My name is Ken Collins and I work at [Custom Ink](https://twitter.com/custominktech) (the t-shirt place) and I have been fortunate enough to also be recognized by AWS as [Serverless Hero](https://aws.amazon.com/developer/community/heroes/ken-collins/). I have authored a Rack adapter, primarily targeted at Rails, to work with AWS Lambda. More info in the proposed link's destination and description.

https://lamby.custominktech.com

> Lamby is as a Rack adapter that converts AWS Lambda integration events into native Rack Environment objects which are sent directly to your application. Lamby can do this when using either API Gateway REST API, API Gateway HTTP API's v1/v2 payloads, or even Application Load Balancer (ALB) integrations. 

The fact our Ruby community has this HTTP standard to allow this to happen is just... well... amazing. I really appreciate the work by all the Rack contributors and the abstractions obtained. It has made the work I have done for Lambda really enjoyable. Coming from a Rails ActiveRecord Adapter background with SQL Server, I have found the work learning both Rack and HTTP a pleasant experience thanks to Rack. If you care to review the Lamby code, check out the rack files here. https://github.com/customink/lamby/tree/master/lib/lamby

## Possible Feedback?

Considering that y'all are open to helping promote this Rack project for AWS Lambda, is there anything else I can do to help or change the pull request in any way to meet other's needs? For example:

- Is this for Rails only? No... Lamby supports any Rack application and we have even decoupled our integration from Rails & ActiveSupport to allow that to happen easily thanks to contributions form others using Sinatra, etc.
- Would you rather the link go to our basic GitHub (https://github.com/customink/lamby) page? I'd prefer the little product site because it has that nice copy explaining how we leverage Rack.
- Do you have issues with this fitting into the web server section? It is a little mind bending but in these cases with Lambda & Rack integration the web server is best described as one of API Gateway (REST or HTTP) or an ALB. But if you tilt your head just right... the web server is basically Lambda since each instance is analogous to a server process. Given API Gateway & ALBs have other uses outside of Lambda "integrations", technically Lamby is a Rack adapter for Lambda. Hope that made sense. Thoughts?