### PR TITLE
Make QueryParser#normalize_params API more compatible with Rack 2

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -205,7 +205,7 @@ module Rack
         @collector.each do |part|
           part.get_data do |data|
             tag_multipart_encoding(part.filename, part.content_type, part.name, data)
-            @query_parser.normalize_params(@params, part.name, data, 0)
+            @query_parser.normalize_params(@params, part.name, data)
           end
         end
         MultipartInfo.new @params.to_params_hash, @collector.find_all(&:file?).map(&:body)


### PR DESCRIPTION
Switching the depth argument to be the starting depth is not compatible
and results in breakage in rack-test (and likely other libraries).

Fix this by keeping the normalize_params API the same, and moving the
implementation to a private _normalize_params method.  Remove
now unnecessary depth arguments when calling normalize_params, and
call _normalize_params directly for internal calls.