### PR TITLE
Get to 100% line/branch coverage

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -40,6 +40,8 @@ module Rack
     def method_missing(method_name, *args, &block)
       @body.__send__(method_name, *args, &block)
     end
+    # :nocov:
     ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+    # :nocov:
   end
 end

--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -88,7 +88,7 @@ module Rack
       config.slice!(/\A#{UTF_8_BOM}/) if config.encoding == Encoding::UTF_8
 
       if config[/^#\\(.*)/]
-        fail "Parsing options from the first comment line is deprecated: #{path}"
+        fail "Parsing options from the first comment line is no longer supported: #{path}"
       end
 
       config.sub!(/^__END__\n.*\Z/m, '')
@@ -147,7 +147,9 @@ module Rack
       end
       @use << proc { |app| middleware.new(app, *args, &block) }
     end
+    # :nocov:
     ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
+    # :nocov:
 
     # Takes an argument that is an object that responds to #call and returns a Rack response.
     # The simplest form of this is a lambda object:

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -99,7 +99,7 @@ module Rack
         response = fail(416, "Byte range unsatisfiable")
         response[1]["content-range"] = "bytes */#{size}"
         return response
-      elsif ranges.size >= 1
+      else
         # Partial content
         partial_content = true
 

--- a/lib/rack/headers.rb
+++ b/lib/rack/headers.rb
@@ -115,7 +115,9 @@ module Rack
       keys.map{|key| self[key]}
     end
     
+    # :nocov:
     if RUBY_VERSION >= '2.5'
+    # :nocov:
       def slice(*a)
         h = self.class.new
         a.each{|k| h[k] = self[k] if has_key?(k)}
@@ -135,7 +137,9 @@ module Rack
       end
     end
 
+    # :nocov:
     if RUBY_VERSION >= '3.0'
+    # :nocov:
       def except(*a)
         super(*a.map!{|key| downcase_key(key)})
       end

--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -116,7 +116,7 @@ module Rack
       env[SERVER_PORT]     = (uri.port ? uri.port.to_s : "80").b
       env[SERVER_PROTOCOL] = opts[:http_version] || 'HTTP/1.1'
       env[QUERY_STRING]    = (uri.query.to_s).b
-      env[PATH_INFO]       = ((!uri.path || uri.path.empty?) ? "/" : uri.path).b
+      env[PATH_INFO]       = (uri.path).b
       env[RACK_URL_SCHEME] = (uri.scheme || "http").b
       env[HTTPS]           = (env[RACK_URL_SCHEME] == "https" ? "on" : "off").b
 

--- a/lib/rack/multipart/generator.rb
+++ b/lib/rack/multipart/generator.rb
@@ -5,9 +5,6 @@ require_relative 'uploaded_file'
 module Rack
   module Multipart
     class Generator
-
-      require_relative '../multipart' unless defined?(Rack::Multipart)
-
       def initialize(params, first = true)
         @params, @first = params, first
 

--- a/lib/rack/multipart/generator.rb
+++ b/lib/rack/multipart/generator.rb
@@ -76,7 +76,7 @@ module Rack
 
       def content_for_tempfile(io, file, name)
         length = ::File.stat(file.path).size if file.path
-        filename = "; filename=\"#{Utils.escape_path(file.original_filename)}\"" if file.original_filename
+        filename = "; filename=\"#{Utils.escape_path(file.original_filename)}\""
 <<-EOF
 --#{MULTIPART_BOUNDARY}\r
 content-disposition: form-data; name="#{name}"#{filename}\r

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -216,7 +216,7 @@ module Rack
               handle_mime_head
             when :MIME_BODY
               handle_mime_body
-            when :DONE
+            else # when :DONE
               return
             end
 

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -254,7 +254,6 @@ module Rack
         if consume_boundary
           @state = :MIME_HEAD
         else
-          raise EOFError, "bad content body" if @sbuf.rest_size >= @bufsize
           :want_read
         end
       end

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -355,6 +355,7 @@ module Rack
       end
 
       CHARSET = "charset"
+      deprecate_constant :CHARSET
 
       def tag_multipart_encoding(filename, content_type, name, body)
         name = name.to_s
@@ -375,7 +376,13 @@ module Rack
               k.strip!
               v.strip!
               v = v[1..-2] if v.start_with?('"') && v.end_with?('"')
-              encoding = Encoding.find v if k == CHARSET
+              if k == "charset"
+                encoding = begin
+                  Encoding.find v
+                rescue ArgumentError
+                  Encoding::BINARY
+                end
+              end
             end
           end
         end

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -39,8 +39,6 @@ module Rack
     RFC2183 = /^#{CONDISP}(#{DISPPARM})+$/i
 
     class Parser
-      require_relative '../multipart' unless defined?(Rack::Multipart)
-
       BUFSIZE = 1_048_576
       TEXT_PLAIN = "text/plain"
       TEMPFILE_FACTORY = lambda { |filename, content_type|

--- a/lib/rack/multipart/uploaded_file.rb
+++ b/lib/rack/multipart/uploaded_file.rb
@@ -6,7 +6,6 @@ require 'fileutils'
 module Rack
   module Multipart
     class UploadedFile
-      require_relative '../multipart' unless defined?(Rack::Multipart)
 
       # The filename, *not* including the path, of the "uploaded" file
       attr_reader :original_filename

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -126,15 +126,9 @@ module Rack
         after = ''
       end
 
-      v ||= String.new
+      return if k.empty?
 
-      if k.empty?
-        if !v.nil? && name == "[]"
-          return Array(v)
-        else
-          return
-        end
-      end
+      v ||= String.new
 
       if after == ''
         if k == '[]' && depth != 0

--- a/lib/rack/rewindable_input.rb
+++ b/lib/rack/rewindable_input.rb
@@ -85,10 +85,12 @@ module Rack
       @rewindable_io.chmod(0000)
       @rewindable_io.set_encoding(Encoding::BINARY) if @rewindable_io.respond_to?(:set_encoding)
       @rewindable_io.binmode
+      # :nocov:
       if filesystem_has_posix_semantics?
         raise 'Unlink failed. IO closed.' if @rewindable_io.closed?
         @unlinked = true
       end
+      # :nocov:
 
       buffer = "".dup
       while @io.read(1024 * 4, buffer)

--- a/lib/rack/rewindable_input.rb
+++ b/lib/rack/rewindable_input.rb
@@ -83,7 +83,7 @@ module Rack
       # access it because we have the file handle open.
       @rewindable_io = Tempfile.new('RackRewindableInput')
       @rewindable_io.chmod(0000)
-      @rewindable_io.set_encoding(Encoding::BINARY) if @rewindable_io.respond_to?(:set_encoding)
+      @rewindable_io.set_encoding(Encoding::BINARY)
       @rewindable_io.binmode
       # :nocov:
       if filesystem_has_posix_semantics?

--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -139,9 +139,7 @@ module Rack
           elsif response[0] == 304
             # Do nothing, leave headers as is
           else
-            if mime_type = Mime.mime_type(::File.extname(path), 'text/plain')
-              response[1][CONTENT_TYPE] = mime_type
-            end
+            response[1][CONTENT_TYPE] = Mime.mime_type(::File.extname(path), 'text/plain')
             response[1]['content-encoding'] = 'gzip'
           end
         end

--- a/lib/rack/tempfile_reaper.rb
+++ b/lib/rack/tempfile_reaper.rb
@@ -19,13 +19,14 @@ module Rack
       begin
         status, headers, body = @app.call(env)
       rescue Exception
-        env[RACK_TEMPFILES].each(&:close!) unless env[RACK_TEMPFILES].nil?
+        env[RACK_TEMPFILES]&.each(&:close!)
         raise
       end
 
       body_proxy = BodyProxy.new(body) do
-        env[RACK_TEMPFILES].each(&:close!) unless env[RACK_TEMPFILES].nil?
+        env[RACK_TEMPFILES]&.each(&:close!)
       end
+
       [status, headers, body_proxy]
     end
   end

--- a/test/multipart/content_type_and_unknown_charset
+++ b/test/multipart/content_type_and_unknown_charset
@@ -1,0 +1,6 @@
+--AaB03x
+content-disposition: form-data; name="text"
+content-type: text/plain; charset=foo; bar=baz
+
+contents
+--AaB03x--

--- a/test/spec_auth_digest.rb
+++ b/test/spec_auth_digest.rb
@@ -273,11 +273,16 @@ describe Rack::Auth::Digest::MD5 do
     req.respond_to?(:nonce).must_equal true
     req.respond_to?(:a).must_equal true
     req.a.must_equal 'b'
+    proc{req.missing}.must_raise NoMethodError
     lambda { req.a(2) }.must_raise ArgumentError
   end
 
   it 'Nonce#fresh? should be the opposite of stale?' do
     Rack::Auth::Digest::Nonce.new.fresh?.must_equal true
     Rack::Auth::Digest::Nonce.new.stale?.must_equal false
+  end
+
+  it 'Params.new can be called without a block' do
+    Rack::Auth::Digest::Params.new.must_be_instance_of(Rack::Auth::Digest::Params)
   end
 end

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -238,6 +238,13 @@ describe Rack::Builder do
       File.join(File.dirname(__FILE__), 'builder', name)
     end
 
+    it "raises if parses commented options" do
+      proc do
+        Rack::Builder.parse_file config_file('options.ru')
+      end.must_raise(RuntimeError).
+       message.must_include('Parsing options from the first comment line is no longer supported')
+    end
+
     it "removes __END__ before evaluating app" do
       app, _ = Rack::Builder.parse_file config_file('end.ru')
       Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'OK'

--- a/test/spec_common_logger.rb
+++ b/test/spec_common_logger.rb
@@ -91,10 +91,10 @@ describe Rack::CommonLogger do
   it "log in common log format" do
     log = StringIO.new
     with_mock_time do
-      Rack::MockRequest.new(Rack::CommonLogger.new(app, log)).get("/")
+      Rack::MockRequest.new(Rack::CommonLogger.new(app, log)).get("/", 'QUERY_STRING' => 'foo=bar')
     end
 
-    md = /- - - \[([^\]]+)\] "(\w+) \/ HTTP\/1\.1" (\d{3}) \d+ ([\d\.]+)/.match(log.string)
+    md = /- - - \[([^\]]+)\] "(\w+) \/\?foo=bar HTTP\/1\.1" (\d{3}) \d+ ([\d\.]+)/.match(log.string)
     md.wont_equal nil
     time, method, status, duration = *md.captures
     time.must_equal Time.at(0).strftime("%d/%b/%Y:%H:%M:%S %z")

--- a/test/spec_directory.rb
+++ b/test/spec_directory.rb
@@ -40,12 +40,34 @@ describe Rack::Directory do
     end
   end
 
+  it "serve root directory index" do
+    res = Rack::MockRequest.new(Rack::Lint.new(app)).
+      get("/")
+
+    res.must_be :ok?
+    assert_includes(res.body, '<html><head>')
+    assert_includes(res.body, "href='cgi")
+  end
+
   it "serve directory indices" do
     res = Rack::MockRequest.new(Rack::Lint.new(app)).
       get("/cgi/")
 
     res.must_be :ok?
-    assert_match(res, /<html><head>/)
+    assert_includes(res.body, '<html><head>')
+    assert_includes(res.body, "rackup_stub.rb")
+  end
+
+  it "return 404 for pipes" do
+    begin
+      File.mkfifo('test/cgi/fifo')
+      res = Rack::MockRequest.new(Rack::Lint.new(app)).
+        get("/cgi/fifo")
+
+      res.status.must_equal 404
+    ensure
+      File.delete('test/cgi/fifo')
+    end
   end
 
   it "serve directory indices with bad symlinks" do

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -76,6 +76,12 @@ describe Rack::ETag do
     response[1]['etag'].must_be_nil
   end
 
+  it "set handle empty body parts" do
+    app = lambda { |env| [200, { 'content-type' => 'text/plain' }, ["Hello", "", ", World!"]] }
+    response = etag(app).call(request)
+    response[1]['etag'].must_equal "W/\"dffd6021bb2bd5b0af676290809ec3a5\""
+  end
+
   it "not set etag if last-modified is set" do
     app = lambda { |env| [200, { 'content-type' => 'text/plain', 'last-modified' => Time.now.httpdate }, ["Hello, World!"]] }
     response = etag(app).call(request)

--- a/test/spec_headers.rb
+++ b/test/spec_headers.rb
@@ -468,6 +468,7 @@ class RackHeadersTest < Minitest::Spec
     def test_slice
       assert_equal(Rack::Headers['Ab'=>'1', 'cD'=>'2', '3'=>'4'], @fh.slice('aB', 'Cd', '3'))
       assert_equal(Rack::Headers['AB'=>'1', 'CD'=>'2'], @fh.slice('Ab', 'CD'))
+      assert_equal(Rack::Headers[], @fh.slice('ad'))
       assert_equal('1', @fh.slice('AB', 'cd')['Ab'])
     end
 

--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -49,6 +49,13 @@ describe Rack::MockRequest do
     env.must_include "rack.version"
   end
 
+  it "should handle a non-GET request with both :input and :params" do
+    env = Rack::MockRequest.env_for("/", method: :post, input: nil, params: {})
+    env["PATH_INFO"].must_equal "/"
+    env.must_be_kind_of Hash
+    env['rack.input'].read.must_equal ''
+  end
+
   it "return an environment with a path" do
     env = Rack::MockRequest.env_for("http://www.example.com/parse?location[]=1&location[]=2&age_group[]=2")
     env["QUERY_STRING"].must_equal "location[]=1&location[]=2&age_group[]=2"
@@ -427,6 +434,10 @@ describe Rack::MockResponse do
     res = Rack::MockResponse.new(200, {}, body)
     body.close if body.respond_to?(:close)
     res.body.must_equal 'hi'
+  end
+
+  it "ignores plain strings passed as errors" do
+    Rack::MockResponse.new(200, {}, [], 'e').errors.must_be_nil
   end
 
   it "optionally make Rack errors fatal" do

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -76,6 +76,18 @@ describe Rack::Multipart do
     end
   end
 
+  it "sets BINARY encoding for invalid charsets" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_unknown_charset))
+    params = Rack::Multipart.parse_multipart(env)
+    params["text"].encoding.must_equal Encoding::BINARY
+
+    # I'm not 100% sure if making the param name encoding match the
+    # content-type charset is the right thing to do.  We should revisit this.
+    params.keys.each do |key|
+      key.encoding.must_equal Encoding::BINARY
+    end
+  end
+
   it "set BINARY encoding on things without content type" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:none))
     params = Rack::Multipart.parse_multipart(env)

--- a/test/spec_rewindable_input.rb
+++ b/test/spec_rewindable_input.rb
@@ -13,10 +13,6 @@ module RewindableTest
     @rio = Rack::RewindableInput.new(@io)
   end
 
-  class << self # HACK to get this running w/ as few changes as possible
-    alias_method :should, :it
-  end
-
   it "be able to handle to read()" do
     @rio.read.must_equal "hello world"
   end
@@ -44,20 +40,33 @@ module RewindableTest
   end
 
   it "rewind to the beginning when #rewind is called" do
-    @rio.read(1)
+    @rio.rewind
+    @rio.read(1).must_equal 'h'
     @rio.rewind
     @rio.read.must_equal "hello world"
   end
 
   it "be able to handle gets" do
     @rio.gets.must_equal "hello world"
+    @rio.rewind
+    @rio.gets.must_equal "hello world"
   end
 
   it "be able to handle size" do
     @rio.size.must_equal "hello world".size
+    @rio.size.must_equal "hello world".size
+    @rio.rewind
+    @rio.gets.must_equal "hello world"
   end
 
   it "be able to handle each" do
+    array = []
+    @rio.each do |data|
+      array << data
+    end
+    array.must_equal ["hello world"]
+
+    @rio.rewind
     array = []
     @rio.each do |data|
       array << data

--- a/test/spec_sendfile.rb
+++ b/test/spec_sendfile.rb
@@ -67,6 +67,19 @@ describe Rack::Sendfile do
     end
   end
 
+  it "closes body when x-sendfile used" do
+    body = sendfile_body
+    closed = false
+    body.define_singleton_method(:close){closed = true}
+    request({'HTTP_X_SENDFILE_TYPE' => 'x-sendfile'}, body) do |response|
+      response.must_be :ok?
+      response.body.must_be :empty?
+      response.headers['content-length'].must_equal '0'
+      response.headers['x-sendfile'].must_equal File.join(Dir.tmpdir,  "rack_sendfile")
+    end
+    closed.must_equal true
+  end
+
   it "sets x-lighttpd-send-file response header and discards body" do
     request 'HTTP_X_SENDFILE_TYPE' => 'x-lighttpd-send-file' do |response|
       response.must_be :ok?

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -151,6 +151,14 @@ describe Rack::Static do
     res.headers['content-type'].must_be_nil
   end
 
+  it "return 304 if gzipped file isn't modified since last serve" do
+    path = File.join(DOCROOT, "/cgi/test")
+    res = @gzip_request.get("/cgi/test", 'HTTP_IF_MODIFIED_SINCE' => File.mtime(path+'.gz').httpdate, 'HTTP_ACCEPT_ENCODING' => 'deflate, gzip')
+
+    res.status.must_equal 304
+    res.body.must_be :empty?
+  end
+
   it "supports serving fixed cache-control (legacy option)" do
     opts = OPTIONS.merge(cache_control: 'public')
     request = Rack::MockRequest.new(static(DummyApp.new, opts))

--- a/test/spec_tempfile_reaper.rb
+++ b/test/spec_tempfile_reaper.rb
@@ -84,4 +84,20 @@ describe Rack::TempfileReaper do
     tempfile1.closed.must_equal true
     tempfile2.closed.must_equal true
   end
+
+  it 'handle missing rack.tempfiles on normal response' do
+    app = lambda do |env|
+      env.delete('rack.tempfiles')
+      [200, {}, ['Hello, World!']]
+    end
+    call(app)[2].close
+  end
+
+  it 'handle missing rack.tempfiles on error' do
+    app = lambda do |env|
+      env.delete('rack.tempfiles')
+      raise 'Foo'
+    end
+    proc{call(app)}.must_raise RuntimeError
+  end
 end

--- a/test/spec_urlmap.rb
+++ b/test/spec_urlmap.rb
@@ -44,6 +44,11 @@ describe Rack::URLMap do
     res["x-scriptname"].must_equal "/foo/bar"
     res["x-pathinfo"].must_equal ""
 
+    res = Rack::MockRequest.new(map).get("/foo/bard")
+    res.must_be :ok?
+    res["x-scriptname"].must_equal "/foo"
+    res["x-pathinfo"].must_equal "/bard"
+
     res = Rack::MockRequest.new(map).get("/foo/bar/")
     res.must_be :ok?
     res["x-scriptname"].must_equal "/foo/bar"

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -131,6 +131,14 @@ describe Rack::Utils do
     Rack::Utils.parse_nested_query(nil).must_equal({})
   end
 
+  deprecated "should warn for deprecated QueryParser.make_default call with key_space_limit" do
+    Rack::QueryParser.make_default(1, 1).must_be_kind_of Rack::QueryParser
+  end
+
+  deprecated "should warn using deprecated QueryParser.new call with key_space_limit" do
+    Rack::QueryParser.new(Rack::QueryParser::Params, 1, 1).must_be_kind_of Rack::QueryParser
+  end
+
   deprecated "should warn using deprecated Rack::Util.key_space_limit=" do
     Rack::Utils.key_space_limit = 65536
   end


### PR DESCRIPTION
Mostly removing dead code and adding tests.

There's a few places here that could use more detailed review:

1) Someone should check my logic in 3cceec07567e52cc0c8c6376275430b3dab4a82a that the code in the multipart parser is in fact dead.

2) Someone should check my logic in 679a5cb9d3b6c03b4ee04a40dc30a3b964408a59 that the code in the query parser is in fact dead.

3) 4527b7d9fc5f2fe9693d100fc3f558944b2463fe changes behavior for an unrecognized charset in the multipart parser from raising an error to using a binary encoding.  I think this behavior makes more sense.  However, if we want to continue raising an error for that case, I'll make that change.