### PR TITLE
Fix MockRequest cookie parsing for hash with array value

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -233,18 +233,20 @@ module Rack
       cookies = Hash.new
       if headers.has_key? 'Set-Cookie'
         set_cookie_header = headers.fetch('Set-Cookie')
-        set_cookie_header.split("\n").each do |cookie|
-          cookie_name, cookie_filling = cookie.split('=', 2)
-          cookie_attributes = identify_cookie_attributes cookie_filling
-          parsed_cookie = CGI::Cookie.new(
-            'name' => cookie_name.strip,
-            'value' => cookie_attributes.fetch('value'),
-            'path' => cookie_attributes.fetch('path', nil),
-            'domain' => cookie_attributes.fetch('domain', nil),
-            'expires' => cookie_attributes.fetch('expires', nil),
-            'secure' => cookie_attributes.fetch('secure', false)
-          )
-          cookies.store(cookie_name, parsed_cookie)
+        Array(set_cookie_header).each do |header_value|
+          header_value.split("\n").each do |cookie|
+            cookie_name, cookie_filling = cookie.split('=', 2)
+            cookie_attributes = identify_cookie_attributes cookie_filling
+            parsed_cookie = CGI::Cookie.new(
+              'name' => cookie_name.strip,
+              'value' => cookie_attributes.fetch('value'),
+              'path' => cookie_attributes.fetch('path', nil),
+              'domain' => cookie_attributes.fetch('domain', nil),
+              'expires' => cookie_attributes.fetch('expires', nil),
+              'secure' => cookie_attributes.fetch('secure', false)
+            )
+            cookies.store(cookie_name, parsed_cookie)
+          end
         end
       end
       cookies

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -345,6 +345,15 @@ describe Rack::MockResponse do
     second_cookie.value[0].must_equal "times"
   end
 
+  it "parses multiple set-cookie headers provided as hash with array value" do
+    cookie_headers = { "set-cookie" => ["array=awesome", "multiple=times"]}
+    res = Rack::MockRequest.new(->(env) { [200, cookie_headers, [""]] }).get("")
+    array_cookie = res.cookie("array")
+    array_cookie.value[0].must_equal "awesome"
+    second_cookie = res.cookie("multiple")
+    second_cookie.value[0].must_equal "times"
+  end
+
   it "provide access to the HTTP body" do
     res = Rack::MockRequest.new(app).get("")
     res.body.must_match(/rack/)


### PR DESCRIPTION
### Problem:
`Rack::Response.new` allows to set multiple cookies just by passing hash with key 'Set-Cookie' and value as an array containing cookies we want to set.
example:
```ruby
Rack::Response.new(
  [ "Authentication failed" ],
  401,
  {
    "Content-type" => "text/error",
    "Set-Cookie" => ["foo=bar", "baz=ban"]
  }
)
```
Unfortunately `MockRequest` class is not able to parse such definition of cookies as it expects cookie value to be always a string.

### Solution:
Wrap every cookie value to `Array()` which converts string values to array. So we can safely iterate over the values. In case the value is already an array it simply return it.