### PR TITLE
Add :escape_key option to set_cookie_header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Added
 
 - `Rack::Headers` added to support lower-case header keys. ([@jeremyevans](https://github.com/jeremyevans))
+- `Rack::Utils#set_cookie_header` now supports `escape_key: false` to avoid key escaping.  ([@jeremyevans](https://github.com/jeremyevans))
 - `Rack::RewindableInput` supports size. ([@ahorek](https://github.com/ahorek))
 - `Rack::RewindableInput::Middleware` added for making `rack.input` rewindable. ([@jeremyevans](https://github.com/jeremyevans))
 - Rack::Session::Pool now accepts `:allow_fallback` option to disable fallback to public id. ([#1431](https://github.com/rack/rack/issues/1431), [@jeremyevans](https://github.com/jeremyevans))

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -240,6 +240,7 @@ module Rack
     def set_cookie_header(key, value)
       case value
       when Hash
+        key = escape(key) unless value[:escape_key] == false
         domain  = "; domain=#{value[:domain]}"   if value[:domain]
         path    = "; path=#{value[:path]}"       if value[:path]
         max_age = "; max-age=#{value[:max_age]}" if value[:max_age]
@@ -260,10 +261,12 @@ module Rack
             raise ArgumentError, "Invalid SameSite value: #{value[:same_site].inspect}"
           end
         value = value[:value]
+      else
+        key = escape(key)
       end
       value = [value] unless Array === value
 
-      return "#{escape(key)}=#{value.map { |v| escape v }.join('&')}#{domain}" \
+      return "#{key}=#{value.map { |v| escape v }.join('&')}#{domain}" \
         "#{path}#{max_age}#{expires}#{secure}#{httponly}#{same_site}"
     end
 

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -599,6 +599,14 @@ describe Rack::Utils, "cookies" do
     headers['set-cookie'].must_equal ['name=value', 'name2=value2', 'name2=value3']
   end
 
+  it "encodes cookie key values by default" do
+    Rack::Utils.set_cookie_header('na e', 'value').must_equal 'na+e=value'
+  end
+
+  it "does not encode cookie key values if :escape_key is false" do
+    Rack::Utils.set_cookie_header('na e', value: 'value', escape_key: false).must_equal 'na e=value'
+  end
+
   it "deletes cookies in header field" do
     header = []
 


### PR DESCRIPTION
This can be set to false to avoid escaping the key.

This is a very explicit approach to allowing some cookie names to
not be escaped.

Fixes #1796