### PR TITLE
Avoid use of regexps for parsing parameter keys

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -205,7 +205,7 @@ module Rack
         @collector.each do |part|
           part.get_data do |data|
             tag_multipart_encoding(part.filename, part.content_type, part.name, data)
-            @query_parser.normalize_params(@params, part.name, data, @query_parser.param_depth_limit)
+            @query_parser.normalize_params(@params, part.name, data, 0)
           end
         end
         MultipartInfo.new @params.to_params_hash, @collector.find_all(&:file?).map(&:body)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1527,6 +1527,22 @@ EOF
     end
   }
 
+  (24..27).each do |exp|
+    length = 2**exp
+    it "handles ASCII NUL input of #{length} bytes" do
+      mr = Rack::MockRequest.env_for("/",
+        "REQUEST_METHOD" => 'POST',
+        :input => "\0"*length)
+      req = make_request mr
+      req.query_string.must_equal ""
+      req.GET.must_be :empty?
+      keys = req.POST.keys
+      keys.length.must_equal 1
+      keys.first.length.must_equal(length-1)
+      keys.first.must_equal("\0"*(length-1))
+    end
+  end
+
   class NonDelegate < Rack::Request
     def delegate?; false; end
   end


### PR DESCRIPTION
This avoids a RegexpError when trying to parse long key input.
It also avoids an invalid InvalidParameterError when trying
to parse non-UTF8 keys, which was only raised previously
because regexps were used without marking them as ASCII-8BIT.

Flip the depth parameter to QueryParser#normalize_params to
be the current parsing depth, instead of a downward counter
from the maximum depth.

Fix a bunch of questionable behavior in parameter parsing
when using [ and ] outside cases that are expected. Treat
[ and ] as normal characters if the occur outside expected
usage.

This leaves one questionable parameter parsing behavior that
also existed previously, which is that: a[b]c is parsed the
same as a[b][c].

Fixes #1704.