### PR TITLE
Use custom exception on params too deep error.

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -14,6 +14,10 @@ module Rack
     # sequence.
     class InvalidParameterError < ArgumentError; end
 
+    # ParamsTooDeepError is the error that is raised when params are recursively
+    # nested over the specified limit.
+    class ParamsTooDeepError < RangeError; end
+
     def self.make_default(_key_space_limit=(not_deprecated = true; nil), param_depth_limit)
       unless not_deprecated
         warn("`first argument `key_space limit` is deprecated and no longer has an effect. Please call with only one argument, which will be required in a future version of Rack", uplevel: 1)
@@ -91,7 +95,7 @@ module Rack
     end
 
     private def _normalize_params(params, name, v, depth)
-      raise RangeError if depth >= param_depth_limit
+      raise ParamsTooDeepError if depth >= param_depth_limit
 
       if !name
         # nil name, treat same as empty string (required by tests)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -400,7 +400,7 @@ class RackRequestTest < Minitest::Spec
   it "limit the allowed parameter depth when parsing parameters" do
     env = Rack::MockRequest.env_for("/?a#{'[a]' * 40}=b")
     req = make_request(env)
-    lambda { req.GET }.must_raise RangeError
+    lambda { req.GET }.must_raise Rack::QueryParser::ParamsTooDeepError
 
     env = Rack::MockRequest.env_for("/?a#{'[a]' * 30}=b")
     req = make_request(env)
@@ -416,7 +416,7 @@ class RackRequestTest < Minitest::Spec
 
       env = Rack::MockRequest.env_for("/?a[a][a][a]=b")
       req = make_request(env)
-      lambda { make_request(env).GET  }.must_raise RangeError
+      lambda { make_request(env).GET  }.must_raise Rack::QueryParser::ParamsTooDeepError
     ensure
       Rack::Utils.param_depth_limit = old
     end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -144,7 +144,7 @@ describe Rack::Utils do
 
     lambda {
       Rack::Utils.parse_nested_query("foo#{"[a]" * len}=bar")
-    }.must_raise(RangeError)
+    }.must_raise(Rack::QueryParser::ParamsTooDeepError)
 
     Rack::Utils.parse_nested_query("foo#{"[a]" * (len - 1)}=bar")
   end


### PR DESCRIPTION
Hello, I have been working on fixing some malicious requests causing server 500s responses at rails application.

There is list of default exceptions transformed into proper responses in Rails.

https://github.com/rails/rails/blob/926b803297c4bc529ee46296a7cd5cc02bb21100/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L6-L24

As you can see, the other errors (`ParameterTypeError` and `InvalidParameterError`) are already part of this list and they result into `400 Bad request` response by default. But breaking the rack `param_depth_limit` setting results into general Ruby `RangeError` exception currently and it is hard to recognise what's the cause (since any other code can raise this general Ruby exception) and that's (probably) the reason why it is not handled by default in Rails.

I suggest to introduce Rack custom exception for this problem as well (inherited from originally used `RangeError`) to be able to  catch this easily. Next step (if approved) would be to add this exception to default Rails list as well. In the end I think it needs to be added in here - https://github.com/rails/rails/blob/926b803297c4bc529ee46296a7cd5cc02bb21100/actionpack/lib/action_dispatch/http/request.rb#L382-L384.

It is hard to fix currently in the app, the only solution I was able to find out is to create simple middleware to read the params and handle the error in there.

Since the exception is inherited from the original one (and tests were passing with no change as well) I would to propose to backport this to 2.x series as well to be able to fix this as soon as possible.