### PR TITLE
Avoid potential Array glob/unglob operations in `Rack::Builder`.

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -111,7 +111,12 @@ module Rack
     # default application if +run+ is not called later.  If a block
     # is given, it is evaluated in the context of the instance.
     def initialize(default_app = nil, &block)
-      @use, @map, @run, @warmup, @freeze_app = [], nil, default_app, nil, false
+      @use = []
+      @map = nil
+      @run = default_app
+      @warmup = nil
+      @freeze_app = false
+
       instance_eval(&block) if block_given?
     end
 


### PR DESCRIPTION
I'll admit this is a bit pedantic but this syntax can be simplified and it's also better for performance (not that it's a critical path).

A -> current approach.
B -> proposed approach.

```
Warming up --------------------------------------
                   A   578.374k i/100ms
                   B   686.813k i/100ms
Calculating -------------------------------------
                   A      5.830M (± 0.8%) i/s -     29.497M in   5.060201s
                   B      6.919M (± 0.8%) i/s -     35.027M in   5.062755s

Comparison:
                   B:  6919058.9 i/s
                   A:  5829588.9 i/s - 1.19x  (± 0.00) slower
```