### PR TITLE
Move RuboCop to optional maintenance group to avoid test failures.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,11 @@ source 'https://rubygems.org'
 gemspec
 
 gem "webrick"
-gem "rubocop", require: false
-gem "rubocop-packaging", require: false
+
+group :maintenance, optional: true do
+  gem "rubocop", require: false
+  gem "rubocop-packaging", require: false
+end
 
 gem "psych", "~> 4.0"
 


### PR DESCRIPTION
@koic the latest version of RuboCop has broken our test suite on Ruby 2.5 only, 2.4 and 2.6+ still working fine.

See the build failure here:

https://github.com/rack/rack/runs/4867600570?check_suite_focus=true

Reverting to `~> 1.24.1` fixes the problem, but breaks Ruby 2.4 haha.