### PR TITLE
Fix MockResponse encoding

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -200,6 +200,10 @@ module Rack
     end
 
     def body
+      # By default String.new creates an object in ASCII-8BIT encoding
+      # We should specify the encoding according to Rack::Response#body encoding
+      encoding = super.join.encoding.to_s
+
       # FIXME: apparently users of MockResponse expect the return value of
       # MockResponse#body to be a string.  However, the real response object
       # returns the body as a list.
@@ -210,7 +214,7 @@ module Rack
       #     ...
       #     res.body.should == "foo!"
       #   end
-      buffer = String.new
+      buffer = String.new.force_encoding(encoding)
 
       super.each do |chunk|
         buffer << chunk

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -393,6 +393,13 @@ describe Rack::MockResponse do
       Rack::MockRequest.new(lambda { |env| env['rack.errors'].write(env['rack.errors'].string) }).get("/", fatal: true)
     }.must_raise(Rack::MockRequest::FatalWarning).message.must_equal ''
   end
+
+  it "allows Rack::Response encoding" do
+    encoding = 'Windows-1251'
+    body = String.new('body').force_encoding(encoding)
+    res = Rack::MockResponse.new(200, {}, body)
+    res.body.encoding.to_s.must_equal encoding
+  end
 end
 
 describe Rack::MockResponse, 'headers' do

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -396,7 +396,7 @@ describe Rack::MockResponse do
 
   it "allows Rack::Response encoding" do
     encoding = 'Windows-1251'
-    body = String.new('body').force_encoding(encoding)
+    body = String.new('(Ответ*)').force_encoding(encoding)
     res = Rack::MockResponse.new(200, {}, body)
     res.body.encoding.to_s.must_equal encoding
   end


### PR DESCRIPTION
During my work connected with rack update, I've noticed that Rack::MockResponse#body returns a string with default ASCII-8BIT encoding. That behavior differs from rack version < 2 where implementation of MockResponse#body was just `super.join`
I decided to implement encoding accept for `body` method for testing encoding of real response.
