### PR TITLE
Prefer `filename*` over `filename` when processing multipart data.

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -300,10 +300,10 @@ module Rack
         when RFC2183
           params = Hash[*head.scan(DISPPARM).flat_map(&:compact)]
 
-          if filename = params['filename']
-            filename = $1 if filename =~ /^"(.*)"$/
-          elsif filename = params['filename*']
+          if filename = params['filename*']
             encoding, _, filename = filename.split("'", 3)
+          elsif filename = params['filename']
+            filename = $1 if filename =~ /^"(.*)"$/
           end
         when BROKEN_QUOTED, BROKEN_UNQUOTED
           filename = $1

--- a/test/multipart/filename_multi
+++ b/test/multipart/filename_multi
@@ -1,0 +1,6 @@
+--AaB03x
+Content-Disposition: form-data; name="files"; filename="foo"; filename*=utf-8''bar
+Content-Type: application/octet-stream
+
+contents
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -49,6 +49,12 @@ describe Rack::Multipart do
     params["text"].must_equal "contents"
   end
 
+  it "parse multipart content with different filename and filename*" do
+    env = Rack::MockRequest.env_for '/', multipart_fixture(:filename_multi)
+    params = Rack::Multipart.parse_multipart(env)
+    params["files"][:filename].must_equal "bar"
+  end
+
   it "set US_ASCII encoding based on charset" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_filename))
     params = Rack::Multipart.parse_multipart(env)


### PR DESCRIPTION
Follow up to https://github.com/rack/rack/pull/1762