### PR TITLE
Properly set the expires attribute for the mock response cookie

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -4,6 +4,7 @@ require 'uri'
 require 'stringio'
 require_relative '../rack'
 require 'cgi/cookie'
+require 'time'
 
 module Rack
   # Rack::MockRequest helps testing your Rack application without
@@ -260,14 +261,18 @@ module Rack
         if bit.include? '='
           cookie_attribute, attribute_value = bit.split('=', 2)
           cookie_attributes.store(cookie_attribute.strip, attribute_value.strip)
-          if cookie_attribute.include? 'max-age'
-            cookie_attributes.store('expires', Time.now + attribute_value.strip.to_i)
-          end
         end
         if bit.include? 'secure'
           cookie_attributes.store('secure', true)
         end
       end
+
+      if cookie_attributes.key? 'max-age'
+        cookie_attributes.store('expires', Time.now + cookie_attributes['max-age'].to_i)
+      elsif cookie_attributes.key? 'expires'
+        cookie_attributes.store('expires', Time.httpdate(cookie_attributes['expires']))
+      end
+
       cookie_attributes
     end
 


### PR DESCRIPTION
Prior to this change, cookies with the `Expires` attribute would have the attribute stored as a `String` object  rather than a `Time` object. `CGI::Cookie` expects a `Time` object [[1]]. Having strings could lead to confusing errors later on. For example, calling `Rack::MockResponse#inspect` would lead to ``undefined method `gmtime' for "Fri, 03 Jun 2022 19:37:33 GMT":String``.

As per RFC 6265, if a cookie has both the `Max-Age` and the `Expires` attribute, `Max-Age` has precedence. [[2]]

[1]: https://ruby-doc.org/stdlib-3.0.1/libdoc/cgi/rdoc/CGI/Cookie.html
[2]: https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.2