### PR TITLE
Add new query parser exception to Utils.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -18,6 +18,7 @@ module Rack
   module Utils
     ParameterTypeError = QueryParser::ParameterTypeError
     InvalidParameterError = QueryParser::InvalidParameterError
+    ParamsTooDeepError = QueryParser::ParamsTooDeepError
     DEFAULT_SEP = QueryParser::DEFAULT_SEP
     COMMON_SEP = QueryParser::COMMON_SEP
     KeySpaceConstrainedParams = QueryParser::Params


### PR DESCRIPTION
I was looking into porting new exception to Rails error handling and I have spotted Rails uses exceptions defined at `Rack::Utils`. Recently added `ParamsTooDeepError` is not defined in there. I'm adding it to keep it consistent.

https://github.com/rails/rails/blob/c9e5057de4be7e0f4365ff9c2d411cffc39c3746/actionpack/lib/action_dispatch/http/request.rb#L383

_:information_source: If approved, I'll backport this to `2-2-stable` as well._