### PR TITLE
Fix "reject insanely long boundaries" test hang

### DIFF
--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -131,7 +131,11 @@ describe Rack::Multipart do
 
         # make the initial boundary a few gigs long
         longer = "0123456789" * 1024 * 1024
-        (1024 * 1024).times { wr.write(longer) }
+        (1024 * 1024).times do
+          while wr.write_nonblock(longer, exception: false) == :wait_writable
+            Thread.pass
+          end
+        end
 
         wr.write("\r\n")
         wr.write('content-disposition: form-data; name="a"; filename="a.txt"')


### PR DESCRIPTION
At least on OpenBSD, this test occasionally hangs, because the
`wr.write` does not return/raise after the `rd.close` in the other
thread.  Switch to `write_nonblock` with `exception: false`, using
Thread.pass if the write would block.

With this change, the test takes less than two seconds and does
not hang.