### PR TITLE
Parse 'expires' to Time in MockResponse cookies

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -4,6 +4,7 @@ require 'uri'
 require 'stringio'
 require_relative '../rack'
 require 'cgi/cookie'
+require 'time'  # for Time.httpdate
 
 module Rack
   # Rack::MockRequest helps testing your Rack application without
@@ -265,6 +266,10 @@ module Rack
         if bit.include? 'secure'
           cookie_attributes.store('secure', true)
         end
+      end
+      # the 'expires' attribute, if set, must be an instance of Time
+      if (expires = cookie_attributes['expires']).is_a? String
+        cookie_attributes.store('expires', Time.httpdate(expires))
       end
       cookie_attributes
     end

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -21,6 +21,7 @@ app = Rack::Lint.new(lambda { |env|
   response.set_cookie("session_test", { value: "session_test", domain: ".test.com", path: "/" })
   response.set_cookie("secure_test", { value: "secure_test", domain: ".test.com",  path: "/", secure: true })
   response.set_cookie("persistent_test", { value: "persistent_test", max_age: 15552000, path: "/" })
+  response.set_cookie("expires_test", { value: "expires_test", expires: (Time.now + 86400), path: "/" })
   response.finish
 })
 
@@ -317,6 +318,17 @@ describe Rack::MockResponse do
     secure_cookie.path.must_equal "/"
     secure_cookie.secure.must_equal true
     secure_cookie.expires.must_be_nil
+  end
+
+  it "handles 'expires' in cookies" do
+    res = Rack::MockRequest.new(app).get("")
+    expires_cookie = res.cookie("expires_test")
+    expires_cookie.value[0].must_equal "expires_test"
+    expires_cookie.domain.must_be_nil
+    expires_cookie.path.must_equal "/"
+    expires_cookie.secure.must_equal false
+    expires_cookie.expires.wont_be_nil
+    expires_cookie.expires.must_be :<, (Time.now + 86400)
   end
 
   it "parses cookie headers with equals sign at the end" do


### PR DESCRIPTION
CGI::Cookie expects the 'expires' attribute, if set, to be an instance
of Time.  While this was being correctly set for 'max-age', 'expires'
was set as-is, a String.  This caused errors when inspecting the
response, as CGI::Cookie#inspect calls #gmtime on the 'expires' value.

This commit fixes MockResponse to parse 'expires' as an RFC1123
formatted date/time when parsing cookies from the header.

Fixes #1758.