### PR TITLE
Remove unnecessary call to `super()` in `Rack::Request::Env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to this project will be documented in this file. For info on
 - Handle cookies with values that end in '=' ([#1645](https://github.com/rack/rack/pull/1645), [@lukaso](https://github.com/lukaso))
 - Fix multipart filename generation for filenames that contain spaces. Encode spaces as "%20" instead of "+" which will be decoded properly by the multipart parser. ([#1736](https://github.com/rack/rack/pull/1645), [@muirdm](https://github.com/muirdm))
 - `Rack::Request#scheme` returns `ws` or `wss` when one of the `X-Forwarded-Scheme` / `X-Forwarded-Proto` headers is set to `ws` or `wss`, respectively. ([#1730](https://github.com/rack/rack/issues/1730), [@erwanst](https://github.com/erwanst))
-- `Rack::Request::Env#initialize` does not need to call `super()`. This was leftover from the creation of the `Env` module. ([#1751](https://github.com/rack/rack/pull/1751)), [@agrberg](https://github.com/agrberg))
+- `Rack::Request::Env#initialize` does not need to call `super()`. This was leftover from the creation of the `Env` module. Flatten the `Env` module into `Request` as it is unused outside. ([#1751](https://github.com/rack/rack/pull/1751)), [@agrberg](https://github.com/agrberg))
 
 ## [2.2.3] - 2020-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file. For info on
 - Handle cookies with values that end in '=' ([#1645](https://github.com/rack/rack/pull/1645), [@lukaso](https://github.com/lukaso))
 - Fix multipart filename generation for filenames that contain spaces. Encode spaces as "%20" instead of "+" which will be decoded properly by the multipart parser. ([#1736](https://github.com/rack/rack/pull/1645), [@muirdm](https://github.com/muirdm))
 - `Rack::Request#scheme` returns `ws` or `wss` when one of the `X-Forwarded-Scheme` / `X-Forwarded-Proto` headers is set to `ws` or `wss`, respectively. ([#1730](https://github.com/rack/rack/issues/1730), [@erwanst](https://github.com/erwanst))
+- `Rack::Request::Env#initialize` does not need to call `super()`. This was leftover from the creation of the `Env` module. ([#1751](https://github.com/rack/rack/pull/1751)), [@agrberg](https://github.com/agrberg))
 
 ## [2.2.3] - 2020-06-15
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -49,7 +49,6 @@ module Rack
 
       def initialize(env)
         @env = env
-        super()
       end
 
       # Predicate method to test to see if `name` has been set as request

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -17,6 +17,10 @@ module Rack
     end
 
     self.ip_filter = lambda { |ip| /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i.match?(ip) }
+
+    # The environment of the request.
+    attr_reader :env
+
     ALLOWED_SCHEMES = %w(https http wss ws).freeze
     SCHEME_WHITELIST = ALLOWED_SCHEMES
     if Object.respond_to?(:deprecate_constant)
@@ -24,8 +28,8 @@ module Rack
     end
 
     def initialize(env)
+      @env = env
       @params = nil
-      super(env)
     end
 
     def params
@@ -43,68 +47,59 @@ module Rack
       v
     end
 
-    module Env
-      # The environment of the request.
-      attr_reader :env
+    # Predicate method to test to see if `name` has been set as request
+    # specific data
+    def has_header?(name)
+      @env.key? name
+    end
 
-      def initialize(env)
-        @env = env
-      end
+    # Get a request specific value for `name`.
+    def get_header(name)
+      @env[name]
+    end
 
-      # Predicate method to test to see if `name` has been set as request
-      # specific data
-      def has_header?(name)
-        @env.key? name
-      end
+    # If a block is given, it yields to the block if the value hasn't been set
+    # on the request.
+    def fetch_header(name, &block)
+      @env.fetch(name, &block)
+    end
 
-      # Get a request specific value for `name`.
-      def get_header(name)
-        @env[name]
-      end
+    # Loops through each key / value pair in the request specific data.
+    def each_header(&block)
+      @env.each(&block)
+    end
 
-      # If a block is given, it yields to the block if the value hasn't been set
-      # on the request.
-      def fetch_header(name, &block)
-        @env.fetch(name, &block)
-      end
+    # Set a request specific value for `name` to `v`
+    def set_header(name, v)
+      @env[name] = v
+    end
 
-      # Loops through each key / value pair in the request specific data.
-      def each_header(&block)
-        @env.each(&block)
+    # Add a header that may have multiple values.
+    #
+    # Example:
+    #   request.add_header 'Accept', 'image/png'
+    #   request.add_header 'Accept', '*/*'
+    #
+    #   assert_equal 'image/png,*/*', request.get_header('Accept')
+    #
+    # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+    def add_header(key, v)
+      if v.nil?
+        get_header key
+      elsif has_header? key
+        set_header key, "#{get_header key},#{v}"
+      else
+        set_header key, v
       end
+    end
 
-      # Set a request specific value for `name` to `v`
-      def set_header(name, v)
-        @env[name] = v
-      end
+    # Delete a request specific value for `name`.
+    def delete_header(name)
+      @env.delete name
+    end
 
-      # Add a header that may have multiple values.
-      #
-      # Example:
-      #   request.add_header 'Accept', 'image/png'
-      #   request.add_header 'Accept', '*/*'
-      #
-      #   assert_equal 'image/png,*/*', request.get_header('Accept')
-      #
-      # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-      def add_header(key, v)
-        if v.nil?
-          get_header key
-        elsif has_header? key
-          set_header key, "#{get_header key},#{v}"
-        else
-          set_header key, v
-        end
-      end
-
-      # Delete a request specific value for `name`.
-      def delete_header(name)
-        @env.delete name
-      end
-
-      def initialize_copy(other)
-        @env = other.env.dup
-      end
+    def initialize_copy(other)
+      @env = other.env.dup
     end
 
     module Helpers
@@ -642,7 +637,6 @@ module Rack
       end
     end
 
-    include Env
     include Helpers
   end
 end


### PR DESCRIPTION
b2d73960e9ea6b8b15321ef190f13a290d1aedf0 changed `Rack::Request#initialize` to call `super(env)` so that the newly added `Rack::Request::Env#initialize` could be called. Previously `Rack::Request#initialize` called `super()` so `Rack::Request::Helpers#initialize` was called. This method was removed but the `super()` call was left in `Rack::Request::Env#initialize` as if it was still needed.

I don't believe this is hurting anything, it just begs the question of why there is a `super()` call that essentially goes to `BasicObject#initialize` (this is according to IRB diving, as this method isn't documented in the [Ruby docs](https://ruby-doc.org/core-3.0.1/BasicObject.html)).