### PR TITLE
Fix Rack::Request headers usage.

### DIFF
--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -54,18 +54,18 @@ module Rack
 
       msg = FORMAT % [
         request.ip || "-",
-        request.get_header("REMOTE_USER") || "-",
+        request.env['REMOTE_USER'] || "-",
         Time.now.strftime("%d/%b/%Y:%H:%M:%S %z"),
         request.request_method,
         request.script_name,
         request.path_info,
         request.query_string.empty? ? "" : "?#{request.query_string}",
-        request.get_header(SERVER_PROTOCOL),
+        request.env[SERVER_PROTOCOL],
         status.to_s[0..3],
         length,
         Utils.clock_time - began_at ]
 
-      logger = @logger || request.get_header(RACK_ERRORS)
+      logger = @logger || request.env[RACK_ERRORS]
       # Standard library logger doesn't support write but it supports << which actually
       # calls to write on the log device without formatting
       if logger.respond_to?(:write)

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -78,7 +78,7 @@ module Rack
         return [200, { 'allow' => ALLOW_HEADER, CONTENT_LENGTH => '0' }, []]
       end
       last_modified = ::File.mtime(path).httpdate
-      return [304, {}, []] if request.get_header('HTTP_IF_MODIFIED_SINCE') == last_modified
+      return [304, {}, []] if request.get_header('if-modified-since') == last_modified
 
       headers = { "last-modified" => last_modified }
       mime_type = mime_type path, @default_mime
@@ -90,7 +90,7 @@ module Rack
       status = 200
       size = filesize path
 
-      ranges = Rack::Utils.get_byte_ranges(request.get_header('HTTP_RANGE'), size)
+      ranges = Rack::Utils.get_byte_ranges(request.get_header('range'), size)
       if ranges.nil?
         # No ranges:
         ranges = [0..size - 1]

--- a/lib/rack/method_override.rb
+++ b/lib/rack/method_override.rb
@@ -48,9 +48,9 @@ module Rack
     def method_override_param(req)
       req.POST[METHOD_OVERRIDE_PARAM_KEY]
     rescue Utils::InvalidParameterError, Utils::ParameterTypeError
-      req.get_header(RACK_ERRORS).puts "Invalid or incomplete POST params"
+      req.env[RACK_ERRORS].puts "Invalid or incomplete POST params"
     rescue EOFError
-      req.get_header(RACK_ERRORS).puts "Bad request content body"
+      req.env[RACK_ERRORS].puts "Bad request content body"
     end
   end
 end

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -190,12 +190,12 @@ module Rack
 
         if HTTP_HEADER_PATTERN.match?(key)
           key = key.upcase
-          key.tr!('-', '_')
-
-          unless CGI_VARIABLES.include?(key)
-            key.prepend('HTTP_')
-          else
+          
+          if CGI_VARIABLES.include?(key)
             warn "Using CGI variable keys (#{key}) with header methods is deprecated and will be removed in Rack 3.1! Please use env directly.", uplevel: 2
+          else
+            key.tr!('-', '_')
+            key.prepend('HTTP_')
           end
         else
           warn "Using env keys (#{key}) with header methods is deprecated and will be removed in Rack 3.1! Please use env directly.", uplevel: 2

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -59,7 +59,19 @@ class RackRequestTest < Minitest::Spec
     assert_equal "bar", req.get_header("FOO")
   end
 
-  it 'can iterate over values' do
+  it 'can set env headers (legacy)' do
+    req = make_request(Rack::MockRequest.env_for("http://example.com:8080/"))
+    req.set_header 'HTTP_FOO', 'bar'
+    assert_equal "bar", req.get_header("foo")
+  end
+
+  it 'can set env variables (legacy)' do
+    req = make_request(Rack::MockRequest.env_for("http://example.com:8080/"))
+    req.set_header 'CONTENT_LENGTH', '42'
+    assert_equal '42', req.env['CONTENT_LENGTH']
+  end
+
+  it 'can iterate headers' do
     req = make_request(Rack::MockRequest.env_for("http://example.com:8080/"))
     req.set_header 'foo', 'bar'
     hash = {}
@@ -69,7 +81,7 @@ class RackRequestTest < Minitest::Spec
     assert_equal 'bar', hash['foo']
   end
 
-  it 'can set values in the env' do
+  it 'can set headers in the env' do
     req = make_request(Rack::MockRequest.env_for("http://example.com:8080/"))
     req.set_header("FOO", "BAR")
     assert_equal "BAR", req.get_header("FOO")
@@ -81,14 +93,14 @@ class RackRequestTest < Minitest::Spec
     assert_equal '1', req.add_header('FOO', '1')
     assert_equal '1', req.get_header('FOO')
 
-    assert_equal '1,2', req.add_header('FOO', '2')
-    assert_equal '1,2', req.get_header('FOO')
+    assert_equal ['1', '2'], req.add_header('FOO', '2')
+    assert_equal ['1', '2'], req.get_header('FOO')
 
-    assert_equal '1,2', req.add_header('FOO', nil)
-    assert_equal '1,2', req.get_header('FOO')
+    assert_equal ['1', '2'], req.add_header('FOO', nil)
+    assert_equal ['1', '2'], req.get_header('FOO')
   end
 
-  it 'can delete env values' do
+  it 'can delete headers' do
     req = make_request(Rack::MockRequest.env_for("http://example.com:8080/"))
     req.set_header 'foo', 'bar'
     assert req.has_header? 'foo'

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -71,6 +71,11 @@ class RackRequestTest < Minitest::Spec
     assert_equal '42', req.env['CONTENT_LENGTH']
   end
 
+  it 'can set path-info header' do
+    req = make_request(Rack::MockRequest.env_for("http://example.com:8080/", 'HTTP_PATH_INFO' => "/hello/world"))
+    assert_equal '/hello/world', req.get_header('path-info')
+  end
+
   it 'can iterate headers' do
     req = make_request(Rack::MockRequest.env_for("http://example.com:8080/"))
     req.set_header 'foo', 'bar'

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -98,11 +98,11 @@ class RackRequestTest < Minitest::Spec
     assert_equal '1', req.add_header('FOO', '1')
     assert_equal '1', req.get_header('FOO')
 
-    assert_equal ['1', '2'], req.add_header('FOO', '2')
-    assert_equal ['1', '2'], req.get_header('FOO')
+    assert_equal '1,2', req.add_header('FOO', '2')
+    assert_equal '1,2', req.get_header('FOO')
 
-    assert_equal ['1', '2'], req.add_header('FOO', nil)
-    assert_equal ['1', '2'], req.get_header('FOO')
+    assert_equal '1,2', req.add_header('FOO', nil)
+    assert_equal '1,2', req.get_header('FOO')
   end
 
   it 'can delete headers' do


### PR DESCRIPTION
As discussed previously there is a mismatch between `Rack::Response#get/set_headers` and `Rack::Request#get/set_headers`.

Specifically, `Rack::Response` headers are actual HTTP headers, while `Rack::Request` headers are env key pairs.

This PR is one option for changing `Rack::Request#get/set_headers` to be consistent with the semantic of HTTP headers. I think this is the best option. The proposed methods are backwards compatible but emit warnings when used with things which are likely to be env keys.

The biggest limitation is that not all HTTP header keys are allowed, specifically headers with periods (`.`) are considered env keys, even though periods are considered valid `token` characters and thus valid header keys. This allows `rack.internal.keys` to pass correctly as non-headers retaining compatibility (following the spec which specifies one period must be included in application specific keys).

I believe this PR is 100% backwards compatible and I've split it into two parts: (commit 1) is just the change itself and emits lots of warnings, and (commit 2) is reworking all Rack code to use `env` directly where it makes sense.

I believe this PR will allow Rails to remove their "patch" https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/actionpack/lib/action_dispatch/http/headers.rb#L121-L129 althought in theory it remains fully compatible.