### PR TITLE
Don't ary.inspect in the lint assertions (backport)

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -48,10 +48,10 @@ module Rack
 
       ## and returns an Array of exactly three values:
       ary = @app.call(env)
-      assert("response #{ary.inspect} is not an Array , but #{ary.class}") {
+      assert("response is not an Array, but #{ary.class}") {
         ary.kind_of? Array
       }
-      assert("response array #{ary.inspect} has #{ary.size} elements instead of 3") {
+      assert("response array has #{ary.size} elements instead of 3") {
         ary.size == 3
       }
 

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -156,7 +156,7 @@ describe Rack::Lint do
         []
       }).call(env("rack.multipart.tempfile_factory" => lambda { |filename, content_type| String.new }))
     }.must_raise(Rack::Lint::LintError).
-      message.must_equal "response array [] has 0 elements instead of 3"
+      message.must_equal "response array has 0 elements instead of 3"
 
     lambda {
       Rack::Lint.new(nil).call(env("REQUEST_METHOD" => "FUCKUP?"))
@@ -250,14 +250,14 @@ describe Rack::Lint do
                        ""
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
-      message.must_include('response "" is not an Array , but String')
+      message.must_include('response is not an Array, but String')
 
     lambda {
       Rack::Lint.new(lambda { |env|
                        [nil, nil, nil, nil]
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
-      message.must_include('response array [nil, nil, nil, nil] has 4 elements instead of 3')
+      message.must_include('response array has 4 elements instead of 3')
   end
 
   it "notice status errors" do


### PR DESCRIPTION
This is a backport to 2.2 of #1626 (fixing #1625)