### PR TITLE
Reduce Array object allocation in Rack::ContentType's initializer

### DIFF
--- a/lib/rack/content_type.rb
+++ b/lib/rack/content_type.rb
@@ -16,7 +16,8 @@ module Rack
     include Rack::Utils
 
     def initialize(app, content_type = "text/html")
-      @app, @content_type = app, content_type
+      @app = app
+      @content_type = content_type
     end
 
     def call(env)


### PR DESCRIPTION
Returning multiple values from a method allocates an Array instance, even if the method is the `initialize` method.
Here's a patch fixing that kind of unnecessary object allocation in Rack::ContentType.