### PR TITLE
Prefer Kernel#sprintf over String#% where passing in multiple values

### DIFF
--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -52,7 +52,7 @@ module Rack
       request = Rack::Request.new(env)
       length = extract_content_length(response_headers)
 
-      msg = FORMAT % [
+      msg = sprintf(FORMAT,
         request.ip || "-",
         request.get_header("REMOTE_USER") || "-",
         Time.now.strftime("%d/%b/%Y:%H:%M:%S %z"),
@@ -63,7 +63,7 @@ module Rack
         request.get_header(SERVER_PROTOCOL),
         status.to_s[0..3],
         length,
-        Utils.clock_time - began_at ]
+        Utils.clock_time - began_at)
 
       logger = @logger || request.get_header(RACK_ERRORS)
       # Standard library logger doesn't support write but it supports << which actually

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -145,7 +145,7 @@ module Rack
           has_options = false
           server.valid_options.each do |name, description|
             next if /^(Host|Port)[^a-zA-Z]/.match?(name.to_s) # ignore handler's host and port options, we do our own.
-            info << "  -O %-21s %s" % [name, description]
+            info << sprintf("  -O %-21s %s", name, description)
             has_options = true
           end
           return "" if !has_options


### PR DESCRIPTION
When formatting a String with multiple values, `String#%` requires the arguments to be wrapped in an Array instance, whereas `Kernel#sprintf` (which is almost equivalent) accepts varargs.
Thus, with this patch, we could reduce one another (actually I fixed two) unnecessary Array object allocation per each call.