### PR TITLE
Only digest body when `body.to_ary` is present

### DIFF
--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -29,9 +29,10 @@ module Rack
       status, headers, body = @app.call(env)
 
       if etag_status?(status) && body.respond_to?(:to_ary) && !skip_caching?(headers)
-        body = body.to_ary
-        digest = digest_body(body)
-        headers[ETAG_STRING] = %(W/"#{digest}") if digest
+        if body = body.to_ary
+          digest = digest_body(body)
+          headers[ETAG_STRING] = %(W/"#{digest}") if digest
+        end
       end
 
       unless headers[CACHE_CONTROL]

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -76,6 +76,17 @@ describe Rack::ETag do
     response[1]['etag'].must_be_nil
   end
 
+  it "not cause error when body.to_ary is nil" do
+    body = Struct.new(:body) do
+      def to_ary; nil; end
+    end.new([])
+
+    app = lambda { |env| [200, { 'content-type' => 'text/plain' }, body] }
+    response = etag(app).call(request)
+    response[0].must_equal(200)
+    response[1]['etag'].must_be_nil
+  end
+
   it "not set etag if last-modified is set" do
     app = lambda { |env| [200, { 'content-type' => 'text/plain', 'last-modified' => Time.now.httpdate }, ["Hello, World!"]] }
     response = etag(app).call(request)


### PR DESCRIPTION
Since https://github.com/rack/rack/pull/1748, the result of `body.to_ary` will be sent directly into `digest_body` for generating etag digest. But `ActionDispatch::Response::RackBody#to_ary` always returns `nil`, which will cause `NoMethodError` with this approach. Therefore, I think it makes sense to check if the result of `body.to_ary` is present before trying to generate digest from it.

(It wasn't an issue before #1748 because Rack used to pass the `body` (responds to `#each`) to `digest_body` instead).