### PR TITLE
Use custom exception on params too deep error.

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -16,6 +16,10 @@ module Rack
     # sequence.
     class InvalidParameterError < ArgumentError; end
 
+    # ParamsTooDeepError is the error that is raised when params are recursively
+    # nested over the specified limit.
+    class ParamsTooDeepError < RangeError; end
+
     def self.make_default(key_space_limit, param_depth_limit)
       new Params, key_space_limit, param_depth_limit
     end
@@ -81,7 +85,7 @@ module Rack
     # the structural types represented by two different parameter names are in
     # conflict, a ParameterTypeError is raised.
     def normalize_params(params, name, v, depth)
-      raise RangeError if depth <= 0
+      raise ParamsTooDeepError if depth <= 0
 
       name =~ %r(\A[\[\]]*([^\[\]]+)\]*)
       k = $1 || ''
@@ -168,7 +172,7 @@ module Rack
 
       def []=(key, value)
         @size += key.size if key && !@params.key?(key)
-        raise RangeError, 'exceeded available parameter key space' if @size > @limit
+        raise ParamsTooDeepError, 'exceeded available parameter key space' if @size > @limit
         @params[key] = value
       end
 

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -92,12 +92,12 @@ describe Rack::Multipart do
     params['user_sid'].encoding.must_equal Encoding::UTF_8
   end
 
-  it "raise RangeError if the key space is exhausted" do
+  it "raise ParamsTooDeepError if the key space is exhausted" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_filename))
 
     old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 1
     begin
-      lambda { Rack::Multipart.parse_multipart(env) }.must_raise(RangeError)
+      lambda { Rack::Multipart.parse_multipart(env) }.must_raise(Rack::QueryParser::ParamsTooDeepError)
     ensure
       Rack::Utils.key_space_limit = old
     end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -292,7 +292,7 @@ class RackRequestTest < Minitest::Spec
     old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 1
     begin
       req = make_request(env)
-      lambda { req.GET }.must_raise RangeError
+      lambda { req.GET }.must_raise Rack::QueryParser::ParamsTooDeepError
     ensure
       Rack::Utils.key_space_limit = old
     end
@@ -306,7 +306,7 @@ class RackRequestTest < Minitest::Spec
     begin
       exp = { "foo" => { "bar" => { "baz" => { "qux" => "1" } } } }
       make_request(nested_query).GET.must_equal exp
-      lambda { make_request(plain_query).GET  }.must_raise RangeError
+      lambda { make_request(plain_query).GET  }.must_raise Rack::QueryParser::ParamsTooDeepError
     ensure
       Rack::Utils.key_space_limit = old
     end
@@ -315,7 +315,7 @@ class RackRequestTest < Minitest::Spec
   it "limit the allowed parameter depth when parsing parameters" do
     env = Rack::MockRequest.env_for("/?a#{'[a]' * 110}=b")
     req = make_request(env)
-    lambda { req.GET }.must_raise RangeError
+    lambda { req.GET }.must_raise Rack::QueryParser::ParamsTooDeepError
 
     env = Rack::MockRequest.env_for("/?a#{'[a]' * 90}=b")
     req = make_request(env)
@@ -331,7 +331,7 @@ class RackRequestTest < Minitest::Spec
 
       env = Rack::MockRequest.env_for("/?a[a][a][a]=b")
       req = make_request(env)
-      lambda { make_request(env).GET  }.must_raise RangeError
+      lambda { make_request(env).GET  }.must_raise Rack::QueryParser::ParamsTooDeepError
     ensure
       Rack::Utils.param_depth_limit = old
     end
@@ -416,7 +416,7 @@ class RackRequestTest < Minitest::Spec
     old, Rack::Utils.key_space_limit = Rack::Utils.key_space_limit, 1
     begin
       req = make_request(env)
-      lambda { req.POST }.must_raise RangeError
+      lambda { req.POST }.must_raise Rack::QueryParser::ParamsTooDeepError
     ensure
       Rack::Utils.key_space_limit = old
     end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -128,7 +128,7 @@ describe Rack::Utils do
 
     lambda {
       Rack::Utils.parse_nested_query("foo#{"[a]" * len}=bar")
-    }.must_raise(RangeError)
+    }.must_raise(Rack::QueryParser::ParamsTooDeepError)
 
     Rack::Utils.parse_nested_query("foo#{"[a]" * (len - 1)}=bar")
   end


### PR DESCRIPTION
- backport of df23f57407426a85245e35d8c0c7c90d53dcb74a

/cc @rafaelfranca 