### PR TITLE
Undeprecate set_cookie_header!/delete_cookie_header!

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -268,8 +268,6 @@ module Rack
     end
 
     def set_cookie_header!(headers, key, value)
-      warn("set_cookie_header! is deprecated and will be removed in Rack 3.1", uplevel: 1)
-
       if header = headers[SET_COOKIE]
         if header.is_a?(Array)
           header << set_cookie_header(key, value)
@@ -298,8 +296,6 @@ module Rack
     end
 
     def delete_cookie_header!(headers, key, value = {})
-      warn("delete_cookie_header! is deprecated and will be removed in Rack 3.1", uplevel: 1)
-
       headers[SET_COOKIE] = delete_set_cookie_header!(headers[SET_COOKIE], key, value)
 
       return nil


### PR DESCRIPTION
There is not a replacement for these methods that updates a
header hash in place.  We should not be deprecating these
methods unless we are providing a suitable replacement for them.