### PR TITLE
Cache Rack::Request#POST result if input content type is not parseable (Fixes #749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file. For info on
 - Decrease default allowed parameter recursion level from 100 to 32. ([#1640](https://github.com/rack/rack/issues/1640), [@jeremyevans](https://github.com/jeremyevans))
 - Attempting to parse a multipart response with an empty body now raises Rack::Multipart::EmptyContentError. ([#1603](https://github.com/rack/rack/issues/1603), [@jeremyevans](https://github.com/jeremyevans))
 - `Rack::Utils.secure_compare` uses OpenSSL's faster implementation if available. ([#1711](https://github.com/rack/rack/pull/1711), [@bdewater](https://github.com/bdewater))
+- `Rack::Request#POST` now caches an empty hash if input content type is not parseable. ([#749](https://github.com/rack/rack/pull/749), [@jeremyevans](https://github.com/jeremyevans))
 - BREAKING CHANGE: Updated `trusted_proxy?` to match full 127.0.0.0/8 network. ([#1781](https://github.com/rack/rack/pull/1781), [@snbloch](https://github.com/snbloch))
 
 ### Fixed

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -471,7 +471,8 @@ module Rack
           set_header RACK_REQUEST_FORM_INPUT, get_header(RACK_INPUT)
           get_header RACK_REQUEST_FORM_HASH
         else
-          {}
+          set_header RACK_REQUEST_FORM_INPUT, get_header(RACK_INPUT)
+          set_header(RACK_REQUEST_FORM_HASH, {})
         end
       end
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -434,7 +434,9 @@ class RackRequestTest < Minitest::Spec
     req.media_type.must_equal 'text/plain'
     req.media_type_params['charset'].must_equal 'utf-8'
     req.content_charset.must_equal 'utf-8'
-    req.POST.must_be :empty?
+    post = req.POST
+    post.must_be_empty
+    req.POST.must_be_same_as post
     req.params.must_equal "foo" => "quux"
     req.body.read.must_equal "foo=bar&quux=bla"
   end


### PR DESCRIPTION
In all other cases, the result was cached, so not caching in this
case is inconsistent, and can result in unexpected behavior if
POST is called multiple times on the same request.