### PR TITLE
Remove Rack::Files.method_added

### DIFF
--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -22,14 +22,6 @@ module Rack
     ALLOW_HEADER = ALLOWED_VERBS.join(', ')
     MULTIPART_BOUNDARY = 'AaB03x'
 
-    # @todo remove in 3.0
-    def self.method_added(name)
-      if name == :response_body
-        raise "#{self.class}\#response_body is no longer supported."
-      end
-      super
-    end
-
     attr_reader :root
 
     def initialize(root, headers = {}, default_mime = 'text/plain')

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -28,14 +28,6 @@ describe Rack::Files do
     assert_equal 200, app.serving(request, file_path)[0]
   end
 
-  it 'raises if you attempt to define response_body in subclass' do
-    c = Class.new(Rack::Files)
-
-    lambda do
-      c.send(:define_method, :response_body){}
-    end.must_raise RuntimeError
-  end
-
   it 'serves files with + in the file name' do
     Dir.mktmpdir do |dir|
       File.write File.join(dir, "you+me.txt"), "hello world"


### PR DESCRIPTION
The comment says this should be removed in Rack 3. This was added
in Rack 2.2, so it should be safe to remove now.