### PR TITLE
 Add rack.response_finished to Rack::Lint

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -137,6 +137,7 @@ There are the following restrictions:
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if
   <tt>SCRIPT_NAME</tt> is empty.
   <tt>SCRIPT_NAME</tt> never should be <tt>/</tt>, but instead be empty.
+<tt>rack.response_finished</tt>:: An array of callables run after the HTTP response has been sent.
 
 === The Input Stream
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -139,7 +139,9 @@ There are the following restrictions:
   <tt>SCRIPT_NAME</tt> never should be <tt>/</tt>, but instead be empty.
 <tt>rack.response_finished</tt>:: An array of callables run after the HTTP response has been sent.
 The array of callables should be called directly after the HTTP response has
-been closed. The callables should be called sequentially and synchronously.
+been completely sent. The callables should be called sequentially and synchronously
+in the same execution context as the response. If an exception is raised, it will
+be ignored and will not impact the execution of other callables.
 
 
 === The Input Stream

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -137,7 +137,15 @@ There are the following restrictions:
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if
   <tt>SCRIPT_NAME</tt> is empty.
   <tt>SCRIPT_NAME</tt> never should be <tt>/</tt>, but instead be empty.
-<tt>rack.response.finished</tt>:: An array of callables run after the HTTP response has been sent.
+<tt>rack.response.finished</tt>:: An array of objects responding to #call with one argument, the env hash for the request, that will be called after the HTTP response has been sent to the client.
+The callables are called directly after the HTTP response has been sent to the
+client. The callables should be called sequentially and synchronously in the
+same execution context as the the response. If an exception is raised, it will
+be ignored and will not impact the execution of the other callables. The
+callbacks will be called event if the request is cancelled (e.g. a user closing
+the browser tab before the request completes). Servers supporting this
+functionality will prepopulate env with an empty array.
+
 
 === The Input Stream
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -146,7 +146,6 @@ callbacks will be called event if the request is cancelled (e.g. a user closing
 the browser tab before the request completes). Servers supporting this
 functionality will prepopulate env with an empty array.
 
-
 === The Input Stream
 
 The input stream is an IO-like object which contains the raw HTTP

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -138,6 +138,9 @@ There are the following restrictions:
   <tt>SCRIPT_NAME</tt> is empty.
   <tt>SCRIPT_NAME</tt> never should be <tt>/</tt>, but instead be empty.
 <tt>rack.response_finished</tt>:: An array of callables run after the HTTP response has been sent.
+The array of callables should be called directly after the HTTP response has
+been closed. The callables should be called sequentially and synchronously.
+
 
 === The Input Stream
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -137,12 +137,7 @@ There are the following restrictions:
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if
   <tt>SCRIPT_NAME</tt> is empty.
   <tt>SCRIPT_NAME</tt> never should be <tt>/</tt>, but instead be empty.
-<tt>rack.response_finished</tt>:: An array of objects responding to #call with one argument, the env hash for the request, that will be called after the HTTP response has been sent to the client.
-The callables are called directly after the HTTP response has been sent to the
-client. The callables should be called sequentially and synchronously in the
-same execution context as the the response. If an exception is raised, it will
-be ignored and will not impact the execution of the other callables.
-
+<tt>rack.response.finished</tt>:: An array of callables run after the HTTP response has been sent.
 
 === The Input Stream
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -137,11 +137,11 @@ There are the following restrictions:
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if
   <tt>SCRIPT_NAME</tt> is empty.
   <tt>SCRIPT_NAME</tt> never should be <tt>/</tt>, but instead be empty.
-<tt>rack.response_finished</tt>:: An array of callables run after the HTTP response has been sent.
-The array of callables should be called directly after the HTTP response has
-been completely sent. The callables should be called sequentially and synchronously
-in the same execution context as the response. If an exception is raised, it will
-be ignored and will not impact the execution of other callables.
+<tt>rack.response_finished</tt>:: An array of objects responding to #call with one argument, the env hash for the request, that will be called after the HTTP response has been sent to the client.
+The callables are called directly after the HTTP response has been sent to the
+client. The callables should be called sequentially and synchronously in the
+same execution context as the the response. If an exception is raised, it will
+be ignored and will not impact the execution of the other callables.
 
 
 === The Input Stream

--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -52,6 +52,7 @@ module Rack
   RACK_RECURSIVE_INCLUDE              = 'rack.recursive.include'
   RACK_MULTIPART_BUFFER_SIZE          = 'rack.multipart.buffer_size'
   RACK_MULTIPART_TEMPFILE_FACTORY     = 'rack.multipart.tempfile_factory'
+  RACK_RESPONSE_FINISHED              = 'rack.response_finished'
   RACK_REQUEST_FORM_INPUT             = 'rack.request.form_input'
   RACK_REQUEST_FORM_HASH              = 'rack.request.form_hash'
   RACK_REQUEST_FORM_VARS              = 'rack.request.form_vars'

--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -52,7 +52,7 @@ module Rack
   RACK_RECURSIVE_INCLUDE              = 'rack.recursive.include'
   RACK_MULTIPART_BUFFER_SIZE          = 'rack.multipart.buffer_size'
   RACK_MULTIPART_TEMPFILE_FACTORY     = 'rack.multipart.tempfile_factory'
-  RACK_RESPONSE_FINISHED              = 'rack.response_finished'
+  RACK_RESPONSE_FINISHED              = 'rack.response.finished'
   RACK_REQUEST_FORM_INPUT             = 'rack.request.form_input'
   RACK_REQUEST_FORM_HASH              = 'rack.request.form_hash'
   RACK_REQUEST_FORM_VARS              = 'rack.request.form_vars'

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -359,6 +359,15 @@ module Rack
         unless env[SCRIPT_NAME] != "/"
           raise LintError, "SCRIPT_NAME cannot be '/', make it '' and PATH_INFO '/'"
         end
+
+        ## <tt>rack.response_finished</tt>:: An array of callables run after the HTTP response has been sent.
+        if callables = env[RACK_RESPONSE_FINISHED]
+          raise LintError, "rack.response_finished must be an array of callable objects" unless callables.is_a?(Array)
+
+          callables.each do |callable|
+            raise LintError, "rack.response_finished values must respond to call" unless callable.respond_to?(:call)
+          end
+        end
       end
 
       ##

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -360,12 +360,12 @@ module Rack
           raise LintError, "SCRIPT_NAME cannot be '/', make it '' and PATH_INFO '/'"
         end
 
-        ## <tt>rack.response_finished</tt>:: An array of callables run after the HTTP response has been sent.
+        ## <tt>rack.response.finished</tt>:: An array of callables run after the HTTP response has been sent.
         if callables = env[RACK_RESPONSE_FINISHED]
-          raise LintError, "rack.response_finished must be an array of callable objects" unless callables.is_a?(Array)
+          raise LintError, "rack.response.finished must be an array of callable objects" unless callables.is_a?(Array)
 
           callables.each do |callable|
-            raise LintError, "rack.response_finished values must respond to call" unless callable.respond_to?(:call)
+            raise LintError, "rack.response.finished values must respond to call" unless callable.respond_to?(:call)
 
             arity = if callable.respond_to?(:arity)
               callable.arity
@@ -373,7 +373,7 @@ module Rack
               callable.method(:call).arity
             end
 
-            raise LintError, "rack.response_finished values must accept an env argument" unless arity == 1
+            raise LintError, "rack.response.finished values must accept an env argument" unless arity == 1
           end
         end
       end

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -366,6 +366,14 @@ module Rack
 
           callables.each do |callable|
             raise LintError, "rack.response_finished values must respond to call" unless callable.respond_to?(:call)
+
+            arity = if callable.respond_to?(:arity)
+              callable.arity
+            else
+              callable.method(:call).arity
+            end
+
+            raise LintError, "rack.response_finished values must accept an env argument" unless arity == 1
           end
         end
       end

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -720,7 +720,7 @@ describe Rack::Lint do
 
   it "pass valid rack.response_finished" do
     Rack::Lint.new(lambda { |env|
-                     [200, { "rack.response_finished" => [-> {}, lambda {}], "Content-length" => "3" }, ["foo"]]
+                     [200, { "rack.response_finished" => [-> {}, lambda {}], "content-length" => "3" }, ["foo"]]
                    }).call(env({})).first.must_equal 200
   end
 

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -211,19 +211,19 @@ describe Rack::Lint do
       message.must_match(/cannot be .* make it ''/)
 
     lambda {
-      Rack::Lint.new(nil).call(env("rack.response_finished" => "not a callable"))
+      Rack::Lint.new(nil).call(env("rack.response.finished" => "not a callable"))
     }.must_raise(Rack::Lint::LintError).
-    message.must_match(/rack.response_finished must be an array of callable objects/)
+    message.must_match(/rack.response.finished must be an array of callable objects/)
 
     lambda {
-      Rack::Lint.new(nil).call(env("rack.response_finished" => [-> (env) {}, "not a callable"]))
+      Rack::Lint.new(nil).call(env("rack.response.finished" => [-> (env) {}, "not a callable"]))
     }.must_raise(Rack::Lint::LintError).
-    message.must_match(/rack.response_finished values must respond to call/)
+    message.must_match(/rack.response.finished values must respond to call/)
 
     lambda {
-      Rack::Lint.new(nil).call(env("rack.response_finished" => [-> () {}]))
+      Rack::Lint.new(nil).call(env("rack.response.finished" => [-> () {}]))
     }.must_raise(Rack::Lint::LintError).
-    message.must_match(/rack.response_finished values must accept an env argument/)
+    message.must_match(/rack.response.finished values must accept an env argument/)
 
     callable_object = Class.new do
       def call
@@ -231,9 +231,9 @@ describe Rack::Lint do
     end.new
 
     lambda {
-      Rack::Lint.new(nil).call(env("rack.response_finished" => [callable_object]))
+      Rack::Lint.new(nil).call(env("rack.response.finished" => [callable_object]))
     }.must_raise(Rack::Lint::LintError).
-    message.must_match(/rack.response_finished values must accept an env argument/)
+    message.must_match(/rack.response.finished values must accept an env argument/)
   end
 
   it "notice input errors" do
@@ -733,7 +733,7 @@ describe Rack::Lint do
                      }).call(env({}))[1]['rack.hijack'].call(StringIO.new).read.must_equal ''
   end
 
-  it "pass valid rack.response_finished" do
+  it "pass valid rack.response.finished" do
     callable_object = Class.new do
       def call(env)
       end
@@ -741,7 +741,7 @@ describe Rack::Lint do
 
     Rack::Lint.new(lambda { |env|
                      [200, {}, ["foo"]]
-                   }).call(env({ "rack.response_finished" => [-> (env) {}, lambda { |env| }, callable_object], "content-length" => "3" })).first.must_equal 200
+                   }).call(env({ "rack.response.finished" => [-> (env) {}, lambda { |env| }, callable_object], "content-length" => "3" })).first.must_equal 200
   end
 
 end

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -216,9 +216,24 @@ describe Rack::Lint do
     message.must_match(/rack.response_finished must be an array of callable objects/)
 
     lambda {
-      Rack::Lint.new(nil).call(env("rack.response_finished" => [->{}, "not a callable"]))
+      Rack::Lint.new(nil).call(env("rack.response_finished" => [-> (env) {}, "not a callable"]))
     }.must_raise(Rack::Lint::LintError).
     message.must_match(/rack.response_finished values must respond to call/)
+
+    lambda {
+      Rack::Lint.new(nil).call(env("rack.response_finished" => [-> () {}]))
+    }.must_raise(Rack::Lint::LintError).
+    message.must_match(/rack.response_finished values must accept an env argument/)
+
+    callable_object = Class.new do
+      def call
+      end
+    end.new
+
+    lambda {
+      Rack::Lint.new(nil).call(env("rack.response_finished" => [callable_object]))
+    }.must_raise(Rack::Lint::LintError).
+    message.must_match(/rack.response_finished values must accept an env argument/)
   end
 
   it "notice input errors" do
@@ -719,9 +734,14 @@ describe Rack::Lint do
   end
 
   it "pass valid rack.response_finished" do
+    callable_object = Class.new do
+      def call(env)
+      end
+    end.new
+
     Rack::Lint.new(lambda { |env|
-                     [200, { "rack.response_finished" => [-> {}, lambda {}], "content-length" => "3" }, ["foo"]]
-                   }).call(env({})).first.must_equal 200
+                     [200, {}, ["foo"]]
+                   }).call(env({ "rack.response_finished" => [-> (env) {}, lambda { |env| }, callable_object], "content-length" => "3" })).first.must_equal 200
   end
 
 end


### PR DESCRIPTION
This updates Rack::Lint to validate that `rack.response_finished` is an
array of callables when present in the `env`. e.g. procs, lambdas, or
objects that respond to `call`.

This validates that:

* `rack.response_finished` is an array
* The contents of the array all respond to `call`

Part of https://github.com/rack/rack/issues/1777