### PR TITLE
handler, update comment to reflect current state

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -3,7 +3,7 @@
 module Rack
   # *Handlers* connect web servers with Rack.
   #
-  # Rack includes Handlers for WEBrick and CGI
+  # Rack includes Handlers for WEBrick and CGI.
   #
   # Handlers usually are activated by calling <tt>MyHandler.run(myapp)</tt>.
   # A second optional hash can be passed to include server-specific


### PR DESCRIPTION
handlers were removed in https://github.com/rack/rack/commit/98d9cf5834d4e27e34bbaa017cdfc68795763b55 but comment still says it is there.
removed it from the comment.