### PR TITLE
Remove an example that passes options on the first `#\` line [ci skip]

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -78,8 +78,6 @@ module Rack
     #
     #   $ cat config.ru
     #
-    #   #\ -p 9393
-    #
     #   use Rack::ContentLength
     #   require './app.rb'
     #   run App


### PR DESCRIPTION
This feature was deprecated since #1574.