### PR TITLE
Add methods for HTTP status codes 406 and 408

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -190,6 +190,8 @@ module Rack
       def forbidden?;           status == 403;                        end
       def not_found?;           status == 404;                        end
       def method_not_allowed?;  status == 405;                        end
+      def not_acceptable?;      status == 406;                        end
+      def request_timeout?;     status == 408;                        end
       def precondition_failed?; status == 412;                        end
       def unprocessable?;       status == 422;                        end
 

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -503,6 +503,16 @@ describe Rack::Response do
     res.must_be :client_error?
     res.must_be :method_not_allowed?
 
+    res.status = 406
+    res.wont_be :successful?
+    res.must_be :client_error?
+    res.must_be :not_acceptable?
+
+    res.status = 408
+    res.wont_be :successful?
+    res.must_be :client_error?
+    res.must_be :request_timeout?
+
     res.status = 412
     res.wont_be :successful?
     res.must_be :client_error?


### PR DESCRIPTION
This commit adds two new predicate methods to the `Rack::Response` class:

- `not_acceptable?` which returns true on HTTP 406 Not Acceptable
- `request_timeout?` which returns true on HTTP 408 Request Timeout

Links to MDN documentation for each status code:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408