### PR TITLE
Remove the autoload of Rack::Handler::WEBrick

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -9,6 +9,8 @@ module Rack
   # A second optional hash can be passed to include server-specific
   # configuration.
   module Handler
+    @handlers = {}
+
     def self.get(server)
       return unless server
       server = server.to_s
@@ -79,11 +81,7 @@ module Rack
     end
 
     def self.register(server, klass)
-      @handlers ||= {}
       @handlers[server.to_s] = klass.to_s
     end
-
-    autoload :WEBrick, "rack/handler/webrick"
-    register 'webrick', 'Rack::Handler::WEBrick'
   end
 end

--- a/lib/rack/handler/webrick.rb
+++ b/lib/rack/handler/webrick.rb
@@ -4,6 +4,7 @@ require 'webrick'
 require 'stringio'
 
 require_relative '../constants'
+require_relative '../handler'
 require_relative '../version'
 
 # This monkey patch allows for applications to perform their own chunking
@@ -124,5 +125,7 @@ module Rack
         end
       end
     end
+
+    register 'webrick', WEBrick
   end
 end

--- a/test/spec_webrick.rb
+++ b/test/spec_webrick.rb
@@ -3,6 +3,7 @@
 require_relative 'helper'
 require 'thread'
 require 'webrick'
+require 'rack/handler/webrick'
 require_relative 'test_request'
 
 separate_testing do


### PR DESCRIPTION
There isn't a reason the constant needs to be autoloaded.  If puma or
falcon is not installed, the try_require will still load the webrick
handler file, so register the the handler in the handler file, similar
to how puma and falcon handle it.  This makes webrick support less
special.