### PR TITLE
Don't overwrite other cookie attributes when building deletion cookie.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -298,11 +298,7 @@ module Rack
     # Adds a cookie that will *remove* a cookie from the client.  Hence the
     # strange method name.
     def delete_set_cookie_header(key, value = {})
-      set_cookie_header(key, {
-        value: '', path: nil, domain: nil,
-        max_age: '0',
-        expires: Time.at(0)
-      }.merge(value))
+      set_cookie_header(key, value.merge(max_age: '0', expires: Time.at(0), value: ''))
     end
 
     def make_delete_cookie_header(header, key, value)

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -648,9 +648,33 @@ describe Rack::Utils, "cookies" do
     header = []
 
     Rack::Utils.delete_set_cookie_header!(header, 'name2')
-    header.must_equal ["name2=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"]
+    header.must_equal [
+      "name2=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    ]
+
     Rack::Utils.delete_set_cookie_header!(header, 'name')
-    header.must_equal ["name2=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT", "name=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"]
+    header.must_equal [
+      "name2=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT",
+      "name=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    ]
+  end
+
+  it "deletes cookies in header field with domain" do
+    header = []
+
+    Rack::Utils.delete_set_cookie_header!(header, 'name', {domain: "mydomain.com"})
+    header.must_equal [
+      "name=; domain=mydomain.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    ]
+  end
+
+  it "deletes cookies in header field with path" do
+    header = []
+
+    Rack::Utils.delete_set_cookie_header!(header, 'name', {path: "/a/b"})
+    header.must_equal [
+      "name=; path=/a/b; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    ]
   end
 
   it "sets and deletes cookies in header hash" do


### PR DESCRIPTION
I noticed this when going through the cookie utils methods. We were previously supplying nil for path and domain but I think it's fair game that they could be specified for the cookie deletion to allow for deleting a very specific cookie.