### PR TITLE
Don't create garbage StringIO.

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -188,7 +188,7 @@ module Rack
       if errors
         @errors = errors.string if errors.respond_to?(:string)
       else
-        @errors = nil
+        @errors = ""
       end
 
       super(body, status, headers)

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -182,9 +182,14 @@ module Rack
     # Errors
     attr_accessor :errors
 
-    def initialize(status, headers, body, errors = StringIO.new(""))
+    def initialize(status, headers, body, errors = nil)
       @original_headers = headers
-      @errors           = errors.string if errors.respond_to?(:string)
+
+      if errors
+        @errors = errors.string if errors.respond_to?(:string)
+      else
+        @errors = nil
+      end
 
       super(body, status, headers)
 


### PR DESCRIPTION
Does this break compatibility? Currently if no argument is supplied it defaults to `""`, but now it defaults to `nil`. However, all usage within Rack supplies an argument AFAIK.