### PR TITLE
Remove functionality for Rack::Utils.key_space_limit

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -178,15 +178,8 @@ Several parameters can be modified on Rack::Utils to configure \Rack behaviour.
 
 e.g:
 
-    Rack::Utils.key_space_limit = 128
+    Rack::Utils.param_depth_limit = 3
 
-=== key_space_limit
-
-The default number of bytes to allow all parameters keys in a given parameter hash to take up.
-Does not affect nested parameter hashes, so doesn't actually prevent an attacker from using
-more than this many bytes for parameter keys.
-
-Defaults to 65536 characters.
 
 === param_depth_limit
 
@@ -213,6 +206,10 @@ The default is 128, which means that a single request can't upload more than 128
 Set to 0 for no limit.
 
 Can also be set via the +RACK_MULTIPART_PART_LIMIT+ environment variable.
+
+=== key_space_limit
+
+No longer has an effect, deprecated.
 
 == Changelog
 

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -14,19 +14,23 @@ module Rack
     # sequence.
     class InvalidParameterError < ArgumentError; end
 
-    def self.make_default(param_depth_limit)
-      new Params, nil, param_depth_limit
+    def self.make_default(_key_space_limit=(not_deprecated = true; nil), param_depth_limit)
+      unless not_deprecated
+        warn("`first argument `key_space limit` is deprecated and no longer has an effect. Please call with only one argument, which will be required in a future version of Rack", uplevel: 1)
+      end
+
+      new Params, param_depth_limit
     end
 
     attr_reader :param_depth_limit
 
-    def initialize(params_class, key_space_limit, param_depth_limit)
+    def initialize(params_class, _key_space_limit=(not_deprecated = true; nil), param_depth_limit)
+      unless not_deprecated
+        warn("`second argument `key_space limit` is deprecated and no longer has an effect. Please call with only two arguments, which will be required in a future version of Rack", uplevel: 1)
+      end
+
       @params_class = params_class
       @param_depth_limit = param_depth_limit
-
-      unless key_space_limit.nil?
-        warn("`second argument `key_space limit` is deprecated and no longer has an effect. It will be removed in a future version of Rack", uplevel: 1)
-      end
     end
 
     # Stolen from Mongrel, with some small modifications:
@@ -127,7 +131,7 @@ module Rack
     end
 
     def new_depth_limit(param_depth_limit)
-      self.class.new @params_class, nil, param_depth_limit
+      self.class.new @params_class, param_depth_limit
     end
 
     private

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -70,6 +70,11 @@ module Rack
       self.default_query_parser = self.default_query_parser.new_depth_limit(v)
     end
 
+    def self.key_space_limit
+      warn("`Rack::Utils.key_space_limit` is deprecated as this value no longer has an effect. It will be removed in a future version of Rack", uplevel: 1)
+      65536
+    end
+
     def self.key_space_limit=(v)
       warn("`Rack::Utils.key_space_limit=` is deprecated and no longer has an effect. It will be removed in a future version of Rack", uplevel: 1)
     end

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -23,9 +23,10 @@ module Rack
     class << self
       attr_accessor :default_query_parser
     end
-    # The default number of bytes to allow parameter keys to take up.
-    # This helps prevent a rogue client from flooding a Request.
-    self.default_query_parser = QueryParser.make_default(65536, 32)
+    # The default amount of nesting to allowed by hash parameters.
+    # This helps prevent a rogue client from triggering a possible stack overflow
+    # when parsing parameters.
+    self.default_query_parser = QueryParser.make_default(32)
 
     module_function
 
@@ -69,12 +70,8 @@ module Rack
       self.default_query_parser = self.default_query_parser.new_depth_limit(v)
     end
 
-    def self.key_space_limit
-      default_query_parser.key_space_limit
-    end
-
     def self.key_space_limit=(v)
-      self.default_query_parser = self.default_query_parser.new_space_limit(v)
+      warn("`Rack::Utils.key_space_limit=` is deprecated and no longer has an effect. It will be removed in a future version of Rack", uplevel: 1)
     end
 
     if defined?(Process::CLOCK_MONOTONIC)

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -98,17 +98,6 @@ describe Rack::Multipart do
     params['user_sid'].encoding.must_equal Encoding::UTF_8
   end
 
-  it "raise RangeError if the key space is exhausted" do
-    env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_filename))
-
-    old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 1
-    begin
-      lambda { Rack::Multipart.parse_multipart(env) }.must_raise(RangeError)
-    ensure
-      Rack::Utils.key_space_limit = old
-    end
-  end
-
   it "parse multipart form webkit style" do
     env = Rack::MockRequest.env_for '/', multipart_fixture(:webkit)
     env['CONTENT_TYPE'] = "multipart/form-data; boundary=----WebKitFormBoundaryWLHCs9qmcJJoyjKR"
@@ -219,7 +208,7 @@ describe Rack::Multipart do
         @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
-    query_parser = Rack::QueryParser.new c, 65536, 100
+    query_parser = Rack::QueryParser.new c, nil, 100
     env = Rack::MockRequest.env_for("/", multipart_fixture(:text))
     params = Rack::Multipart.parse_multipart(env, query_parser)
     params[:files][:type].must_equal "text/plain"

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -208,7 +208,7 @@ describe Rack::Multipart do
         @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
-    query_parser = Rack::QueryParser.new c, nil, 100
+    query_parser = Rack::QueryParser.new c, 100
     env = Rack::MockRequest.env_for("/", multipart_fixture(:text))
     params = Rack::Multipart.parse_multipart(env, query_parser)
     params[:files][:type].must_equal "text/plain"

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -295,7 +295,7 @@ class RackRequestTest < Minitest::Spec
         @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
-    parser = Rack::QueryParser.new(c, nil, 100)
+    parser = Rack::QueryParser.new(c, 100)
     c = Class.new(Rack::Request) do
       define_method(:query_parser) do
         parser
@@ -362,7 +362,7 @@ class RackRequestTest < Minitest::Spec
         @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
-    parser = Rack::QueryParser.new(c, nil, 100)
+    parser = Rack::QueryParser.new(c, 100)
     c = Class.new(Rack::Request) do
       define_method(:query_parser) do
         parser

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -295,7 +295,7 @@ class RackRequestTest < Minitest::Spec
         @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
-    parser = Rack::QueryParser.new(c, 65536, 100)
+    parser = Rack::QueryParser.new(c, nil, 100)
     c = Class.new(Rack::Request) do
       define_method(:query_parser) do
         parser
@@ -314,32 +314,6 @@ class RackRequestTest < Minitest::Spec
     req.GET.must_equal "foo" => "bar", "quux" => "b;la;wun=duh"
     req.POST.must_be :empty?
     req.params.must_equal "foo" => "bar", "quux" => "b;la;wun=duh"
-  end
-
-  it "limit the keys from the GET query string" do
-    env = Rack::MockRequest.env_for("/?foo=bar")
-
-    old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 1
-    begin
-      req = make_request(env)
-      lambda { req.GET }.must_raise RangeError
-    ensure
-      Rack::Utils.key_space_limit = old
-    end
-  end
-
-  it "limit the key size per nested params hash" do
-    nested_query = Rack::MockRequest.env_for("/?foo%5Bbar%5D%5Bbaz%5D%5Bqux%5D=1")
-    plain_query  = Rack::MockRequest.env_for("/?foo_bar__baz__qux_=1")
-
-    old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 3
-    begin
-      exp = { "foo" => { "bar" => { "baz" => { "qux" => "1" } } } }
-      make_request(nested_query).GET.must_equal exp
-      lambda { make_request(plain_query).GET  }.must_raise RangeError
-    ensure
-      Rack::Utils.key_space_limit = old
-    end
   end
 
   it "limit the allowed parameter depth when parsing parameters" do
@@ -388,7 +362,7 @@ class RackRequestTest < Minitest::Spec
         @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
       end
     end
-    parser = Rack::QueryParser.new(c, 65536, 100)
+    parser = Rack::QueryParser.new(c, nil, 100)
     c = Class.new(Rack::Request) do
       define_method(:query_parser) do
         parser
@@ -436,20 +410,6 @@ class RackRequestTest < Minitest::Spec
     req.GET.must_equal "foo" => "quux"
     req.POST.must_equal "foo" => "bar", "quux" => "bla"
     req.params.must_equal "foo" => "bar", "quux" => "bla"
-  end
-
-  it "limit the keys from the POST form data" do
-    env = Rack::MockRequest.env_for("",
-            "REQUEST_METHOD" => 'POST',
-            :input => "foo=bar&quux=bla")
-
-    old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 1
-    begin
-      req = make_request(env)
-      lambda { req.POST }.must_raise RangeError
-    ensure
-      Rack::Utils.key_space_limit = old
-    end
   end
 
   it "parse POST data with explicit content type regardless of method" do

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -114,13 +114,26 @@ describe Rack::Utils do
     ex = { "foo" => nil }
     ex["foo"] = ex
 
-    params = Rack::Utils::KeySpaceConstrainedParams.new(65536)
+    params = Rack::Utils::KeySpaceConstrainedParams.new
     params['foo'] = params
     params.to_params_hash.to_s.must_equal ex.to_s
   end
 
   it "parse nil as an empty query string" do
     Rack::Utils.parse_nested_query(nil).must_equal({})
+  end
+
+  it "should warn using deprecated Rack::Util.key_space_limit=" do
+    begin
+      warn_arg = nil
+      Rack::Utils.define_singleton_method(:warn) do |*args|
+        warn_arg = args.first
+      end
+      Rack::Utils.key_space_limit = 65536
+      warn_arg.must_equal("`Rack::Utils.key_space_limit=` is deprecated and no longer has an effect. It will be removed in a future version of Rack")
+    ensure
+      Rack::Utils.singleton_class.send(:remove_method, :warn)
+    end
   end
 
   it "raise an exception if the params are too deep" do
@@ -259,7 +272,7 @@ describe Rack::Utils do
           @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
         end
       end
-      Rack::Utils.default_query_parser = Rack::QueryParser.new(param_parser_class, 65536, 100)
+      Rack::Utils.default_query_parser = Rack::QueryParser.new(param_parser_class, nil, 100)
       h1 = Rack::Utils.parse_query(",foo=bar;,", ";,")
       h1[:foo].must_equal "bar"
       h2 = Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][w]=2")

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -136,6 +136,19 @@ describe Rack::Utils do
     end
   end
 
+  it "should warn using deprecated Rack::Util.key_space_limit" do
+    begin
+      warn_arg = nil
+      Rack::Utils.define_singleton_method(:warn) do |*args|
+        warn_arg = args.first
+      end
+      Rack::Utils.key_space_limit
+      warn_arg.must_equal("`Rack::Utils.key_space_limit` is deprecated as this value no longer has an effect. It will be removed in a future version of Rack")
+    ensure
+      Rack::Utils.singleton_class.send(:remove_method, :warn)
+    end
+  end
+
   it "raise an exception if the params are too deep" do
     len = Rack::Utils.param_depth_limit
 
@@ -272,7 +285,7 @@ describe Rack::Utils do
           @params = Hash.new{|h, k| h[k.to_s] if k.is_a?(Symbol)}
         end
       end
-      Rack::Utils.default_query_parser = Rack::QueryParser.new(param_parser_class, nil, 100)
+      Rack::Utils.default_query_parser = Rack::QueryParser.new(param_parser_class, 100)
       h1 = Rack::Utils.parse_query(",foo=bar;,", ";,")
       h1[:foo].must_equal "bar"
       h2 = Rack::Utils.parse_nested_query("x[y][][z]=1&x[y][][w]=2")


### PR DESCRIPTION
It was determined that as this limit did not affect nested parameter hashes, it didn't actually prevent an attacker from using more than limited number of bytes for parameter keys, so this limit isn't actually doing anything useful. It is confusing people when it gets in the way of desired large parameter requests.

See notes by and conversation with @jeremyevans at https://github.com/rack/rack/pull/1487

So I decided to take a stab at removing it. 

It ended up being a little bit trickier than simply deprecating `Rack::Utils.key_space_limit=` -- although I have done that. But this parameter had kind of wormed it's way into several different methods and classes. 

I wasn't sure if I should leave every single one for backwards compatibility; in this first draft I do not. 

* changed QueryParser.make_default(key_space_limit, param_depth_limit) to just QueryParser.make_default(param_depth_limit). 

* And changed Rack::QueryParser::Params.new to not take a limit. 

* But left RackQueryParser.new() with it's second positional key_space_limit arg (which just no-ops and issues deprecation message), because it seems somewhat more likely to be used by third party code, and changing a 3-positional-arg signature to 2 by removing the middle one seems especially confusing. 

* Removed QueryParser.key_space_limit reader, but left QueryParser.key_space_limit= writer as a no-op deprecated, because we KNOW the latter is used by callers wanting to increase it!

I can change these choices if you let me know what you'd prefer. Leave ALL of that stuff, with deprecation warnings, like `Rack::QueryParser::Params.new(arg)` would get you a deprecation warning? I can do that!

It's also not clear to me how this fits into Rack release plans (if any). CHANGELOG makes it look like there's an upcoming 3.0 release... but we shouldn't put in deprecations in a 3.0 release... so would that mean this should actually be PR'd to a 2.x patch release? Not sure if I should change my PR base, or what. Didn't put anything in CHANGELOG cause didn't know what was going on with that. 

As usual with software like this, what seemed like it shoudl be a simple change ended up tangled in a few different places/choices.... might be more trouble than it's worth? But I thought I'd at least make a stab at it, feedback welcome. 