### PR TITLE
process_filename_asterisk_before_filename

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -300,10 +300,10 @@ module Rack
         when RFC2183
           params = Hash[*head.scan(DISPPARM).flat_map(&:compact)]
 
-          if filename = params['filename']
-            filename = $1 if filename =~ /^"(.*)"$/
-          elsif filename = params['filename*']
+          if filename = params['filename*']
             encoding, _, filename = filename.split("'", 3)
+          elsif filename = params['filename']
+            filename = $1 if filename =~ /^"(.*)"$/
           end
         when BROKEN_QUOTED, BROKEN_UNQUOTED
           filename = $1


### PR DESCRIPTION
when I post a form data with file that Content-Deposition contain both `filename` and `filename*` like below
```
"Content-Disposition: form-data; name=\"file\"; filename=\"\xE9\xA2\xA8\xE6\x99\xAF.jpeg\"; filename*=UTF-8''%E9%A2%A8%E6%99%AF.jpeg\r\nContent-Type: image/jpeg\r\n"
```

I am expecting that `filename*` having higher priority to be parsed, because it has encoding information that `filename` don't have.
and also in [MDN Doc - Content Depositioon](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) said 
> filename and filename* are present in a single header field value, filename* is preferred over filename when both are understood.

so I think it might be good to switch the condition order inside `get_filename` method.

PS: Since I don't know should we test the private method, so I just bypass the test case, please let me know if I still need to write test, thanks.