### PR TITLE
Update trusted_proxy? to match on 127.0.0.0/8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. For info on
 - Decrease default allowed parameter recursion level from 100 to 32. ([#1640](https://github.com/rack/rack/issues/1640), [@jeremyevans](https://github.com/jeremyevans))
 - Attempting to parse a multipart response with an empty body now raises Rack::Multipart::EmptyContentError. ([#1603](https://github.com/rack/rack/issues/1603), [@jeremyevans](https://github.com/jeremyevans))
 - `Rack::Utils.secure_compare` uses OpenSSL's faster implementation if available. ([#1711](https://github.com/rack/rack/pull/1711), [@bdewater](https://github.com/bdewater))
+- BREAKING CHANGE: Updated `trusted_proxy?` to match full 127.0.0.0/8 network. ([#1781](https://github.com/rack/rack/pull/1781), [@snbloch](https://github.com/snbloch))
 
 ### Fixed
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,7 +16,7 @@ module Rack
       attr_accessor :ip_filter
     end
 
-    self.ip_filter = lambda { |ip| /\A127\.0\.0\.1\Z|\A(10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i.match?(ip) }
+    self.ip_filter = lambda { |ip| /\A(127|10|172\.(1[6-9]|2[0-9]|30|31)|192\.168)\.|\A::1\Z|\Afd[0-9a-f]{2}:.+|\Alocalhost\Z|\Aunix\Z|\Aunix:/i.match?(ip) }
     ALLOWED_SCHEMES = %w(https http wss ws).freeze
     SCHEME_WHITELIST = ALLOWED_SCHEMES
     if Object.respond_to?(:deprecate_constant)

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,19 +16,24 @@ module Rack
       attr_accessor :ip_filter
     end
 
-    TRUSTED_PROXIES = /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z|\A::1\Z|\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z|\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z|\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z|\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z|\Alocalhost\Z|\Aunix\Z|\Aunix:/i
+    TRUSTED_PROXIES = /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z
+                      |\A::1\Z
+                      |\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z
+                      |\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z
+                      |\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z
+                      |\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z
+                      |\Alocalhost\Z|\Aunix\Z|\Aunix:/ix
     
     # For readability and comprehension, here is the preceding regex represented in parts:
-    # TRUSTED_PROXIES = 
-    #  [
-    #    /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z/, # localhost IPv4 range, per RFC-3330
-    #    /\A::1\Z/, # localhost IPv6
-    #    /\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z/, # private IPv6 range fc00::/7
-    #    /\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z/, # private IPv4 range 10.x.x.x
-    #    /\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z/, # private IPv4 range 172.16.0.0 .. 172.31.255.255
-    #    /\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z/, # private IPv4 range 192.168.x.x
-    #    /\Alocalhost\Z|\Aunix\Z|\Aunix:/i
-    #  ]
+    #
+    #    \A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z     # localhost IPv4 range 127.x.x.x, per RFC-3330
+    #    \A::1\Z                                                    # localhost IPv6 ::1
+    #    \A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z   # private IPv6 range fc00::/7
+    #    \A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z      # private IPv4 range 10.x.x.x
+    #    \A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z      # private IPv4 range 172.16.0.0 .. 172.31.255.255
+    #    \A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z     # private IPv4 range 192.168.x.x
+    #    \Alocalhost\Z|\Aunix\Z|\Aunix:                             # localhost hostname, and unix domain sockets
+    #
     
     self.ip_filter = lambda { |ip| TRUSTED_PROXIES.match?(ip) }
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,24 +16,21 @@ module Rack
       attr_accessor :ip_filter
     end
 
-    TRUSTED_PROXIES = 
-      [
-        "127.0.0.0/8", # localhost IPv4 range, per RFC-3330
-        "::1", # localhost IPv6
-        "fc00::/7", # private IPv6 range fc00::/7
-        "10.0.0.0/8", # private IPv4 range 10.x.x.x
-        "172.16.0.0/12", # private IPv4 range 172.16.0.0 .. 172.31.255.255
-        "192.168.0.0/16", # private IPv4 range 192.168.x.x
-      ].map { |proxy| IPAddr.new(proxy) }
+    TRUSTED_PROXIES = /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z|\A::1\Z|\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z|\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z|\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z|\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z|\Alocalhost\Z|\Aunix\Z|\Aunix:/i
     
-    self.ip_filter = lambda do |ip| 
-      return true if TRUSTED_PROXIES.any? { |tp| tp.include? ip } 
-      false
-    rescue IPAddr::InvalidAddressError
-      # Not actually an IP address
-      return true if /\Alocalhost\Z|\Aunix\Z|\Aunix:/i.match?(ip)
-      false
-    end
+    # For readability and comprehension, here is the preceding regex represented in parts:
+    # TRUSTED_PROXIES = 
+    #  [
+    #    /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z/, # localhost IPv4 range, per RFC-3330
+    #    /\A::1\Z/, # localhost IPv6
+    #    /\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z/, # private IPv6 range fc00::/7
+    #    /\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z/, # private IPv4 range 10.x.x.x
+    #    /\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z/, # private IPv4 range 172.16.0.0 .. 172.31.255.255
+    #    /\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z/, # private IPv4 range 192.168.x.x
+    #    /\Alocalhost\Z|\Aunix\Z|\Aunix:/i
+    #  ]
+    
+    self.ip_filter = lambda { |ip| TRUSTED_PROXIES.match?(ip) }
 
     ALLOWED_SCHEMES = %w(https http wss ws).freeze
     SCHEME_WHITELIST = ALLOWED_SCHEMES

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -23,7 +23,7 @@ module Rack
       /\A::1$\Z/,                                                      # localhost IPv6 ::1
       /\A[f][cd][0-9a-f]{2}(?:[:][0-9a-f]{0,4}){0,7}$\Z/i,             # private IPv6 range fc00 .. fdff
       /\A10(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                          # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2\d|3[01])(\.(#{VALID_IPV4_OCTET})){2}$\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A172\.(1[6-9]|2[0-9]|3[01])(\.(#{VALID_IPV4_OCTET})){2}$\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
       /\A192\.168(\.(#{VALID_IPV4_OCTET})){2}$\Z/,                     # private IPv4 range 192.168.x.x
       /\Alocalhost\Z|\Aunix\Z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
     ).freeze

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -19,11 +19,11 @@ module Rack
     VALID_IPV4_OCTET = '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])'.freeze
     
     TRUSTED_PROXIES = Regexp.union(
-      /\A127(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
+      /\A127(\.(#{VALID_IPV4_OCTET})){3}\Z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
       /\A::1\Z/,                                                      # localhost IPv6 ::1
       /\A[f][cd][0-9a-f]{2}(?:[:][0-9a-f]{0,4}){0,7}\Z/i,             # private IPv6 range fc00 .. fdff
-      /\A10(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                          # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2\d|3[01])(\.(#{VALID_IPV4_OCTET})){2}$\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A10(\.(#{VALID_IPV4_OCTET})){3}\Z/,                          # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2\d|3[01])(\.(#{VALID_IPV4_OCTET})){2}\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
       /\A192\.168(\.(#{VALID_IPV4_OCTET})){2}\Z/,                     # private IPv4 range 192.168.x.x
       /\Alocalhost\Z|\Aunix\Z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
     ).freeze

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -19,12 +19,12 @@ module Rack
     valid_ipv4_octet = '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])'.freeze
     
     TRUSTED_PROXIES = Regexp.union(
-      /\A127(\.(#{valid_ipv4_octet})){3}$\z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
-      /\A::1$\z/,                                                      # localhost IPv6 ::1
-      /\Af[cd][0-9a-f]{2}(?::[0-9a-f]{0,4}){0,7}$\z/i,             # private IPv6 range fc00 .. fdff
-      /\A10(\.(#{valid_ipv4_octet})){3}$\z/,                          # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2[0-9]|3[01])(\.(#{valid_ipv4_octet})){2}$\z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
-      /\A192\.168(\.(#{valid_ipv4_octet})){2}$\z/,                     # private IPv4 range 192.168.x.x
+      /\A127(\.(#{valid_ipv4_octet})){3}\z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
+      /\A::1\z/,                                                      # localhost IPv6 ::1
+      /\Af[cd][0-9a-f]{2}(?::[0-9a-f]{0,4}){0,7}\z/i,             # private IPv6 range fc00 .. fdff
+      /\A10(\.(#{valid_ipv4_octet})){3}\z/,                          # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2[0-9]|3[01])(\.(#{valid_ipv4_octet})){2}\z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A192\.168(\.(#{valid_ipv4_octet})){2}\z/,                     # private IPv4 range 192.168.x.x
       /\Alocalhost\z|\Aunix\z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
     ).freeze
     

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,13 +16,15 @@ module Rack
       attr_accessor :ip_filter
     end
 
-    TRUSTED_PROXIES = /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z     # localhost IPv4 range 127.x.x.x, per RFC-3330
-                      |\A::1\Z                                                    # localhost IPv6 ::1
-                      |\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z   # private IPv6 range fc00 .. fdff
-                      |\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z      # private IPv4 range 10.x.x.x
-                      |\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z      # private IPv4 range 172.16.0.0 .. 172.31.255.255
-                      |\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z     # private IPv4 range 192.168.x.x
-                      |\Alocalhost\Z|\Aunix\Z|\Aunix:/ix                          # localhost hostname, and unix domain sockets
+    TRUSTED_PROXIES = Regexp.union(
+      /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z/i,     # localhost IPv4 range 127.x.x.x, per RFC-3330
+      /\A::1\Z/i,                                                    # localhost IPv6 ::1
+      /\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z/i,   # private IPv6 range fc00 .. fdff
+      /\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z/i,      # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z/i,      # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z/i,     # private IPv4 range 192.168.x.x
+      /\Alocalhost\Z|\Aunix\Z|\Aunix:/i,                             # localhost hostname, and unix domain sockets
+    )
     
     self.ip_filter = lambda { |ip| TRUSTED_PROXIES.match?(ip) }
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -19,12 +19,12 @@ module Rack
     VALID_IPV4_OCTET = '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])'.freeze
     
     TRUSTED_PROXIES = Regexp.union(
-      /\A127(\.(#{VALID_IPV4_OCTET})){3}\Z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
-      /\A::1\Z/,                                                      # localhost IPv6 ::1
-      /\A[f][cd][0-9a-f]{2}(?:[:][0-9a-f]{0,4}){0,7}\Z/i,             # private IPv6 range fc00 .. fdff
-      /\A10(\.(#{VALID_IPV4_OCTET})){3}\Z/,                          # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2\d|3[01])(\.(#{VALID_IPV4_OCTET})){2}\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
-      /\A192\.168(\.(#{VALID_IPV4_OCTET})){2}\Z/,                     # private IPv4 range 192.168.x.x
+      /\A127(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
+      /\A::1$\Z/,                                                      # localhost IPv6 ::1
+      /\A[f][cd][0-9a-f]{2}(?:[:][0-9a-f]{0,4}){0,7}$\Z/i,             # private IPv6 range fc00 .. fdff
+      /\A10(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                          # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2\d|3[01])(\.(#{VALID_IPV4_OCTET})){2}$\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A192\.168(\.(#{VALID_IPV4_OCTET})){2}$\Z/,                     # private IPv4 range 192.168.x.x
       /\Alocalhost\Z|\Aunix\Z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
     ).freeze
     

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,19 +16,19 @@ module Rack
       attr_accessor :ip_filter
     end
 
-    valid_ipv4_octet = '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])'.freeze
+    valid_ipv4_octet = /\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])/
     
-    TRUSTED_PROXIES = Regexp.union(
-      /\A127(\.(#{valid_ipv4_octet})){3}\z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
+    trusted_proxies = Regexp.union(
+      /\A127#{valid_ipv4_octet}{3}\z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
       /\A::1\z/,                                                      # localhost IPv6 ::1
       /\Af[cd][0-9a-f]{2}(?::[0-9a-f]{0,4}){0,7}\z/i,             # private IPv6 range fc00 .. fdff
-      /\A10(\.(#{valid_ipv4_octet})){3}\z/,                          # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2[0-9]|3[01])(\.(#{valid_ipv4_octet})){2}\z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
-      /\A192\.168(\.(#{valid_ipv4_octet})){2}\z/,                     # private IPv4 range 192.168.x.x
-      /\Alocalhost\z|\Aunix\z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
+      /\A10#{valid_ipv4_octet}{3}\z/,                          # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2[0-9]|3[01])#{valid_ipv4_octet}{2}\z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A192\.168#{valid_ipv4_octet}{2}\z/,                     # private IPv4 range 192.168.x.x
+      /\Alocalhost\z|\Aunix(\z|:)/i,                              # localhost hostname, and unix domain sockets
     ).freeze
     
-    self.ip_filter = lambda { |ip| TRUSTED_PROXIES.match?(ip) }
+    self.ip_filter = lambda { |ip| trusted_proxies.match?(ip) }
 
     ALLOWED_SCHEMES = %w(https http wss ws).freeze
     SCHEME_WHITELIST = ALLOWED_SCHEMES

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -19,14 +19,14 @@ module Rack
     valid_ipv4_octet = /\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])/
     
     trusted_proxies = Regexp.union(
-      /\A127#{valid_ipv4_octet}{3}\z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
-      /\A::1\z/,                                                      # localhost IPv6 ::1
-      /\Af[cd][0-9a-f]{2}(?::[0-9a-f]{0,4}){0,7}\z/i,             # private IPv6 range fc00 .. fdff
-      /\A10#{valid_ipv4_octet}{3}\z/,                          # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2[0-9]|3[01])#{valid_ipv4_octet}{2}\z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A127#{valid_ipv4_octet}{3}\z/,                          # localhost IPv4 range 127.x.x.x, per RFC-3330
+      /\A::1\z/,                                                # localhost IPv6 ::1
+      /\Af[cd][0-9a-f]{2}(?::[0-9a-f]{0,4}){0,7}\z/i,           # private IPv6 range fc00 .. fdff
+      /\A10#{valid_ipv4_octet}{3}\z/,                           # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2[0-9]|3[01])#{valid_ipv4_octet}{2}\z/,   # private IPv4 range 172.16.0.0 .. 172.31.255.255
       /\A192\.168#{valid_ipv4_octet}{2}\z/,                     # private IPv4 range 192.168.x.x
-      /\Alocalhost\z|\Aunix(\z|:)/i,                              # localhost hostname, and unix domain sockets
-    ).freeze
+      /\Alocalhost\z|\Aunix(\z|:)/i,                            # localhost hostname, and unix domain sockets
+    )
     
     self.ip_filter = lambda { |ip| trusted_proxies.match?(ip) }
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,15 +16,17 @@ module Rack
       attr_accessor :ip_filter
     end
 
+    VALID_IPV4_OCTET = '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])'.freeze
+    
     TRUSTED_PROXIES = Regexp.union(
-      /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z/i,     # localhost IPv4 range 127.x.x.x, per RFC-3330
-      /\A::1\Z/i,                                                    # localhost IPv6 ::1
-      /\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z/i,   # private IPv6 range fc00 .. fdff
-      /\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z/i,      # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z/i,      # private IPv4 range 172.16.0.0 .. 172.31.255.255
-      /\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z/i,     # private IPv4 range 192.168.x.x
-      /\Alocalhost\Z|\Aunix\Z|\Aunix:/i,                             # localhost hostname, and unix domain sockets
-    )
+      /\A127(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
+      /\A::1\Z/,                                                      # localhost IPv6 ::1
+      /\A[f][cd][0-9a-f]{2}(?:[:][0-9a-f]{0,4}){0,7}\Z/i,             # private IPv6 range fc00 .. fdff
+      /\A10(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                          # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2\d|3[01])(\.(#{VALID_IPV4_OCTET})){2}$\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A192\.168(\.(#{VALID_IPV4_OCTET})){2}\Z/,                     # private IPv4 range 192.168.x.x
+      /\Alocalhost\Z|\Aunix\Z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
+    ).freeze
     
     self.ip_filter = lambda { |ip| TRUSTED_PROXIES.match?(ip) }
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,24 +16,13 @@ module Rack
       attr_accessor :ip_filter
     end
 
-    TRUSTED_PROXIES = /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z
-                      |\A::1\Z
-                      |\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z
-                      |\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z
-                      |\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z
-                      |\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z
-                      |\Alocalhost\Z|\Aunix\Z|\Aunix:/ix
-    
-    # For readability and comprehension, here is the preceding regex represented in parts:
-    #
-    #    \A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z     # localhost IPv4 range 127.x.x.x, per RFC-3330
-    #    \A::1\Z                                                    # localhost IPv6 ::1
-    #    \A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z   # private IPv6 range fc00::/7
-    #    \A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z      # private IPv4 range 10.x.x.x
-    #    \A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z      # private IPv4 range 172.16.0.0 .. 172.31.255.255
-    #    \A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z     # private IPv4 range 192.168.x.x
-    #    \Alocalhost\Z|\Aunix\Z|\Aunix:                             # localhost hostname, and unix domain sockets
-    #
+    TRUSTED_PROXIES = /\A127\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z     # localhost IPv4 range 127.x.x.x, per RFC-3330
+                      |\A::1\Z                                                    # localhost IPv6 ::1
+                      |\A[fF][cCdD][0-9a-fA-F]{2}(?:[:][0-9a-fA-F]{0,4}){0,7}\Z   # private IPv6 range fc00 .. fdff
+                      |\A10\.(([1-9]?\d|[12]\d\d)\.){2}([1-9]?\d|[12]\d\d)\Z      # private IPv4 range 10.x.x.x
+                      |\A172\.(1[6-9]|2\d|3[01])(\.([1-9]?\d|[12]\d\d)){2}\Z      # private IPv4 range 172.16.0.0 .. 172.31.255.255
+                      |\A192\.168\.([1-9]?\d|[12]\d\d)\.([1-9]?\d|[12]\d\d)\Z     # private IPv4 range 192.168.x.x
+                      |\Alocalhost\Z|\Aunix\Z|\Aunix:/ix                          # localhost hostname, and unix domain sockets
     
     self.ip_filter = lambda { |ip| TRUSTED_PROXIES.match?(ip) }
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -16,15 +16,15 @@ module Rack
       attr_accessor :ip_filter
     end
 
-    VALID_IPV4_OCTET = '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])'.freeze
+    valid_ipv4_octet = '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])'.freeze
     
     TRUSTED_PROXIES = Regexp.union(
-      /\A127(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
+      /\A127(\.(#{valid_ipv4_octet})){3}$\Z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
       /\A::1$\Z/,                                                      # localhost IPv6 ::1
-      /\A[f][cd][0-9a-f]{2}(?:[:][0-9a-f]{0,4}){0,7}$\Z/i,             # private IPv6 range fc00 .. fdff
-      /\A10(\.(#{VALID_IPV4_OCTET})){3}$\Z/,                          # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2[0-9]|3[01])(\.(#{VALID_IPV4_OCTET})){2}$\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
-      /\A192\.168(\.(#{VALID_IPV4_OCTET})){2}$\Z/,                     # private IPv4 range 192.168.x.x
+      /\Af[cd][0-9a-f]{2}(?::[0-9a-f]{0,4}){0,7}$\Z/i,             # private IPv6 range fc00 .. fdff
+      /\A10(\.(#{valid_ipv4_octet})){3}$\Z/,                          # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2[0-9]|3[01])(\.(#{valid_ipv4_octet})){2}$\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A192\.168(\.(#{valid_ipv4_octet})){2}$\Z/,                     # private IPv4 range 192.168.x.x
       /\Alocalhost\Z|\Aunix\Z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
     ).freeze
     

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -19,13 +19,13 @@ module Rack
     valid_ipv4_octet = '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])'.freeze
     
     TRUSTED_PROXIES = Regexp.union(
-      /\A127(\.(#{valid_ipv4_octet})){3}$\Z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
-      /\A::1$\Z/,                                                      # localhost IPv6 ::1
-      /\Af[cd][0-9a-f]{2}(?::[0-9a-f]{0,4}){0,7}$\Z/i,             # private IPv6 range fc00 .. fdff
-      /\A10(\.(#{valid_ipv4_octet})){3}$\Z/,                          # private IPv4 range 10.x.x.x
-      /\A172\.(1[6-9]|2[0-9]|3[01])(\.(#{valid_ipv4_octet})){2}$\Z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
-      /\A192\.168(\.(#{valid_ipv4_octet})){2}$\Z/,                     # private IPv4 range 192.168.x.x
-      /\Alocalhost\Z|\Aunix\Z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
+      /\A127(\.(#{valid_ipv4_octet})){3}$\z/,                         # localhost IPv4 range 127.x.x.x, per RFC-3330
+      /\A::1$\z/,                                                      # localhost IPv6 ::1
+      /\Af[cd][0-9a-f]{2}(?::[0-9a-f]{0,4}){0,7}$\z/i,             # private IPv6 range fc00 .. fdff
+      /\A10(\.(#{valid_ipv4_octet})){3}$\z/,                          # private IPv4 range 10.x.x.x
+      /\A172\.(1[6-9]|2[0-9]|3[01])(\.(#{valid_ipv4_octet})){2}$\z/,     # private IPv4 range 172.16.0.0 .. 172.31.255.255
+      /\A192\.168(\.(#{valid_ipv4_octet})){2}$\z/,                     # private IPv4 range 192.168.x.x
+      /\Alocalhost\z|\Aunix\z|\Aunix:/i,                              # localhost hostname, and unix domain sockets
     ).freeze
     
     self.ip_filter = lambda { |ip| TRUSTED_PROXIES.match?(ip) }

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1473,14 +1473,18 @@ EOF
   it "regards local addresses as proxies" do
     req = make_request(Rack::MockRequest.env_for("/"))
     req.trusted_proxy?('127.0.0.1').must_equal true
+    req.trusted_proxy?('127.000.000.001').must_equal true
     req.trusted_proxy?('127.0.0.6').must_equal true
     req.trusted_proxy?('127.0.0.30').must_equal true
     req.trusted_proxy?('10.0.0.1').must_equal true
+    req.trusted_proxy?('10.000.000.001').must_equal true
     req.trusted_proxy?('172.16.0.1').must_equal true
     req.trusted_proxy?('172.20.0.1').must_equal true
     req.trusted_proxy?('172.30.0.1').must_equal true
     req.trusted_proxy?('172.31.0.1').must_equal true
+    req.trusted_proxy?('172.31.000.001').must_equal true
     req.trusted_proxy?('192.168.0.1').must_equal true
+    req.trusted_proxy?('192.168.000.001').must_equal true
     req.trusted_proxy?('::1').must_equal true
     req.trusted_proxy?('fd00::').must_equal true
     req.trusted_proxy?('FD00::').must_equal true
@@ -1499,6 +1503,7 @@ EOF
     req.trusted_proxy?("10.0.256.1").must_equal false
     req.trusted_proxy?("10.0.0.256").must_equal false
     req.trusted_proxy?("11.0.0.1").must_equal false
+    req.trusted_proxy?("11.000.000.001").must_equal false
     req.trusted_proxy?("172.15.0.1").must_equal false
     req.trusted_proxy?("172.32.0.1").must_equal false
     req.trusted_proxy?("172.16.256.1").must_equal false

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1488,7 +1488,6 @@ EOF
 
     req.trusted_proxy?("unix.example.org").must_equal false
     req.trusted_proxy?("example.org\n127.0.0.1").must_equal false
-    req.trusted_proxy?("127.0.0.1\nexample.org").must_equal false
     req.trusted_proxy?("11.0.0.1").must_equal false
     req.trusted_proxy?("172.15.0.1").must_equal false
     req.trusted_proxy?("172.32.0.1").must_equal false

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1482,6 +1482,7 @@ EOF
     req.trusted_proxy?('192.168.0.1').must_equal true
     req.trusted_proxy?('::1').must_equal true
     req.trusted_proxy?('fd00::').must_equal true
+    req.trusted_proxy?('FD00::').must_equal true
     req.trusted_proxy?('localhost').must_equal true
     req.trusted_proxy?('unix').must_equal true
     req.trusted_proxy?('unix:/tmp/sock').must_equal true
@@ -1489,9 +1490,17 @@ EOF
     req.trusted_proxy?("unix.example.org").must_equal false
     req.trusted_proxy?("example.org\n127.0.0.1").must_equal false
     req.trusted_proxy?("127.0.0.1\nexample.org").must_equal false
+    req.trusted_proxy?("127.256.0.1").must_equal false
+    req.trusted_proxy?("127.0.256.1").must_equal false
+    req.trusted_proxy?("127.0.0.256").must_equal false
+    req.trusted_proxy?("10.256.0.1").must_equal false
+    req.trusted_proxy?("10.0.256.1").must_equal false
+    req.trusted_proxy?("10.0.0.256").must_equal false
     req.trusted_proxy?("11.0.0.1").must_equal false
     req.trusted_proxy?("172.15.0.1").must_equal false
     req.trusted_proxy?("172.32.0.1").must_equal false
+    req.trusted_proxy?("172.16.256.1").must_equal false
+    req.trusted_proxy?("172.16.0.256").must_equal false
     req.trusted_proxy?("2001:470:1f0b:18f8::1").must_equal false
   end
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1488,6 +1488,7 @@ EOF
 
     req.trusted_proxy?("unix.example.org").must_equal false
     req.trusted_proxy?("example.org\n127.0.0.1").must_equal false
+    req.trusted_proxy?("127.0.0.1\nexample.org").must_equal false
     req.trusted_proxy?("11.0.0.1").must_equal false
     req.trusted_proxy?("172.15.0.1").must_equal false
     req.trusted_proxy?("172.32.0.1").must_equal false

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1474,6 +1474,7 @@ EOF
     req = make_request(Rack::MockRequest.env_for("/"))
     req.trusted_proxy?('127.0.0.1').must_equal true
     req.trusted_proxy?('127.0.0.6').must_equal true
+    req.trusted_proxy?('127.0.0.30').must_equal true
     req.trusted_proxy?('10.0.0.1').must_equal true
     req.trusted_proxy?('172.16.0.1').must_equal true
     req.trusted_proxy?('172.20.0.1').must_equal true
@@ -1493,6 +1494,7 @@ EOF
     req.trusted_proxy?("127.256.0.1").must_equal false
     req.trusted_proxy?("127.0.256.1").must_equal false
     req.trusted_proxy?("127.0.0.256").must_equal false
+    req.trusted_proxy?('127.0.0.300').must_equal false
     req.trusted_proxy?("10.256.0.1").must_equal false
     req.trusted_proxy?("10.0.256.1").must_equal false
     req.trusted_proxy?("10.0.0.256").must_equal false

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1473,6 +1473,7 @@ EOF
   it "regards local addresses as proxies" do
     req = make_request(Rack::MockRequest.env_for("/"))
     req.trusted_proxy?('127.0.0.1').must_equal true
+    req.trusted_proxy?('127.0.0.6').must_equal true
     req.trusted_proxy?('10.0.0.1').must_equal true
     req.trusted_proxy?('172.16.0.1').must_equal true
     req.trusted_proxy?('172.20.0.1').must_equal true


### PR DESCRIPTION
RFC-3330 defines the entire 127.0.0.0/8 network as internal and as such I believe that the ip_filter regex should honor this instead of only 127.0.0.1 when determining remote IP address: https://datatracker.ietf.org/doc/html/rfc3330

Rails has already made this modification to the ActionDispatch RemoteIp TRUSTED_PROXIES default configuration as of v6.2: https://edgeapi.rubyonrails.org/classes/ActionDispatch/RemoteIp.html

This behavior was observed when introducing a rails application in to an Istio service mesh, where an envoy proxy is injected in front of the application by way of iptables and forwards inbounds requests from a "magic" IP address of 127.0.0.6 in order to break loopback routing loops: https://github.com/istio/istio/issues/29603