### PR TITLE
Update list of included handlers in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -18,14 +18,10 @@ which all \Rack applications should conform to.
 
 == Supported web servers
 
-The included *handlers* connect all kinds of web servers to \Rack:
+The included *handlers* can connect these web servers to \Rack:
 
 * WEBrick[https://github.com/ruby/webrick]
-* FCGI
 * CGI
-* SCGI
-* LiteSpeed[https://www.litespeedtech.com/]
-* Thin[https://rubygems.org/gems/thin]
 
 These web servers include \Rack handlers in their distributions:
 
@@ -35,6 +31,7 @@ These web servers include \Rack handlers in their distributions:
 * {NGINX Unit}[https://unit.nginx.org/]
 * {Phusion Passenger}[https://www.phusionpassenger.com/] (which is mod_rack for Apache and for nginx)
 * Puma[https://puma.io/]
+* Thin[https://rubygems.org/gems/thin]
 * Unicorn[https://yhbt.net/unicorn/]
 * uWSGI[https://uwsgi-docs.readthedocs.io/en/latest/]
 * Lamby[https://lamby.custominktech.com] (for AWS Lambda)


### PR DESCRIPTION
Only handlers for WEBrick and CGI are included with Rack, the other handlers were removed.

See #1584, commit 98d9cf5834d4e27e34bbaa017cdfc68795763b55.