### PR TITLE
Add rack.early_hints to SPEC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file. For info on
 - Remove non-standard status codes 306, 509, & 510 and update descriptions for 413, 422, & 451. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
 - Add fallback lookup and deprecation warning for obsolete status symbols. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
 - In `Rack::Files`, ignore the `Range` header if served file is 0 bytes. ([#2159](https://github.com/rack/rack/pull/2159), [@zarqman])
+- rack.early_hints is now officially supported as an optional feature (already implemented by Unicorn, Puma, and Falcon). ([#1831](https://github.com/rack/rack/pull/1831), [@casperisfine, @jeremyevans])
 
 ## [3.0.11] - 2024-05-10
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -123,6 +123,7 @@ There are the following restrictions:
 * There may be a valid input stream in <tt>rack.input</tt>.
 * There must be a valid error stream in <tt>rack.errors</tt>.
 * There may be a valid hijack callback in <tt>rack.hijack</tt>
+* There may be a valid early hints callback in <tt>rack.early_hints</tt>
 * The <tt>REQUEST_METHOD</tt> must be a valid token.
 * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
 * The <tt>PATH_INFO</tt>, if non-empty (or the request is something other than <tt>OPTIONS *</tt>), must start with <tt>/</tt>
@@ -227,6 +228,16 @@ instance is recommended.
 
 The special response header +rack.hijack+ must only be set
 if the request +env+ has a truthy +rack.hijack?+.
+
+=== Early Hints
+
+The application or any middleware may call the <tt>rack.early_hints</tt>
+with an object which would be valid as the headers of a Rack response.
+
+If <tt>rack.early_hints</tt> is present, it must respond to #call.
+If <tt>rack.early_hints</tt> is called, it must be called with
+valid Rack response headers.
+
 == The Response
 
 === The Status

--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -39,6 +39,7 @@ module Rack
   # Rack environment variables
   RACK_VERSION                        = 'rack.version'
   RACK_TEMPFILES                      = 'rack.tempfiles'
+  RACK_EARLY_HINTS                    = 'rack.early_hints'
   RACK_ERRORS                         = 'rack.errors'
   RACK_LOGGER                         = 'rack.logger'
   RACK_INPUT                          = 'rack.input'


### PR DESCRIPTION
This is already de facto spec as both Unicorn and Puma
implement it. The changes to SPEC are compatible with
both implementations.

Fixes #1692
Fixes #1695

Co-authored-by: Jeremy Evans <code@jeremyevans.net>