### PR TITLE
Restore: changed behavior for request.host when multiple X-Forwarded-Host are used

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -359,7 +359,7 @@ module Rack
 
       def forwarded_authority
         if value = get_header(HTTP_X_FORWARDED_HOST)
-          wrap_ipv6(split_header(value).first)
+          wrap_ipv6(split_header(value).last)
         end
       end
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -168,6 +168,11 @@ class RackRequestTest < Minitest::Spec
     req.hostname.must_equal "example.org"
 
     req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "somehost:9292, anotherhost:9292, example.org:9292")
+    req.host.must_equal "example.org"
+    req.hostname.must_equal "example.org"
+
+    req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "[2001:db8:cafe::17]:47011")
     req.host.must_equal "[2001:db8:cafe::17]"
     req.hostname.must_equal "2001:db8:cafe::17"


### PR DESCRIPTION
As explained in https://github.com/rack/rack/issues/1829 commit https://github.com/rack/rack/commit/290523f67cc43c5847b2be2d12964d1232061fe1 changed the behavior of request.host when multiple X-Forwarded-Host are used. This PR restores the previous behavior.

I don't know which behavior is the correct one, but this is a breaking change. If we really want to change from `last` to `first` we should issue the proper deprecation warning and include the change in the v3 release. I didn't update the changelog yet because I think it would be best to have this fix in 2.2.4 though I'd prefer to have your insight.

Here is the before after:

Before:

```
ylecuyer@lenovo:~$ curl -X GET -H "X-Forwarded-Host: host1" -H "X-Forwarded-Host: host2" -H "X-Forwarded-Host: host3" -H "X-Forwarded-Host: host4" http://localhost:9292
host1
ylecuyer@lenovo:~$ curl -X GET -H "X-Forwarded-Host: host1" -H "X-Forwarded-Host: host2" -H "X-Forwarded-Host: host3" http://localhost:9292
host1
ylecuyer@lenovo:~$ curl -X GET -H "X-Forwarded-Host: host1" -H "X-Forwarded-Host: host2" http://localhost:9292
host1
ylecuyer@lenovo:~$ curl -X GET -H "X-Forwarded-Host: host1" http://localhost:9292
host1
```

After

```
ylecuyer@lenovo:~$ curl -X GET -H "X-Forwarded-Host: host1" -H "X-Forwarded-Host: host2" -H "X-Forwarded-Host: host3" -H "X-Forwarded-Host: host4" http://localhost:9292
host4
ylecuyer@lenovo:~$ curl -X GET -H "X-Forwarded-Host: host1" -H "X-Forwarded-Host: host2" -H "X-Forwarded-Host: host3" http://localhost:9292
host3
ylecuyer@lenovo:~$ curl -X GET -H "X-Forwarded-Host: host1" -H "X-Forwarded-Host: host2" http://localhost:9292
host2
ylecuyer@lenovo:~$ curl -X GET -H "X-Forwarded-Host: host1" http://localhost:9292
host1
```

Also it should be noted that rails is also using last https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/http/url.rb#L216 so for consistency if one is changed the other should be changed too.

cc @ioquatix as you are the author of the initial commit and maybe cc @tenderlove for the rails note above.