### PR TITLE
Add Rack::RewindableInput::Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. For info on
 
 - `Rack::Headers` added to support lower-case header keys. ([@jeremyevans](https://github.com/jeremyevans))
 - `Rack::RewindableInput` supports size. ([@ahorek](https://github.com/ahorek))
+- `Rack::RewindableInput::Middleware` added for making `rack.input` rewindable. ([@jeremyevans](https://github.com/jeremyevans))
 - Rack::Session::Pool now accepts `:allow_fallback` option to disable fallback to public id. ([#1431](https://github.com/rack/rack/issues/1431), [@jeremyevans](https://github.com/jeremyevans))
 
 ### Changed

--- a/test/spec_rewindable_input.rb
+++ b/test/spec_rewindable_input.rb
@@ -155,3 +155,12 @@ describe Rack::RewindableInput do
     include RewindableTest
   end
 end
+
+describe Rack::RewindableInput::Middleware do
+  it "wraps rack.input in RewindableInput" do
+    app = proc{|env| [200, {}, [env['rack.input'].class.to_s]]}
+    app.call('rack.input'=>StringIO.new(''))[2].must_equal ['StringIO']
+    app = Rack::RewindableInput::Middleware.new(app)
+    app.call('rack.input'=>StringIO.new(''))[2].must_equal ['Rack::RewindableInput']
+  end
+end


### PR DESCRIPTION
This will automatically wrap rack.input with Rack::RewindableInput,
for compatibility with middleware and applications that expect
rewindable input.

Related to #1148, but this does not contain any SPEC changes. It's
possible for servers targetting Rack 2 compatibility to use this
middleware to implement the compatibility.