### PR TITLE
Fix verbose warnings in specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file. For info on
 - Fix using Rack::Session::Cookie with coder: Rack::Session::Cookie::Base64::{JSON,Zip}. ([#1666](https://github.com/rack/rack/issues/1666), [@jeremyevans](https://github.com/jeremyevans))
 - Avoid NoMethodError when accessing Rack::Session::Cookie without requiring delegate first. ([#1610](https://github.com/rack/rack/issues/1610), [@onigra](https://github.com/onigra))
 - Handle cookies with values that end in '=' ([#1645](https://github.com/rack/rack/pull/1645), [@lukaso](https://github.com/lukaso))
+- Make `Rack::NullLogger` respond to `#fatal!` [@jeremyevans](https://github.com/jeremyevans))
 - Fix multipart filename generation for filenames that contain spaces. Encode spaces as "%20" instead of "+" which will be decoded properly by the multipart parser. ([#1736](https://github.com/rack/rack/pull/1645), [@muirdm](https://github.com/muirdm))
 - `Rack::Request#scheme` returns `ws` or `wss` when one of the `X-Forwarded-Scheme` / `X-Forwarded-Proto` headers is set to `ws` or `wss`, respectively. ([#1730](https://github.com/rack/rack/issues/1730), [@erwanst](https://github.com/erwanst))
 

--- a/lib/rack/null_logger.rb
+++ b/lib/rack/null_logger.rb
@@ -26,7 +26,7 @@ module Rack
     def fatal? ; end
     def debug! ; end
     def error! ; end
-    def fatal ; end
+    def fatal! ; end
     def info! ; end
     def warn! ; end
     def level ; end

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -263,11 +263,13 @@ describe Rack::Builder do
     it "strips leading unicode byte order mark when present" do
       enc = Encoding.default_external
       begin
+        verbose, $VERBOSE = $VERBOSE, nil 
         Encoding.default_external = 'UTF-8'
         app, _ = Rack::Builder.parse_file config_file('bom.ru')
         Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'OK'
       ensure
         Encoding.default_external = enc
+        $VERBOSE = verbose
       end
     end
 

--- a/test/spec_events.rb
+++ b/test/spec_events.rb
@@ -62,7 +62,7 @@ module Rack
       app = lambda { |env| events << [app, :call]; ret }
       se = EventMiddleware.new events
       e = Events.new app, [se]
-      triple = e.call({})
+      e.call({})
       assert_equal [[se, :on_start],
                     [app, :call],
                     [se, :on_commit],
@@ -122,7 +122,6 @@ module Rack
 
     def test_finish_is_called_if_there_is_an_exception
       events = []
-      ret = [200, {}, []]
       app = lambda { |env| raise }
       se = EventMiddleware.new events
       e = Events.new app, [se]

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -25,8 +25,7 @@ describe Rack::Files do
     )
 
     file_path = File.expand_path("cgi/test", __dir__)
-    status, headers, body = app.serving(request, file_path)
-    assert_equal 200, status
+    assert_equal 200, app.serving(request, file_path)[0]
   end
 
   it 'raises if you attempt to define response_body in subclass' do

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -158,15 +158,6 @@ describe Rack::Lock do
     lock.unlocked?.must_equal false
   end
 
-  it "not reset the environment while the body is proxied" do
-    proxy = Class.new do
-      attr_reader :env
-      def initialize(env) @env = env end
-    end
-    app = Rack::Lock.new lambda { |env| [200, { "content-type" => "text/plain" }, proxy.new(env)] }
-    response = app.call(Rack::MockRequest.env_for("/"))[2]
-  end
-
   it "unlock if an exception occurs before returning" do
     lock = Lock.new
     env  = Rack::MockRequest.env_for("/")

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -103,7 +103,7 @@ EOF
     Rack::MethodOverride.new(proc { [200, { "content-type" => "text/plain" }, []] }).call env
 
     env[Rack::RACK_ERRORS].rewind
-    env[Rack::RACK_ERRORS].read.must_match /Bad request content body/
+    env[Rack::RACK_ERRORS].read.must_include 'Bad request content body'
   end
 
   it "not modify REQUEST_METHOD for POST requests when the params are unparseable" do

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -344,25 +344,25 @@ describe Rack::Response do
   it "can do redirects" do
     response = Rack::Response.new
     response.redirect "/foo"
-    status, header, body = response.finish
+    status, header = response.finish
     status.must_equal 302
     header["Location"].must_equal "/foo"
 
     response = Rack::Response.new
     response.redirect "/foo", 307
-    status, header, body = response.finish
+    status, = response.finish
 
     status.must_equal 307
   end
 
   it "has a useful constructor" do
     r = Rack::Response.new("foo")
-    status, header, body = r.finish
+    body = r.finish[2]
     str = "".dup; body.each { |part| str << part }
     str.must_equal "foo"
 
     r = Rack::Response.new(["foo", "bar"])
-    status, header, body = r.finish
+    body = r.finish[2]
     str = "".dup; body.each { |part| str << part }
     str.must_equal "foobar"
 
@@ -373,7 +373,7 @@ describe Rack::Response do
     end
     r = Rack::Response.new(object_with_each)
     r.write "foo"
-    status, header, body = r.finish
+    body = r.finish[2]
     str = "".dup; body.each { |part| str << part }
     str.must_equal "foobarfoo"
 
@@ -611,7 +611,7 @@ describe Rack::Response do
 
     res.body = StringIO.new
     res.status = 205
-    _, _, b = res.finish
+    res.finish
     res.body.wont_be :closed?
   end
 

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -113,7 +113,7 @@ describe Rack::Server do
   def test_options_server(*args)
     SPEC_ARGV[0..-1] = args
     output = String.new
-    server = Class.new(Rack::Server) do
+    Class.new(Rack::Server) do
       define_method(:opt_parser) do
         Class.new(Rack::Server::Options) do
           define_method(:puts) do |*args|
@@ -163,6 +163,7 @@ describe Rack::Server do
   it "support -b option to specify inline rackup config" do
     SPEC_ARGV[0..-1] = ['-scgi', '-E', 'development', '-b', 'use Rack::ContentLength; run ->(env){[200, {}, []]}']
     server = Rack::Server.new
+    server.server.singleton_class.send(:remove_method, :run)
     def (server.server).run(app, **) app end
     s, h, b = server.start.call('rack.errors' => StringIO.new)
     s.must_equal 500
@@ -173,7 +174,7 @@ describe Rack::Server do
   it "support -e option to evaluate ruby code" do
     SPEC_ARGV[0..-1] = ['-scgi', '-e', 'Object::XYZ = 2']
     begin
-      server = Rack::Server.new
+      Rack::Server.new
       Object::XYZ.must_equal 2
     ensure
       Object.send(:remove_const, :XYZ)
@@ -194,6 +195,7 @@ describe Rack::Server do
     SPEC_ARGV[0..-1] = ['-scgi', '-Ifoo/bar', '-Itest/load', '-rrack-test-a', '-rrack-test-b']
     begin
       server = Rack::Server.new
+      server.server.singleton_class.send(:remove_method, :run)
       def (server.server).run(*) end
       def server.handle_profiling(*) end
       def server.app(*) end
@@ -216,6 +218,7 @@ describe Rack::Server do
     debug = $DEBUG
     begin
       server = Rack::Server.new
+      server.server.singleton_class.send(:remove_method, :run)
       def (server.server).run(*) end
       def server.handle_profiling(*) end
       def server.app(*) end
@@ -241,6 +244,7 @@ describe Rack::Server do
         begin
           SPEC_ARGV[0..-1] = ['-scgi', '--heap', t.path, '-E', 'production', '-b', 'run ->(env){[200, {}, []]}']
           server = Rack::Server.new
+          server.server.singleton_class.send(:remove_method, :run)
           def (server.server).run(*) end
           def server.exit; throw :exit end
           catch :exit do
@@ -307,6 +311,7 @@ describe Rack::Server do
   it "support exit for INT signal when server does not respond to shutdown" do
     SPEC_ARGV[0..-1] = ['-scgi']
     server = Rack::Server.new
+    server.server.singleton_class.send(:remove_method, :run)
     def (server.server).run(*) end
     def server.handle_profiling(*) end
     def server.app(*) end

--- a/test/spec_show_status.rb
+++ b/test/spec_show_status.rb
@@ -136,7 +136,7 @@ describe Rack::ShowStatus do
         [404, { "content-type" => "text/plain", "content-length" => "0" }, body]
     }))
 
-    response = req.get("/", lint: true)
+    req.get("/", lint: true)
     closed.must_equal true
   end
 end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -610,50 +610,50 @@ describe Rack::Utils, "cookies" do
 
 end
 
-describe Rack::Utils, "byte_range" do
+describe Rack::Utils, "get_byte_ranges" do
   it "ignore missing or syntactically invalid byte ranges" do
-    Rack::Utils.byte_ranges({}, 500).must_be_nil
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "foobar" }, 500).must_be_nil
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "furlongs=123-456" }, 500).must_be_nil
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=" }, 500).must_be_nil
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-" }, 500).must_be_nil
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123,456" }, 500).must_be_nil
+    Rack::Utils.get_byte_ranges(nil, 500).must_be_nil
+    Rack::Utils.get_byte_ranges("foobar", 500).must_be_nil
+    Rack::Utils.get_byte_ranges("furlongs=123-456", 500).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=", 500).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=-", 500).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=123,456", 500).must_be_nil
     # A range of non-positive length is syntactically invalid and ignored:
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=456-123" }, 500).must_be_nil
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=456-455" }, 500).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=456-123", 500).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=456-455", 500).must_be_nil
   end
 
   it "parse simple byte ranges" do
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123-456" }, 500).must_equal [(123..456)]
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123-" }, 500).must_equal [(123..499)]
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-100" }, 500).must_equal [(400..499)]
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=0-0" }, 500).must_equal [(0..0)]
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=499-499" }, 500).must_equal [(499..499)]
+    Rack::Utils.get_byte_ranges("bytes=123-456", 500).must_equal [(123..456)]
+    Rack::Utils.get_byte_ranges("bytes=123-", 500).must_equal [(123..499)]
+    Rack::Utils.get_byte_ranges("bytes=-100", 500).must_equal [(400..499)]
+    Rack::Utils.get_byte_ranges("bytes=0-0", 500).must_equal [(0..0)]
+    Rack::Utils.get_byte_ranges("bytes=499-499", 500).must_equal [(499..499)]
   end
 
   it "parse several byte ranges" do
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=500-600,601-999" }, 1000).must_equal [(500..600), (601..999)]
+    Rack::Utils.get_byte_ranges("bytes=500-600,601-999", 1000).must_equal [(500..600), (601..999)]
   end
 
   it "truncate byte ranges" do
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123-999" }, 500).must_equal [(123..499)]
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=600-999" }, 500).must_equal []
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-999" }, 500).must_equal [(0..499)]
+    Rack::Utils.get_byte_ranges("bytes=123-999", 500).must_equal [(123..499)]
+    Rack::Utils.get_byte_ranges("bytes=600-999", 500).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=-999", 500).must_equal [(0..499)]
   end
 
   it "ignore unsatisfiable byte ranges" do
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=500-501" }, 500).must_equal []
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=500-" }, 500).must_equal []
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=999-" }, 500).must_equal []
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-0" }, 500).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=500-501", 500).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=500-", 500).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=999-", 500).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=-0", 500).must_equal []
   end
 
   it "handle byte ranges of empty files" do
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=123-456" }, 0).must_equal []
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=0-" }, 0).must_equal []
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-100" }, 0).must_equal []
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=0-0" }, 0).must_equal []
-    Rack::Utils.byte_ranges({ "HTTP_RANGE" => "bytes=-0" }, 0).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=123-456", 0).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=0-", 0).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=-100", 0).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=0-0", 0).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=-0", 0).must_equal []
   end
 end
 


### PR DESCRIPTION
Also, fix a method redefined warning in NullLogger which appears to be a due to a typo in the method name.