### PR TITLE
Add missing `require_relative 'constants'` to `rack/utils.rb`.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -10,6 +10,7 @@ require 'time'
 require_relative 'query_parser'
 require_relative 'mime'
 require_relative 'headers'
+require_relative 'constants'
 
 module Rack
   # Rack::Utils contains a grab-bag of useful methods for writing web


### PR DESCRIPTION
Without this, trying to require `rack/utils` by itself results in code which fails when it tries to access any constants defined in `rack/constants.rb`.