### PR TITLE
Handle changes to YAML.

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -53,13 +53,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
-
-    - uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: bundle-use-ruby-${{matrix.os}}-${{matrix.ruby}}-${{hashFiles('**/Gemfile')}}
-        restore-keys: |
-          bundle-use-ruby-${{matrix.os}}-${{matrix.ruby}}-
+        bundler-cache: true
 
     - name: Installing packages (ubuntu)
       if: matrix.os == 'ubuntu-latest'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem "webrick"
 gem "rubocop", require: false
 gem "rubocop-packaging", require: false
 
+gem "psych", "~> 4.0"
+
 group :doc do
   gem 'rdoc'
 end

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -317,21 +317,6 @@ module Rack
       time.rfc2822
     end
 
-    # Modified version of stdlib time.rb Time#rfc2822 to use '%d-%b-%Y' instead
-    # of '% %b %Y'.
-    # It assumes that the time is in GMT to comply to the RFC 2109.
-    #
-    # NOTE: I'm not sure the RFC says it requires GMT, but is ambiguous enough
-    # that I'm certain someone implemented only that option.
-    # Do not use %a and %b from Time.strptime, it would use localized names for
-    # weekday and month.
-    #
-    def rfc2109(time)
-      wday = Time::RFC2822_DAY_NAME[time.wday]
-      mon = Time::RFC2822_MONTH_NAME[time.mon - 1]
-      time.strftime("#{wday}, %d-#{mon}-%Y %H:%M:%S GMT")
-    end
-
     # Parses the "Range:" header, if present, into an array of Range objects.
     # Returns nil if the header is missing or syntactically invalid.
     # Returns an empty array if none of the ranges are satisfiable.

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -47,7 +47,7 @@ describe Rack::MockRequest do
   it "provide sensible defaults" do
     res = Rack::MockRequest.new(app).request
 
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["SERVER_NAME"].must_equal "example.org"
     env["SERVER_PORT"].must_equal "80"
@@ -60,23 +60,23 @@ describe Rack::MockRequest do
 
   it "allow GET/POST/PUT/DELETE/HEAD" do
     res = Rack::MockRequest.new(app).get("", input: "foo")
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
 
     res = Rack::MockRequest.new(app).post("", input: "foo")
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
 
     res = Rack::MockRequest.new(app).put("", input: "foo")
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "PUT"
 
     res = Rack::MockRequest.new(app).patch("", input: "foo")
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "PATCH"
 
     res = Rack::MockRequest.new(app).delete("", input: "foo")
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "DELETE"
 
     Rack::MockRequest.env_for("/", method: "HEAD")["REQUEST_METHOD"]
@@ -102,11 +102,11 @@ describe Rack::MockRequest do
 
   it "allow posting" do
     res = Rack::MockRequest.new(app).get("", input: "foo")
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["mock.postdata"].must_equal "foo"
 
     res = Rack::MockRequest.new(app).post("", input: StringIO.new("foo"))
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["mock.postdata"].must_equal "foo"
   end
 
@@ -115,7 +115,7 @@ describe Rack::MockRequest do
       get("https://bla.example.org:9292/meh/foo?bar")
     res.must_be_kind_of Rack::MockResponse
 
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["SERVER_NAME"].must_equal "bla.example.org"
     env["SERVER_PORT"].must_equal "9292"
@@ -129,7 +129,7 @@ describe Rack::MockRequest do
       get("https://example.org/foo")
     res.must_be_kind_of Rack::MockResponse
 
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["SERVER_NAME"].must_equal "example.org"
     env["SERVER_PORT"].must_equal "443"
@@ -144,7 +144,7 @@ describe Rack::MockRequest do
       get("foo")
     res.must_be_kind_of Rack::MockResponse
 
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["SERVER_NAME"].must_equal "example.org"
     env["SERVER_PORT"].must_equal "80"
@@ -155,13 +155,13 @@ describe Rack::MockRequest do
 
   it "properly convert method name to an uppercase string" do
     res = Rack::MockRequest.new(app).request(:get)
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
   end
 
   it "accept params and build query string for GET requests" do
     res = Rack::MockRequest.new(app).get("/foo?baz=2", params: { foo: { bar: "1" } })
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["QUERY_STRING"].must_include "baz=2"
     env["QUERY_STRING"].must_include "foo[bar]=1"
@@ -171,7 +171,7 @@ describe Rack::MockRequest do
 
   it "accept raw input in params for GET requests" do
     res = Rack::MockRequest.new(app).get("/foo?baz=2", params: "foo[bar]=1")
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "GET"
     env["QUERY_STRING"].must_include "baz=2"
     env["QUERY_STRING"].must_include "foo[bar]=1"
@@ -181,7 +181,7 @@ describe Rack::MockRequest do
 
   it "accept params and build url encoded params for POST requests" do
     res = Rack::MockRequest.new(app).post("/foo", params: { foo: { bar: "1" } })
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
     env["QUERY_STRING"].must_equal ""
     env["PATH_INFO"].must_equal "/foo"
@@ -191,7 +191,7 @@ describe Rack::MockRequest do
 
   it "accept raw input in params for POST requests" do
     res = Rack::MockRequest.new(app).post("/foo", params: "foo[bar]=1")
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
     env["QUERY_STRING"].must_equal ""
     env["PATH_INFO"].must_equal "/foo"
@@ -202,7 +202,7 @@ describe Rack::MockRequest do
   it "accept params and build multipart encoded params for POST requests" do
     files = Rack::Multipart::UploadedFile.new(File.join(File.dirname(__FILE__), "multipart", "file1.txt"))
     res = Rack::MockRequest.new(app).post("/foo", params: { "submit-name" => "Larry", "files" => files })
-    env = YAML.load(res.body)
+    env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
     env["QUERY_STRING"].must_equal ""
     env["PATH_INFO"].must_equal "/foo"

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -481,10 +481,6 @@ describe Rack::Utils do
     Rack::Utils.rfc2822(Time.at(0).gmtime).must_equal "Thu, 01 Jan 1970 00:00:00 -0000"
   end
 
-  it "return rfc2109 format from rfc2109 helper" do
-    Rack::Utils.rfc2109(Time.at(0).gmtime).must_equal "Thu, 01-Jan-1970 00:00:00 GMT"
-  end
-
   it "clean directory traversal" do
     Rack::Utils.clean_path_info("/cgi/../cgi/test").must_equal "/cgi/test"
     Rack::Utils.clean_path_info(".").must_be_empty

--- a/test/test_request.rb
+++ b/test/test_request.rb
@@ -42,7 +42,7 @@ class TestRequest
         http.request(get) { |response|
           @status = response.code.to_i
           begin
-            @response = YAML.load(response.body)
+            @response = YAML.unsafe_load(response.body)
           rescue TypeError, ArgumentError
             @response = nil
           end
@@ -60,7 +60,7 @@ class TestRequest
         post.basic_auth user, passwd  if user && passwd
         http.request(post) { |response|
           @status = response.code.to_i
-          @response = YAML.load(response.body)
+          @response = YAML.unsafe_load(response.body)
         }
       }
     end


### PR DESCRIPTION
The test suite fails on Ruby 3.x+ - there are two issues:

1. Psych/YAML got a lot more strict and our tests depend on some unsafe behaviour. So we need to change `YAML.load` to `YAML.unsafe_load`.
2. Our RFC2109 date formatting implementation depends on some internal details of `Time` which have been removed. Since RFC2109 is obsolete, I've opted to remove this entirely. See the introduction (page 4) of https://datatracker.ietf.org/doc/html/rfc6265 for more details.