### PR TITLE
Remove `Rack::MockResponse#body` and introduce `Rack::MockResponse#join` as a replacement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::Utils.secure_compare` uses OpenSSL's faster implementation if available. ([#1711](https://github.com/rack/rack/pull/1711), [@bdewater](https://github.com/bdewater))
 - BREAKING CHANGE: Updated `trusted_proxy?` to match full 127.0.0.0/8 network. ([#1781](https://github.com/rack/rack/pull/1781), [@snbloch](https://github.com/snbloch))
 
+### Removed
+
+- `Rack::MockResponse#body` violates Liskov substitution principle. Use `Rack::MockResponse#join` for the current behaviour. ([#1791][https://github.com/rack/rack/pull/1791], [@ioquatix][https://github.com/ioquatix])
+
 ### Fixed
 
 - Make Rack::MockResponse handle non-hash headers. ([#1629](https://github.com/rack/rack/issues/1629), [@jeremyevans](https://github.com/jeremyevans))

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -199,24 +199,23 @@ module Rack
       body.match other
     end
 
-    def body
-      # FIXME: apparently users of MockResponse expect the return value of
-      # MockResponse#body to be a string.  However, the real response object
-      # returns the body as a list.
-      #
-      # See spec_showstatus.rb:
-      #
-      #   should "not replace existing messages" do
-      #     ...
-      #     res.body.should == "foo!"
-      #   end
-      buffer = String.new
+    def body(join: true)
+      if join
+        buffer = String.new
 
-      super.each do |chunk|
-        buffer << chunk
+        super().each do |chunk|
+          buffer << chunk
+        end
+
+        return buffer
+      else
+        super
       end
+    end
 
-      return buffer
+    # @returns [String] The response body parts joined into a single string.
+    def join
+      body(join: true)
     end
 
     def empty?

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -192,19 +192,29 @@ module Rack
       buffered_body!
     end
 
-    # @returns [String] The response body parts joined into a single string.
-    def join
-      unless @joined
-        @joined = String.new
+    def body(join = true)
+      body = super()
+
+      # This is considered deprecated behaviour, prefer to use #join.
+      if join && body.respond_to?(:each)
+        # warn 'Prefer MockResponse#join for response body as string!' if deprecated
+
+        buffer = String.new
 
         body.each do |chunk|
-          @joined << chunk
+          buffer << chunk
         end
 
-        @joined.freeze
+        return buffer
+      else
+        # Everything else:
+        return body
       end
+    end
 
-      return @joined
+    # @returns [String] The response body parts joined into a single string.
+    def join
+      @joined ||= self.body(true)
     end
 
     def =~(other)

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -182,8 +182,9 @@ module Rack
     attr_accessor :errors
 
     def initialize(status, headers, body, errors = StringIO.new(""))
+      @joined = false
       @original_headers = headers
-      @errors           = errors.string if errors.respond_to?(:string)
+      @errors = errors.string if errors.respond_to?(:string)
 
       super(body, status, headers)
 
@@ -191,16 +192,10 @@ module Rack
       buffered_body!
     end
 
-    def =~(other)
-      body =~ other
-    end
-
-    def match(other)
-      body.match other
-    end
-
-    def body(join: true)
+    def body(join = (deprecated = true))
       if join
+        warn 'Prefer MockResponse#join for response body as string!' if deprecated
+
         buffer = String.new
 
         super().each do |chunk|
@@ -215,7 +210,15 @@ module Rack
 
     # @returns [String] The response body parts joined into a single string.
     def join
-      body(join: true)
+      @joined ||= self.body(true)
+    end
+
+    def =~(other)
+      join =~ other
+    end
+
+    def match(other)
+      join.match other
     end
 
     def empty?

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -192,25 +192,19 @@ module Rack
       buffered_body!
     end
 
-    def body(join = (deprecated = true))
-      if join
-        warn 'Prefer MockResponse#join for response body as string!' if deprecated
-
-        buffer = String.new
-
-        super().each do |chunk|
-          buffer << chunk
-        end
-
-        return buffer
-      else
-        super
-      end
-    end
-
     # @returns [String] The response body parts joined into a single string.
     def join
-      @joined ||= self.body(true)
+      unless @joined
+        @joined = String.new
+
+        body.each do |chunk|
+          @joined << chunk
+        end
+
+        @joined.freeze
+      end
+
+      return @joined
     end
 
     def =~(other)

--- a/test/spec_auth_basic.rb
+++ b/test/spec_auth_basic.rb
@@ -36,7 +36,7 @@ describe Rack::Auth::Basic do
     response.status.must_equal 401
     response.must_include 'WWW-Authenticate'
     response.headers['WWW-Authenticate'].must_match(/Basic realm="#{Regexp.escape(realm)}"/)
-    response.body.must_be :empty?
+    response.join.must_be :empty?
   end
 
   it 'challenge correctly when no credentials are specified' do
@@ -54,7 +54,7 @@ describe Rack::Auth::Basic do
   it 'return application output if correct credentials are specified' do
     request_with_basic_auth 'Boss', 'password' do |response|
       response.status.must_equal 200
-      response.body.to_s.must_equal 'Hi Boss'
+      response.join.must_equal 'Hi Boss'
     end
   end
 

--- a/test/spec_auth_digest.rb
+++ b/test/spec_auth_digest.rb
@@ -104,7 +104,7 @@ describe Rack::Auth::Digest::MD5 do
     response.status.must_equal 401
     response.must_include 'WWW-Authenticate'
     response.headers['WWW-Authenticate'].must_match(/^Digest /)
-    response.body.must_be :empty?
+    response.join.must_be :empty?
   end
 
   def assert_bad_request(response)
@@ -122,7 +122,7 @@ describe Rack::Auth::Digest::MD5 do
   it 'return application output if correct credentials given' do
     request_with_digest_auth 'GET', '/', 'Alice', 'correct-password' do |response|
       response.status.must_equal 200
-      response.body.to_s.must_equal 'Hi Alice'
+      response.join.must_equal 'Hi Alice'
     end
   end
 
@@ -131,7 +131,7 @@ describe Rack::Auth::Digest::MD5 do
 
     request_with_digest_auth 'GET', '/', 'Alice', 'correct-password' do |response|
       response.status.must_equal 200
-      response.body.to_s.must_equal 'Hi Alice'
+      response.join.must_equal 'Hi Alice'
     end
   end
 
@@ -159,7 +159,7 @@ describe Rack::Auth::Digest::MD5 do
 
       request_with_digest_auth 'GET', '/', 'Alice', 'correct-password', wait: 1 do |response|
         response.status.must_equal 200
-        response.body.to_s.must_equal 'Hi Alice'
+        response.join.must_equal 'Hi Alice'
         response.headers['WWW-Authenticate'].wont_match(/\bstale=true\b/)
       end
     ensure
@@ -216,7 +216,7 @@ describe Rack::Auth::Digest::MD5 do
     @request = Rack::MockRequest.new(partially_protected_app)
     request_with_digest_auth 'GET', '/protected', 'Alice', 'correct-password' do |response|
       response.status.must_equal 200
-      response.body.to_s.must_equal 'Hi Alice'
+      response.join.must_equal 'Hi Alice'
     end
   end
 
@@ -224,7 +224,7 @@ describe Rack::Auth::Digest::MD5 do
     @request = Rack::MockRequest.new(partially_protected_app)
     request_with_digest_auth 'GET', '/protected?friend=Mike', 'Alice', 'correct-password' do |response|
       response.status.must_equal 200
-      response.body.to_s.must_equal 'Hi Alice and Mike'
+      response.join.must_equal 'Hi Alice and Mike'
     end
   end
 
@@ -233,14 +233,14 @@ describe Rack::Auth::Digest::MD5 do
     qs_uri = '/protected?friend=Mike'
     request_with_digest_auth 'GET', qs_uri, 'Alice', 'correct-password', 'uri' => qs_uri do |response|
       response.status.must_equal 200
-      response.body.to_s.must_equal 'Hi Alice and Mike'
+      response.join.must_equal 'Hi Alice and Mike'
     end
   end
 
   it 'return application output if correct credentials given for POST' do
     request_with_digest_auth 'POST', '/', 'Alice', 'correct-password' do |response|
       response.status.must_equal 200
-      response.body.to_s.must_equal 'Hi Alice'
+      response.join.must_equal 'Hi Alice'
     end
   end
 
@@ -248,7 +248,7 @@ describe Rack::Auth::Digest::MD5 do
     @request = Rack::MockRequest.new(protected_app_with_method_override)
     request_with_digest_auth 'POST', '/', 'Alice', 'correct-password', input: "_method=put" do |response|
       response.status.must_equal 200
-      response.body.to_s.must_equal 'Hi Alice'
+      response.join.must_equal 'Hi Alice'
     end
   end
 

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -34,8 +34,8 @@ describe Rack::Builder do
         run lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, ['sub']] }
       end
     end
-    Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'root'
-    Rack::MockRequest.new(app).get("/sub").body.to_s.must_equal 'sub'
+    Rack::MockRequest.new(app).get("/").join.must_equal 'root'
+    Rack::MockRequest.new(app).get("/sub").join.must_equal 'sub'
   end
 
   it "supports use when mapping" do
@@ -61,7 +61,7 @@ describe Rack::Builder do
         }
       end
     end
-    Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'root'
+    Rack::MockRequest.new(app).get("/").join.must_equal 'root'
     NothingMiddleware.env['new_key'].must_equal 'new_value'
   end
 
@@ -72,8 +72,8 @@ describe Rack::Builder do
       end
     end
 
-    builder_app1_id = Rack::MockRequest.new(app).get("/").body.to_s
-    builder_app2_id = Rack::MockRequest.new(app).get("/").body.to_s
+    builder_app1_id = Rack::MockRequest.new(app).get("/").join
+    builder_app2_id = Rack::MockRequest.new(app).get("/").join
 
     builder_app2_id.wont_equal builder_app1_id
   end
@@ -118,7 +118,7 @@ describe Rack::Builder do
     response = Rack::MockRequest.new(app).get("/",
         'HTTP_AUTHORIZATION' => 'Basic ' + ["joe:secret"].pack("m*"))
     response.status.must_equal 200
-    response.body.to_s.must_equal 'Hi Boss'
+    response.join.must_equal 'Hi Boss'
   end
 
   it "has explicit #to_app" do
@@ -140,8 +140,8 @@ describe Rack::Builder do
       run lambda { |inner_env| [200, { "Content-Type" => "text/plain" }, ['root']] }
     end
 
-    Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'root'
-    Rack::MockRequest.new(app).get("/sub").body.to_s.must_equal 'sub'
+    Rack::MockRequest.new(app).get("/").join.must_equal 'root'
+    Rack::MockRequest.new(app).get("/sub").join.must_equal 'sub'
   end
 
   it "accepts middleware-only map blocks" do
@@ -231,7 +231,7 @@ describe Rack::Builder do
 
     it "removes __END__ before evaluating app" do
       app, _ = Rack::Builder.parse_file config_file('end.ru')
-      Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'OK'
+      Rack::MockRequest.new(app).get("/").join.must_equal 'OK'
     end
 
     it "supports multi-line comments" do
@@ -242,13 +242,13 @@ describe Rack::Builder do
     it 'requires an_underscore_app not ending in .ru' do
       $: << File.dirname(__FILE__)
       app, * = Rack::Builder.parse_file 'builder/an_underscore_app'
-      Rack::MockRequest.new(app).get('/').body.to_s.must_equal 'OK'
+      Rack::MockRequest.new(app).get('/').join.must_equal 'OK'
       $:.pop
     end
 
     it "sets __LINE__ correctly" do
       app, _ = Rack::Builder.parse_file config_file('line.ru')
-      Rack::MockRequest.new(app).get("/").body.to_s.must_equal '3'
+      Rack::MockRequest.new(app).get("/").join.must_equal '3'
     end
 
     it "strips leading unicode byte order mark when present" do
@@ -256,7 +256,7 @@ describe Rack::Builder do
       begin
         Encoding.default_external = 'UTF-8'
         app, _ = Rack::Builder.parse_file config_file('bom.ru')
-        Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'OK'
+        Rack::MockRequest.new(app).get("/").join.must_equal 'OK'
       ensure
         Encoding.default_external = enc
       end
@@ -265,7 +265,7 @@ describe Rack::Builder do
     it "respects the frozen_string_literal magic comment" do
       app, _ = Rack::Builder.parse_file(config_file('frozen.ru'))
       response = Rack::MockRequest.new(app).get('/')
-      response.body.must_equal 'frozen'
+      response.join.must_equal 'frozen'
       body = response.instance_variable_get(:@body)
       body.must_equal(['frozen'])
       body[0].frozen?.must_equal true
@@ -275,7 +275,7 @@ describe Rack::Builder do
   describe 'new_from_string' do
     it "builds a rack app from string" do
       app, = Rack::Builder.new_from_string "run lambda{|env| [200, {'Content-Type' => 'text/plane'}, ['OK']] }"
-      Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'OK'
+      Rack::MockRequest.new(app).get("/").join.must_equal 'OK'
     end
   end
 end

--- a/test/spec_chunked.rb
+++ b/test/spec_chunked.rb
@@ -35,7 +35,7 @@ describe Rack::Chunked do
     response = Rack::MockResponse.new(*chunked(app).call(@env))
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
-    response.body.must_equal "5\r\nHello\r\n1\r\n \r\n6\r\nWorld!\r\n0\r\nExpires: tomorrow\r\n\r\n"
+    response.join.must_equal "5\r\nHello\r\n1\r\n \r\n6\r\nWorld!\r\n0\r\nExpires: tomorrow\r\n\r\n"
   end
 
   it 'chunk responses with no Content-Length' do
@@ -43,7 +43,7 @@ describe Rack::Chunked do
     response = Rack::MockResponse.new(*chunked(app).call(@env))
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
-    response.body.must_equal "5\r\nHello\r\n1\r\n \r\n6\r\nWorld!\r\n0\r\n\r\n"
+    response.join.must_equal "5\r\nHello\r\n1\r\n \r\n6\r\nWorld!\r\n0\r\n\r\n"
   end
 
   it 'chunks empty bodies properly' do
@@ -51,7 +51,7 @@ describe Rack::Chunked do
     response = Rack::MockResponse.new(*chunked(app).call(@env))
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
-    response.body.must_equal "0\r\n\r\n"
+    response.join.must_equal "0\r\n\r\n"
   end
 
   it 'closes body' do
@@ -63,7 +63,7 @@ describe Rack::Chunked do
     response = Rack::MockRequest.new(Rack::Chunked.new(app)).get('/', @env)
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
-    response.body.must_equal "1\r\ns\r\n0\r\n\r\n"
+    response.join.must_equal "1\r\ns\r\n0\r\n\r\n"
     closed.must_equal true
   end
 
@@ -73,9 +73,9 @@ describe Rack::Chunked do
     response = Rack::MockResponse.new(*chunked(app).call(@env))
     response.headers.wont_include 'Content-Length'
     response.headers['Transfer-Encoding'].must_equal 'chunked'
-    response.body.encoding.to_s.must_equal "ASCII-8BIT"
-    response.body.must_equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".dup.force_encoding("BINARY")
-    response.body.must_equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".dup.force_encoding(Encoding::BINARY)
+    response.join.encoding.to_s.must_equal "ASCII-8BIT"
+    response.join.must_equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".dup.force_encoding("BINARY")
+    response.join.must_equal "c\r\n\xFE\xFFH\x00e\x00l\x00l\x00o\x00\r\n2\r\n \x00\r\na\r\nW\x00o\x00r\x00l\x00d\x00\r\n0\r\n\r\n".dup.force_encoding(Encoding::BINARY)
   end
 
   it 'not modify response when Content-Length header present' do

--- a/test/spec_conditional_get.rb
+++ b/test/spec_conditional_get.rb
@@ -17,7 +17,7 @@ describe Rack::ConditionalGet do
       get("/", 'HTTP_IF_MODIFIED_SINCE' => timestamp)
 
     response.status.must_equal 304
-    response.body.must_be :empty?
+    response.join.must_be :empty?
   end
 
   it "set a 304 status and truncate body when If-Modified-Since hits and is higher than current time" do
@@ -28,7 +28,7 @@ describe Rack::ConditionalGet do
       get("/", 'HTTP_IF_MODIFIED_SINCE' => Time.now.httpdate)
 
     response.status.must_equal 304
-    response.body.must_be :empty?
+    response.join.must_be :empty?
   end
 
   it "set a 304 status and truncate body when If-None-Match hits" do
@@ -39,7 +39,7 @@ describe Rack::ConditionalGet do
       get("/", 'HTTP_IF_NONE_MATCH' => '1234')
 
     response.status.must_equal 304
-    response.body.must_be :empty?
+    response.join.must_be :empty?
   end
 
   it "set a 304 status and truncate body when If-None-Match hits but If-Modified-Since is after Last-Modified" do
@@ -50,7 +50,7 @@ describe Rack::ConditionalGet do
       get("/", 'HTTP_IF_MODIFIED_SINCE' => Time.now.httpdate, 'HTTP_IF_NONE_MATCH' => '1234')
 
     response.status.must_equal 304
-    response.body.must_be :empty?
+    response.join.must_be :empty?
   end
 
   it "not set a 304 status if If-Modified-Since hits but Etag does not" do
@@ -62,7 +62,7 @@ describe Rack::ConditionalGet do
       get("/", 'HTTP_IF_MODIFIED_SINCE' => timestamp, 'HTTP_IF_NONE_MATCH' => '4321')
 
     response.status.must_equal 200
-    response.body.must_equal 'TEST'
+    response.join.must_equal 'TEST'
   end
 
   it "set a 304 status and truncate body when both If-None-Match and If-Modified-Since hits" do
@@ -74,7 +74,7 @@ describe Rack::ConditionalGet do
       get("/", 'HTTP_IF_MODIFIED_SINCE' => timestamp, 'HTTP_IF_NONE_MATCH' => '1234')
 
     response.status.must_equal 304
-    response.body.must_be :empty?
+    response.join.must_be :empty?
   end
 
   it "not affect non-GET/HEAD requests" do
@@ -85,7 +85,7 @@ describe Rack::ConditionalGet do
       post("/", 'HTTP_IF_NONE_MATCH' => '1234')
 
     response.status.must_equal 200
-    response.body.must_equal 'TEST'
+    response.join.must_equal 'TEST'
   end
 
   it "not affect non-200 requests" do
@@ -96,7 +96,7 @@ describe Rack::ConditionalGet do
       get("/", 'HTTP_IF_NONE_MATCH' => '1234')
 
     response.status.must_equal 302
-    response.body.must_equal 'TEST'
+    response.join.must_equal 'TEST'
   end
 
   it "not affect requests with malformed HTTP_IF_NONE_MATCH" do
@@ -108,7 +108,7 @@ describe Rack::ConditionalGet do
       get("/", 'HTTP_IF_MODIFIED_SINCE' => bad_timestamp)
 
     response.status.must_equal 200
-    response.body.must_equal 'TEST'
+    response.join.must_equal 'TEST'
   end
 
 end

--- a/test/spec_config.rb
+++ b/test/spec_config.rb
@@ -15,6 +15,6 @@ describe Rack::Config do
     end
 
     response = Rack::MockRequest.new(app).get('/')
-    response.body.must_equal 'hello'
+    response.join.must_equal 'hello'
   end
 end

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -127,7 +127,7 @@ describe Rack::Directory do
       FileUtils.touch File.join(dir, "secret.txt")
       app = Rack::Directory.new(File.join(dir, "uploads"))
       res = Rack::MockRequest.new(app).get("/.%3F")
-      refute_match "secret.txt", res.body
+      refute_match "secret.txt", res.join
     end
   end
 
@@ -144,7 +144,7 @@ describe Rack::Directory do
     res = mr.get("/cgi/test%2bdirectory")
 
     res.must_be :ok?
-    res.body.must_match(Regexp.new(Rack::Utils.escape_html(
+    res.join.must_match(Regexp.new(Rack::Utils.escape_html(
       "/cgi/test\\+directory/test\\+file")))
 
     res = mr.get("/cgi/test%2bdirectory/test%2bfile")
@@ -200,7 +200,7 @@ describe Rack::Directory do
     res = mr.get("/script-path/cgi/test%2bdirectory")
 
     res.must_be :ok?
-    res.body.must_match(Regexp.new(Rack::Utils.escape_html(
+    res.join.must_match(Regexp.new(Rack::Utils.escape_html(
       "/script-path/cgi/test\\+directory/test\\+file")))
 
     res = mr.get("/script-path/cgi/test+directory/test+file")
@@ -212,6 +212,6 @@ describe Rack::Directory do
       head("/cgi/missing")
 
     res.must_be :not_found?
-    res.body.must_be :empty?
+    res.join.must_be :empty?
   end
 end

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -73,7 +73,7 @@ describe Rack::Files do
       get("/cgi/test", 'HTTP_IF_MODIFIED_SINCE' => File.mtime(path).httpdate)
 
     res.status.must_equal 304
-    res.body.must_be :empty?
+    res.join.must_be :empty?
   end
 
   it "return the file if it's modified since last serve" do
@@ -192,7 +192,7 @@ describe Rack::Files do
     res.status.must_equal 206
     res["Content-Length"].must_equal "12"
     res["Content-Range"].must_equal "bytes 22-33/209"
-    res.body.must_equal "IS FILE! ***"
+    res.join.must_equal "IS FILE! ***"
   end
 
   it "return correct multiple byte ranges in body" do
@@ -218,7 +218,7 @@ Content-Range: bytes 60-80/209\r
 --AaB03x--\r
     EOF
 
-    res.body.must_equal expected_body
+    res.join.must_equal expected_body
   end
 
   it "return error for unsatisfiable byte range" do
@@ -306,6 +306,6 @@ Content-Range: bytes 60-80/209\r
   it "return error when file not found for head request" do
     res = Rack::MockRequest.new(files(DOCROOT)).head("/cgi/missing")
     res.must_be :not_found?
-    res.body.must_be :empty?
+    res.join.must_be :empty?
   end
 end

--- a/test/spec_lobster.rb
+++ b/test/spec_lobster.rb
@@ -23,14 +23,14 @@ describe Rack::Lobster::LambdaLobster do
   it "look like a lobster" do
     res = lambda_lobster.get("/")
     res.must_be :ok?
-    res.body.must_include "(,(,,(,,,("
-    res.body.must_include "?flip"
+    res.join.must_include "(,(,,(,,,("
+    res.join.must_include "?flip"
   end
 
   it "be flippable" do
     res = lambda_lobster.get("/?flip")
     res.must_be :ok?
-    res.body.must_include "(,,,(,,(,("
+    res.join.must_include "(,,,(,,(,("
   end
 end
 
@@ -40,15 +40,15 @@ describe Rack::Lobster do
   it "look like a lobster" do
     res = lobster.get("/")
     res.must_be :ok?
-    res.body.must_include "(,(,,(,,,("
-    res.body.must_include "?flip"
-    res.body.must_include "crash"
+    res.join.must_include "(,(,,(,,,("
+    res.join.must_include "?flip"
+    res.join.must_include "crash"
   end
 
   it "be flippable" do
     res = lobster.get("/?flip=left")
     res.must_be :ok?
-    res.body.must_include "),,,),,),)"
+    res.join.must_include "),,,),,),)"
   end
 
   it "provide crashing for testing purposes" do

--- a/test/spec_recursive.rb
+++ b/test/spec_recursive.rb
@@ -42,7 +42,7 @@ describe Rack::Recursive do
       get("/app2")
 
     res.must_be :ok?
-    res.body.must_equal "App2App1"
+    res.join.must_equal "App2App1"
   end
 
   it "raise error on requests not below the app" do
@@ -63,11 +63,11 @@ describe Rack::Recursive do
 
     res = Rack::MockRequest.new(app).get("/app3")
     res.must_be :ok?
-    res.body.must_equal "App1"
+    res.join.must_equal "App1"
 
     res = Rack::MockRequest.new(app).get("/app4")
     res.must_be :ok?
-    res.body.must_equal "App1"
+    res.join.must_equal "App1"
     res["X-Path-Info"].must_equal "/quux"
     res["X-Query-String"].must_equal "meh"
   end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1326,19 +1326,19 @@ EOF
     mock = Rack::MockRequest.new(Rack::Lint.new(ip_app))
 
     res = mock.get '/', 'REMOTE_ADDR' => '1.2.3.4'
-    res.body.must_equal '1.2.3.4'
+    res.join.must_equal '1.2.3.4'
 
     res = mock.get '/', 'REMOTE_ADDR' => 'fe80::202:b3ff:fe1e:8329'
-    res.body.must_equal 'fe80::202:b3ff:fe1e:8329'
+    res.join.must_equal 'fe80::202:b3ff:fe1e:8329'
 
     res = mock.get '/', 'REMOTE_ADDR' => '1.2.3.4,3.4.5.6'
-    res.body.must_equal '1.2.3.4'
+    res.join.must_equal '1.2.3.4'
 
     res = mock.get '/', 'REMOTE_ADDR' => '127.0.0.1'
-    res.body.must_equal '127.0.0.1'
+    res.join.must_equal '127.0.0.1'
 
     res = mock.get '/', 'REMOTE_ADDR' => '127.0.0.1,127.0.0.1'
-    res.body.must_equal '127.0.0.1'
+    res.join.must_equal '127.0.0.1'
   end
 
   it 'deals with proxies' do
@@ -1347,92 +1347,92 @@ EOF
     res = mock.get '/',
       'REMOTE_ADDR' => '1.2.3.4',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
-    res.body.must_equal '1.2.3.4'
+    res.join.must_equal '1.2.3.4'
 
     res = mock.get '/',
       'REMOTE_ADDR' => '1.2.3.4',
       'HTTP_X_FORWARDED_FOR' => 'unknown'
-    res.body.must_equal '1.2.3.4'
+    res.join.must_equal '1.2.3.4'
 
     res = mock.get '/',
       'REMOTE_ADDR' => '127.0.0.1',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => 'unknown,3.4.5.6'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '192.168.0.1,3.4.5.6'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '10.0.0.1,3.4.5.6'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '10.0.0.1, 10.0.0.1, 3.4.5.6'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '127.0.0.1, 3.4.5.6'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
 
     # IPv6 format with optional port: "[2001:db8:cafe::17]:47011"
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '[2001:db8:cafe::17]:47011'
-    res.body.must_equal '2001:db8:cafe::17'
+    res.join.must_equal '2001:db8:cafe::17'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '1.2.3.4, [2001:db8:cafe::17]:47011'
-    res.body.must_equal '2001:db8:cafe::17'
+    res.join.must_equal '2001:db8:cafe::17'
 
     # IPv4 format with optional port: "192.0.2.43:47011"
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '192.0.2.43:47011'
-    res.body.must_equal '192.0.2.43'
+    res.join.must_equal '192.0.2.43'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '1.2.3.4, 192.0.2.43:47011'
-    res.body.must_equal '192.0.2.43'
+    res.join.must_equal '192.0.2.43'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => 'unknown,192.168.0.1'
-    res.body.must_equal 'unknown'
+    res.join.must_equal 'unknown'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => 'other,unknown,192.168.0.1'
-    res.body.must_equal 'unknown'
+    res.join.must_equal 'unknown'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => 'unknown,localhost,192.168.0.1'
-    res.body.must_equal 'unknown'
+    res.join.must_equal 'unknown'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '9.9.9.9, 3.4.5.6, 10.0.0.1, 172.31.4.4'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '::1,2620:0:1c00:0:812c:9583:754b:ca11'
-    res.body.must_equal '2620:0:1c00:0:812c:9583:754b:ca11'
+    res.join.must_equal '2620:0:1c00:0:812c:9583:754b:ca11'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '2620:0:1c00:0:812c:9583:754b:ca11,::1'
-    res.body.must_equal '2620:0:1c00:0:812c:9583:754b:ca11'
+    res.join.must_equal '2620:0:1c00:0:812c:9583:754b:ca11'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => 'fd5b:982e:9130:247f:0000:0000:0000:0000,2620:0:1c00:0:812c:9583:754b:ca11'
-    res.body.must_equal '2620:0:1c00:0:812c:9583:754b:ca11'
+    res.join.must_equal '2620:0:1c00:0:812c:9583:754b:ca11'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '2620:0:1c00:0:812c:9583:754b:ca11,fd5b:982e:9130:247f:0000:0000:0000:0000'
-    res.body.must_equal '2620:0:1c00:0:812c:9583:754b:ca11'
+    res.join.must_equal '2620:0:1c00:0:812c:9583:754b:ca11'
 
     res = mock.get '/',
       'HTTP_X_FORWARDED_FOR' => '1.1.1.1, 127.0.0.1',
       'HTTP_CLIENT_IP' => '1.1.1.1'
-    res.body.must_equal '1.1.1.1'
+    res.join.must_equal '1.1.1.1'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '8.8.8.8, 9.9.9.9'
-    res.body.must_equal '9.9.9.9'
+    res.join.must_equal '9.9.9.9'
 
     res = mock.get '/', 'HTTP_X_FORWARDED_FOR' => '8.8.8.8, fe80::202:b3ff:fe1e:8329'
-    res.body.must_equal 'fe80::202:b3ff:fe1e:8329'
+    res.join.must_equal 'fe80::202:b3ff:fe1e:8329'
 
     # Unix Sockets
     res = mock.get '/',
       'REMOTE_ADDR' => 'unix',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
 
     res = mock.get '/',
       'REMOTE_ADDR' => 'unix:/tmp/foo',
       'HTTP_X_FORWARDED_FOR' => '3.4.5.6'
-    res.body.must_equal '3.4.5.6'
+    res.join.must_equal '3.4.5.6'
   end
 
   it "not allow IP spoofing via Client-IP and X-Forwarded-For headers" do
@@ -1450,7 +1450,7 @@ EOF
     res = mock.get '/',
       'HTTP_X_FORWARDED_FOR' => '6.6.6.6, 2.2.2.3, 192.168.0.7',
       'HTTP_CLIENT_IP' => '6.6.6.6'
-    res.body.must_equal '2.2.2.3'
+    res.join.must_equal '2.2.2.3'
   end
 
   it "preserves ip for trusted proxy chain" do
@@ -1458,7 +1458,7 @@ EOF
     res = mock.get '/',
       'HTTP_X_FORWARDED_FOR' => '192.168.0.11, 192.168.0.7',
       'HTTP_CLIENT_IP' => '127.0.0.1'
-    res.body.must_equal '192.168.0.11'
+    res.join.must_equal '192.168.0.11'
 
   end
 

--- a/test/spec_sendfile.rb
+++ b/test/spec_sendfile.rb
@@ -35,7 +35,7 @@ describe Rack::Sendfile do
   it "does nothing when no X-Sendfile-Type header present" do
     request do |response|
       response.must_be :ok?
-      response.body.must_equal 'Hello World'
+      response.join.must_equal 'Hello World'
       response.headers.wont_include 'X-Sendfile'
     end
   end
@@ -44,7 +44,7 @@ describe Rack::Sendfile do
     io = StringIO.new
     request 'HTTP_X_SENDFILE_TYPE' => 'X-Banana', 'rack.errors' => io do |response|
       response.must_be :ok?
-      response.body.must_equal 'Hello World'
+      response.join.must_equal 'Hello World'
       response.headers.wont_include 'X-Sendfile'
 
       io.rewind
@@ -55,7 +55,7 @@ describe Rack::Sendfile do
   it "sets X-Sendfile response header and discards body" do
     request 'HTTP_X_SENDFILE_TYPE' => 'X-Sendfile' do |response|
       response.must_be :ok?
-      response.body.must_be :empty?
+      response.join.must_be :empty?
       response.headers['Content-Length'].must_equal '0'
       response.headers['X-Sendfile'].must_equal File.join(Dir.tmpdir,  "rack_sendfile")
     end
@@ -64,7 +64,7 @@ describe Rack::Sendfile do
   it "sets X-Lighttpd-Send-File response header and discards body" do
     request 'HTTP_X_SENDFILE_TYPE' => 'X-Lighttpd-Send-File' do |response|
       response.must_be :ok?
-      response.body.must_be :empty?
+      response.join.must_be :empty?
       response.headers['Content-Length'].must_equal '0'
       response.headers['X-Lighttpd-Send-File'].must_equal File.join(Dir.tmpdir,  "rack_sendfile")
     end
@@ -77,7 +77,7 @@ describe Rack::Sendfile do
     }
     request headers do |response|
       response.must_be :ok?
-      response.body.must_be :empty?
+      response.join.must_be :empty?
       response.headers['Content-Length'].must_equal '0'
       response.headers['X-Accel-Redirect'].must_equal '/foo/bar/rack_sendfile'
     end
@@ -90,7 +90,7 @@ describe Rack::Sendfile do
     }
     request headers, sendfile_body('file_with_%_?_symbol') do |response|
       response.must_be :ok?
-      response.body.must_be :empty?
+      response.join.must_be :empty?
       response.headers['Content-Length'].must_equal '0'
       response.headers['X-Accel-Redirect'].must_equal '/foo/bar%25/file_with_%25_%3F_symbol'
     end
@@ -99,7 +99,7 @@ describe Rack::Sendfile do
   it 'writes to rack.error when no X-Accel-Mapping is specified' do
     request 'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect' do |response|
       response.must_be :ok?
-      response.body.must_equal 'Hello World'
+      response.join.must_equal 'Hello World'
       response.headers.wont_include 'X-Accel-Redirect'
       response.errors.must_include 'X-Accel-Mapping'
     end
@@ -107,7 +107,7 @@ describe Rack::Sendfile do
 
   it 'does nothing when body does not respond to #to_path' do
     request({ 'HTTP_X_SENDFILE_TYPE' => 'X-Sendfile' }, ['Not a file...']) do |response|
-      response.body.must_equal 'Not a file...'
+      response.join.must_equal 'Not a file...'
       response.headers.wont_include 'X-Sendfile'
     end
   end
@@ -130,14 +130,14 @@ describe Rack::Sendfile do
 
       request({ 'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect' }, first_body, mappings) do |response|
         response.must_be :ok?
-        response.body.must_be :empty?
+        response.join.must_be :empty?
         response.headers['Content-Length'].must_equal '0'
         response.headers['X-Accel-Redirect'].must_equal '/foo/bar/rack_sendfile'
       end
 
       request({ 'HTTP_X_SENDFILE_TYPE' => 'X-Accel-Redirect' }, second_body, mappings) do |response|
         response.must_be :ok?
-        response.body.must_be :empty?
+        response.join.must_be :empty?
         response.headers['Content-Length'].must_equal '0'
         response.headers['X-Accel-Redirect'].must_equal '/wibble/rack_sendfile'
       end
@@ -169,21 +169,21 @@ describe Rack::Sendfile do
 
       request(headers, first_body) do |response|
         response.must_be :ok?
-        response.body.must_be :empty?
+        response.join.must_be :empty?
         response.headers['Content-Length'].must_equal '0'
         response.headers['X-Accel-Redirect'].must_equal '/foo/bar/rack_sendfile'
       end
 
       request(headers, second_body) do |response|
         response.must_be :ok?
-        response.body.must_be :empty?
+        response.join.must_be :empty?
         response.headers['Content-Length'].must_equal '0'
         response.headers['X-Accel-Redirect'].must_equal '/wibble/rack_sendfile'
       end
 
       request(headers, third_body) do |response|
         response.must_be :ok?
-        response.body.must_be :empty?
+        response.join.must_be :empty?
         response.headers['Content-Length'].must_equal '0'
         response.headers['X-Accel-Redirect'].must_equal "#{dir3}/rack_sendfile"
       end

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -38,7 +38,7 @@ describe Rack::Server do
   it "prefer to use :builder when it is passed in" do
     server = Rack::Server.new(builder: "run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['success']] }")
     server.app.class.must_equal Proc
-    Rack::MockRequest.new(server.app).get("/").body.to_s.must_equal 'success'
+    Rack::MockRequest.new(server.app).get("/").join.must_equal 'success'
   end
 
   it "allow subclasses to override middleware" do

--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -186,14 +186,14 @@ describe Rack::Session::Cookie do
     response = response_for(app: [incrementor, { coder: identity }])
 
     response["Set-Cookie"].must_include "rack.session="
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
     identity.calls.must_equal [:decode, :encode]
   end
 
   it "creates a new cookie" do
     response = response_for(app: incrementor)
     response["Set-Cookie"].must_include "rack.session="
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
   end
 
   it "passes through same_site option to session cookie" do
@@ -217,10 +217,10 @@ describe Rack::Session::Cookie do
     response = response_for(app: incrementor)
 
     response = response_for(app: incrementor, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.join.must_equal '{"counter"=>2}'
 
     response = response_for(app: incrementor, cookie: response)
-    response.body.must_equal '{"counter"=>3}'
+    response.join.must_equal '{"counter"=>3}'
   end
 
   it "renew session id" do
@@ -229,29 +229,29 @@ describe Rack::Session::Cookie do
     response = response_for(app: only_session_id, cookie: cookie)
     cookie   = response['Set-Cookie'] if response['Set-Cookie']
 
-    response.body.wont_equal ""
-    old_session_id = response.body
+    response.join.wont_equal ""
+    old_session_id = response.join
 
     response = response_for(app: renewer, cookie: cookie)
     cookie   = response['Set-Cookie'] if response['Set-Cookie']
     response = response_for(app: only_session_id, cookie: cookie)
 
-    response.body.wont_equal ""
-    response.body.wont_equal old_session_id
+    response.join.wont_equal ""
+    response.join.wont_equal old_session_id
   end
 
   it "destroys session" do
     response = response_for(app: incrementor)
     response = response_for(app: only_session_id, cookie: response)
 
-    response.body.wont_equal ""
-    old_session_id = response.body
+    response.join.wont_equal ""
+    old_session_id = response.join
 
     response = response_for(app: destroy_session, cookie: response)
     response = response_for(app: only_session_id, cookie: response)
 
-    response.body.wont_equal ""
-    response.body.wont_equal old_session_id
+    response.join.wont_equal ""
+    response.join.wont_equal old_session_id
   end
 
   it "survives broken cookies" do
@@ -259,13 +259,13 @@ describe Rack::Session::Cookie do
       app: incrementor,
       cookie: "rack.session=blarghfasel"
     )
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
 
     response = response_for(
       app: [incrementor, { secret: "test" }],
       cookie: "rack.session="
     )
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
   end
 
   it "barks on too big cookies" do
@@ -279,15 +279,15 @@ describe Rack::Session::Cookie do
 
     response = response_for(app: app)
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.join.must_equal '{"counter"=>2}'
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>3}'
+    response.join.must_equal '{"counter"=>3}'
 
     app = [incrementor, { secret: "other" }]
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
   end
 
   it "loads from a cookie with accept-only integrity hash for graceful key rotation" do
@@ -295,42 +295,42 @@ describe Rack::Session::Cookie do
 
     app = [incrementor, { secret: "test2", old_secret: "test" }]
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.join.must_equal '{"counter"=>2}'
 
     app = [incrementor, { secret: "test3", old_secret: "test2" }]
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>3}'
+    response.join.must_equal '{"counter"=>3}'
   end
 
   it "ignores tampered with session cookies" do
     app = [incrementor, { secret: "test" }]
     response = response_for(app: app)
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.join.must_equal '{"counter"=>2}'
 
     _, digest = response["Set-Cookie"].split("--")
     tampered_with_cookie = "hackerman-was-here" + "--" + digest
 
     response = response_for(app: app, cookie: tampered_with_cookie)
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
   end
 
   it "supports either of secret or old_secret" do
     app = [incrementor, { secret: "test" }]
     response = response_for(app: app)
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.join.must_equal '{"counter"=>2}'
 
     app = [incrementor, { old_secret: "test" }]
     response = response_for(app: app)
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.join.must_equal '{"counter"=>2}'
   end
 
   it "supports custom digest instance" do
@@ -338,15 +338,15 @@ describe Rack::Session::Cookie do
 
     response = response_for(app: app)
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.join.must_equal '{"counter"=>2}'
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>3}'
+    response.join.must_equal '{"counter"=>3}'
 
     app = [incrementor, { secret: "other" }]
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
   end
 
   it "can handle Rack::Lint middleware" do
@@ -354,7 +354,7 @@ describe Rack::Session::Cookie do
 
     lint = Rack::Lint.new(session_id)
     response = response_for(app: lint, cookie: response)
-    response.body.wont_be :nil?
+    response.join.wont_be :nil?
   end
 
   it "can handle middleware that inspects the env" do
@@ -372,16 +372,16 @@ describe Rack::Session::Cookie do
 
     inspector = TestEnvInspector.new(session_id)
     response = response_for(app: inspector, cookie: response)
-    response.body.wont_be :nil?
+    response.join.wont_be :nil?
   end
 
   it "returns the session id in the session hash" do
     response = response_for(app: incrementor)
-    response.body.must_equal '{"counter"=>1}'
+    response.join.must_equal '{"counter"=>1}'
 
     response = response_for(app: session_id, cookie: response)
-    response.body.must_match(/"session_id"=>/)
-    response.body.must_match(/"counter"=>1/)
+    response.join.must_match(/"session_id"=>/)
+    response.join.must_match(/"counter"=>1/)
   end
 
   it "does not return a cookie if set to secure but not using ssl" do
@@ -420,25 +420,25 @@ describe Rack::Session::Cookie do
 
   it "exposes :secret in env['rack.session.option']" do
     response = response_for(app: [session_option[:secret], { secret: "foo" }])
-    response.body.must_equal '"foo"'
+    response.join.must_equal '"foo"'
   end
 
   it "exposes :coder in env['rack.session.option']" do
     response = response_for(app: session_option[:coder])
-    response.body.must_match(/Base64::Marshal/)
+    response.join.must_match(/Base64::Marshal/)
   end
 
   it "allows passing in a hash with session data from middleware in front" do
     request = { 'rack.session' => { foo: 'bar' } }
     response = response_for(app: session_id, request: request)
-    response.body.must_match(/foo/)
+    response.join.must_match(/foo/)
   end
 
   it "allows modifying session data with session data from middleware in front" do
     request = { 'rack.session' => { foo: 'bar' } }
     response = response_for(app: incrementor, request: request)
-    response.body.must_match(/counter/)
-    response.body.must_match(/foo/)
+    response.join.must_match(/counter/)
+    response.join.must_match(/foo/)
   end
 
   it "allows more than one '--' in the cookie when calculating digests" do
@@ -457,9 +457,9 @@ describe Rack::Session::Cookie do
     }.new
     _app = [ app, { secret: "test", coder: unsafe_coder } ]
     response = response_for(app: _app)
-    response.body.must_equal "1--"
+    response.join.must_equal "1--"
     response = response_for(app: _app, cookie: response)
-    response.body.must_equal "1--2--"
+    response.join.must_equal "1--2--"
   end
 
   it 'allows for non-strict encoded cookie' do
@@ -491,8 +491,8 @@ describe Rack::Session::Cookie do
       incrementor
     ], cookie: non_strict_response)
 
-    response.body.must_match %Q["value"=>"#{'A' * 256}"]
-    response.body.must_match '"counter"=>2'
-    response.body.must_match(/\A{[^}]+}\z/)
+    response.join.must_match %Q["value"=>"#{'A' * 256}"]
+    response.join.must_match '"counter"=>2'
+    response.join.must_match(/\A{[^}]+}\z/)
   end
 end

--- a/test/spec_session_pool.rb
+++ b/test/spec_session_pool.rb
@@ -41,24 +41,21 @@ describe Rack::Session::Pool do
     pool = Rack::Session::Pool.new(incrementor)
     res = Rack::MockRequest.new(pool).get("/")
     res["Set-Cookie"].must_match(session_match)
-    res.body.must_equal '{"counter"=>1}'
+    res.join.must_equal '{"counter"=>1}'
   end
 
   it "determines session from a cookie" do
     pool = Rack::Session::Pool.new(incrementor)
     req = Rack::MockRequest.new(pool)
     cookie = req.get("/")["Set-Cookie"]
-    req.get("/", "HTTP_COOKIE" => cookie).
-      body.must_equal '{"counter"=>2}'
-    req.get("/", "HTTP_COOKIE" => cookie).
-      body.must_equal '{"counter"=>3}'
+    req.get("/", "HTTP_COOKIE" => cookie).join.must_equal '{"counter"=>2}'
+    req.get("/", "HTTP_COOKIE" => cookie).join.must_equal '{"counter"=>3}'
   end
 
   it "survives nonexistent cookies" do
     pool = Rack::Session::Pool.new(incrementor)
-    res = Rack::MockRequest.new(pool).
-      get("/", "HTTP_COOKIE" => "#{session_key}=blarghfasel")
-    res.body.must_equal '{"counter"=>1}'
+    res = Rack::MockRequest.new(pool).get("/", "HTTP_COOKIE" => "#{session_key}=blarghfasel")
+    res.join.must_equal '{"counter"=>1}'
   end
 
   it "does not send the same session id if it did not change" do
@@ -67,17 +64,17 @@ describe Rack::Session::Pool do
 
     res0 = req.get("/")
     cookie = res0["Set-Cookie"][session_match]
-    res0.body.must_equal '{"counter"=>1}'
+    res0.join.must_equal '{"counter"=>1}'
     pool.pool.size.must_equal 1
 
     res1 = req.get("/", "HTTP_COOKIE" => cookie)
     res1["Set-Cookie"].must_be_nil
-    res1.body.must_equal '{"counter"=>2}'
+    res1.join.must_equal '{"counter"=>2}'
     pool.pool.size.must_equal 1
 
     res2 = req.get("/", "HTTP_COOKIE" => cookie)
     res2["Set-Cookie"].must_be_nil
-    res2.body.must_equal '{"counter"=>3}'
+    res2.join.must_equal '{"counter"=>3}'
     pool.pool.size.must_equal 1
   end
 
@@ -89,17 +86,17 @@ describe Rack::Session::Pool do
 
     res1 = req.get("/")
     session = (cookie = res1["Set-Cookie"])[session_match]
-    res1.body.must_equal '{"counter"=>1}'
+    res1.join.must_equal '{"counter"=>1}'
     pool.pool.size.must_equal 1
 
     res2 = dreq.get("/", "HTTP_COOKIE" => cookie)
     res2["Set-Cookie"].must_be_nil
-    res2.body.must_equal '{"counter"=>2}'
+    res2.join.must_equal '{"counter"=>2}'
     pool.pool.size.must_equal 0
 
     res3 = req.get("/", "HTTP_COOKIE" => cookie)
     res3["Set-Cookie"][session_match].wont_equal session
-    res3.body.must_equal '{"counter"=>1}'
+    res3.join.must_equal '{"counter"=>1}'
     pool.pool.size.must_equal 1
   end
 
@@ -111,22 +108,22 @@ describe Rack::Session::Pool do
 
     res1 = req.get("/")
     session = (cookie = res1["Set-Cookie"])[session_match]
-    res1.body.must_equal '{"counter"=>1}'
+    res1.join.must_equal '{"counter"=>1}'
     pool.pool.size.must_equal 1
 
     res2 = rreq.get("/", "HTTP_COOKIE" => cookie)
     new_cookie = res2["Set-Cookie"]
     new_session = new_cookie[session_match]
     new_session.wont_equal session
-    res2.body.must_equal '{"counter"=>2}'
+    res2.join.must_equal '{"counter"=>2}'
     pool.pool.size.must_equal 1
 
     res3 = req.get("/", "HTTP_COOKIE" => new_cookie)
-    res3.body.must_equal '{"counter"=>3}'
+    res3.join.must_equal '{"counter"=>3}'
     pool.pool.size.must_equal 1
 
     res4 = req.get("/", "HTTP_COOKIE" => cookie)
-    res4.body.must_equal '{"counter"=>1}'
+    res4.join.must_equal '{"counter"=>1}'
     pool.pool.size.must_equal 2
   end
 
@@ -137,7 +134,7 @@ describe Rack::Session::Pool do
 
     res1 = dreq.get("/")
     res1["Set-Cookie"].must_be_nil
-    res1.body.must_equal '{"counter"=>1}'
+    res1.join.must_equal '{"counter"=>1}'
     pool.pool.size.must_equal 1
   end
 
@@ -154,7 +151,7 @@ describe Rack::Session::Pool do
 
     res1 = req.get("/", "HTTP_COOKIE" => cookie)
     res1["Set-Cookie"].must_be_nil
-    res1.body.must_equal '{"counter"=>2}'
+    res1.join.must_equal '{"counter"=>2}'
     pool.pool[session_id.private_id].wont_be_nil
   end
 
@@ -171,7 +168,7 @@ describe Rack::Session::Pool do
 
     res1 = req.get("/", "HTTP_COOKIE" => cookie)
     res1["Set-Cookie"].wont_be_nil
-    res1.body.must_equal '{"counter"=>1}'
+    res1.join.must_equal '{"counter"=>1}'
   end
 
   it "drops the session in the legacy id as well" do
@@ -189,7 +186,7 @@ describe Rack::Session::Pool do
 
     res2 = dreq.get("/", "HTTP_COOKIE" => cookie)
     res2["Set-Cookie"].must_be_nil
-    res2.body.must_equal '{"counter"=>2}'
+    res2.join.must_equal '{"counter"=>2}'
     pool.pool[session_id.private_id].must_be_nil
     pool.pool[session_id.public_id].must_be_nil
   end
@@ -225,7 +222,7 @@ describe Rack::Session::Pool do
     req = Rack::MockRequest.new(pool)
 
     res = req.get('/')
-    res.body.must_equal '{"counter"=>1}'
+    res.join.must_equal '{"counter"=>1}'
     cookie = res["Set-Cookie"]
     sess_id = cookie[/#{pool.key}=([^,;]+)/, 1]
 
@@ -246,7 +243,7 @@ describe Rack::Session::Pool do
     end.reverse.map{|t| t.run.join.value }
     r.each do |resp|
       resp['Set-Cookie'].must_equal cookie
-      resp.body.must_include '"counter"=>2'
+      resp.join.must_include '"counter"=>2'
     end
 
     session = pool.pool[sess_id]

--- a/test/spec_show_exceptions.rb
+++ b/test/spec_show_exceptions.rb
@@ -39,12 +39,12 @@ describe Rack::ShowExceptions do
     res.must_be :server_error?
     res.status.must_equal 500
 
-    assert_includes(res.body, 'RuntimeError')
-    assert_includes(res.body, 'ShowExceptions')
-    assert_includes(res.body, 'No GET data')
-    assert_includes(res.body, 'No POST data')
-    assert_includes(res.body, 'nonexistant.rb')
-    refute_includes(res.body, 'bad-backtrace')
+    assert_includes(res.join, 'RuntimeError')
+    assert_includes(res.join, 'ShowExceptions')
+    assert_includes(res.join, 'No GET data')
+    assert_includes(res.join, 'No POST data')
+    assert_includes(res.join, 'nonexistant.rb')
+    refute_includes(res.join, 'bad-backtrace')
   end
 
   it "handles invalid POST data exceptions" do
@@ -107,13 +107,13 @@ describe Rack::ShowExceptions do
 
       res.content_type.must_equal exmime
 
-      res.body.must_include "RuntimeError"
-      res.body.must_include "It was never supposed to work"
+      res.join.must_include "RuntimeError"
+      res.join.must_include "It was never supposed to work"
 
       if exmime == "text/html"
-        res.body.must_include '</html>'
+        res.join.must_include '</html>'
       else
-        res.body.wont_include '</html>'
+        res.join.wont_include '</html>'
       end
     end
   end
@@ -156,7 +156,7 @@ describe Rack::ShowExceptions do
 
     res.must_be :server_error?
     res.status.must_equal 500
-    res.body.must_equal "foo"
+    res.join.must_equal "foo"
   end
 
   it "knows to prefer plaintext for non-html" do

--- a/test/spec_show_status.rb
+++ b/test/spec_show_status.rb
@@ -53,9 +53,9 @@ describe Rack::ShowStatus do
     res.wont_be_empty
 
     res["Content-Type"].must_equal "text/html"
-    assert_includes(res.body, '404')
-    assert_includes(res.body, 'Not Found')
-    assert_includes(res.body, '[&quot;gone too meta.&quot;]')
+    assert_includes(res.join, '404')
+    assert_includes(res.join, 'Not Found')
+    assert_includes(res.join, '[&quot;gone too meta.&quot;]')
   end
 
   it "escape error" do
@@ -73,7 +73,7 @@ describe Rack::ShowStatus do
     res["Content-Type"].must_equal "text/html"
     assert_match(res, /500/)
     res.wont_include detail
-    res.body.must_include Rack::Utils.escape_html(detail)
+    res.join.must_include Rack::Utils.escape_html(detail)
   end
 
   it "not replace existing messages" do
@@ -86,7 +86,7 @@ describe Rack::ShowStatus do
     res = req.get("/", lint: true)
     res.must_be :not_found?
 
-    res.body.must_equal "foo!"
+    res.join.must_equal "foo!"
   end
 
   it "pass on original headers" do
@@ -115,7 +115,7 @@ describe Rack::ShowStatus do
     res["Content-Length"].wont_equal "4"
     assert_match(res, /404/)
     assert_match(res, /too meta/)
-    res.body.wont_match(/foo/)
+    res.join.wont_match(/foo/)
   end
 
   it "close the original body" do

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -40,7 +40,7 @@ describe Rack::Static do
   it "serves files" do
     res = @request.get("/cgi/test")
     res.must_be :ok?
-    res.body.must_match(/ruby/)
+    res.join.must_match(/ruby/)
   end
 
   it "404s if url root is known but it can't find the file" do
@@ -51,65 +51,65 @@ describe Rack::Static do
   it "serves files when using :cascade option" do
     res = @cascade_request.get("/cgi/test")
     res.must_be :ok?
-    res.body.must_match(/ruby/)
+    res.join.must_match(/ruby/)
   end
 
   it "calls down the chain if if can't find the file when using the :cascade option" do
     res = @cascade_request.get("/cgi/foo")
     res.must_be :ok?
-    res.body.must_equal "Hello World"
+    res.join.must_equal "Hello World"
   end
 
   it "calls down the chain if url root is not known" do
     res = @request.get("/something/else")
     res.must_be :ok?
-    res.body.must_equal "Hello World"
+    res.join.must_equal "Hello World"
   end
 
   it "calls index file when requesting root in the given folder" do
     res = @static_request.get("/")
     res.must_be :ok?
-    res.body.must_match(/index!/)
+    res.join.must_match(/index!/)
 
     res = @static_request.get("/other/")
     res.must_be :not_found?
 
     res = @static_request.get("/another/")
     res.must_be :ok?
-    res.body.must_match(/another index!/)
+    res.join.must_match(/another index!/)
   end
 
   it "does not call index file when requesting folder with unknown prefix" do
     res = @static_urls_request.get("/static/another/")
     res.must_be :ok?
-    res.body.must_match(/index!/)
+    res.join.must_match(/index!/)
 
     res = @static_urls_request.get("/something/else/")
     res.must_be :ok?
-    res.body.must_equal "Hello World"
+    res.join.must_equal "Hello World"
   end
 
   it "doesn't call index file if :index option was omitted" do
     res = @request.get("/")
-    res.body.must_equal "Hello World"
+    res.join.must_equal "Hello World"
   end
 
   it "serves hidden files" do
     res = @hash_request.get("/cgi/sekret")
     res.must_be :ok?
-    res.body.must_match(/ruby/)
+    res.join.must_match(/ruby/)
   end
 
   it "calls down the chain if the URI is not specified" do
     res = @hash_request.get("/something/else")
     res.must_be :ok?
-    res.body.must_equal "Hello World"
+    res.join.must_equal "Hello World"
   end
 
   it "allows the root URI to be configured via hash options" do
     res = @hash_root_request.get("/")
     res.must_be :ok?
-    res.body.must_match(/foo.html!/)
+    res.join.must_match(/foo.html!/)
   end
 
   it "serves gzipped files if client accepts gzip encoding and gzip files are present" do
@@ -117,7 +117,7 @@ describe Rack::Static do
     res.must_be :ok?
     res.headers['Content-Encoding'].must_equal 'gzip'
     res.headers['Content-Type'].must_equal 'text/plain'
-    Zlib::GzipReader.wrap(StringIO.new(res.body), &:read).must_match(/ruby/)
+    Zlib::GzipReader.wrap(StringIO.new(res.join), &:read).must_match(/ruby/)
   end
 
   it "serves regular files if client accepts gzip encoding and gzip files are not present" do
@@ -125,7 +125,7 @@ describe Rack::Static do
     res.must_be :ok?
     res.headers['Content-Encoding'].must_be_nil
     res.headers['Content-Type'].must_equal 'text/x-script.ruby'
-    res.body.must_match(/ruby/)
+    res.join.must_match(/ruby/)
   end
 
   it "serves regular files if client does not accept gzip encoding" do
@@ -133,14 +133,14 @@ describe Rack::Static do
     res.must_be :ok?
     res.headers['Content-Encoding'].must_be_nil
     res.headers['Content-Type'].must_equal 'text/plain'
-    res.body.must_match(/ruby/)
+    res.join.must_match(/ruby/)
   end
 
   it "returns 304 if gzipped file isn't modified since last serve" do
     path = File.join(DOCROOT, "/cgi/test")
     res = @gzip_request.get("/cgi/test", 'HTTP_IF_MODIFIED_SINCE' => File.mtime(path).httpdate)
     res.status.must_equal 304
-    res.body.must_be :empty?
+    res.join.must_be :empty?
     res.headers['Content-Encoding'].must_be_nil
     res.headers['Content-Type'].must_be_nil
   end
@@ -224,7 +224,7 @@ describe Rack::Static do
     Dir.chdir '..' do
       res = request.get("")
       res.must_be :ok?
-      res.body.must_match(/index!/)
+      res.join.must_match(/index!/)
     end
   end
 end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -843,6 +843,6 @@ describe Rack::Utils::Context do
     r4.status.must_equal 200
     r5 = Rack::MockRequest.new(a5).get('/')
     r5.status.must_equal 200
-    r4.body.must_equal r5.body
+    r4.join.must_equal r5.join
   end
 end


### PR DESCRIPTION
The subclass interface is not compatible with the base class (Liskov substitution principle). There is a comment which basically cries for help. This retains backwards compatibility with a warning, and provides an alternative convenient interface for joining the body (which is not deprecated).

I propose for Rack 3.1 or 4.0 we remove the keyword argument.