### PR TITLE
Add a .ci.gemfile for CI testing

### DIFF
--- a/.ci.gemfile
+++ b/.ci.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem "webrick"
+gem "minitest", "~> 5.0"
+gem "minitest-global_expectations"
+gem "rake"

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -10,6 +10,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby, truffleruby-head]
     runs-on: ${{matrix.os}}
+    env:
+      BUNDLE_GEMFILE: .ci.gemfile
     steps:
     - uses: actions/checkout@v2
 
@@ -26,12 +28,6 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: brew install fcgi libmemcached
 
-    - name: Bundle install...
-      run: |
-        gem update --system
-        bundle config path vendor/bundle
-        bundle install
-
     - run: bundle exec rake
 
   external:
@@ -42,6 +38,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         ruby: [2.6, 2.7]
     runs-on: ${{matrix.os}}
+    env:
+      BUNDLE_GEMFILE: .ci.gemfile
     steps:
     - uses: actions/checkout@v2
 
@@ -57,10 +55,5 @@ jobs:
     - name: Installing packages (macos)
       if: matrix.os == 'macos-latest'
       run: brew install libmemcached
-
-    - name: Bundle install...
-      run: |
-        bundle config path vendor/bundle
-        bundle install
 
     - run: bundle exec rake external


### PR DESCRIPTION
This avoids potentially installing unnecessary dependencies.

Also, avoid gem update --system and bundler config/install.

Fixes CI on Ruby 2.5 due to rubygems/bundler conflicts with psych, seen in recent PRs:

```
ArgumentError: wrong number of arguments (given 4, expected 1)
    /home/runner/work/rack/rack/vendor/bundle/ruby/2.5.0/gems/psych-4.0.3/lib/psych.rb:323:in `safe_load'
    /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/safe_yaml.rb:31:in `safe_load'
    /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:[49](https://github.com/rack/rack/runs/6372337912?check_suite_focus=true#step:3:49)6:in `block (2 levels) in read_checksums'
    /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:495:in `wrap'
    /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:495:in `block in read_checksums'
```