### PR TITLE
Eager load Rack::MediaType from Rack::Request

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'media_type'
+
 module Rack
   # Rack::Request provides a convenient interface to a Rack
   # environment.  It is stateless, the environment +env+ passed to the


### PR DESCRIPTION
Closes: https://github.com/rack/rack/issues/1823

This avoid triggering some lazy autoloading when `Request#media_type` is accessed. If you use `Rack::Request` it's lamost certain you'll use `Rack::MediaType` so it makes sense to load them together.

cc @jeremyevans 