### PR TITLE
Impose a 70 character limit on boundary size

### DIFF
--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -35,6 +35,13 @@ describe Rack::Multipart do
     Rack::Multipart.parse_multipart(env).must_be_nil
   end
 
+  it "raises exception if boundary is too long" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_filename, "A"*71))
+    lambda {
+      Rack::Multipart.parse_multipart(env)
+    }.must_raise Rack::Multipart::Error
+  end
+
   it "parse multipart content when content type present but disposition is not" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_disposition))
     params = Rack::Multipart.parse_multipart(env)


### PR DESCRIPTION
This limit comes from RFC 1521 Section 7.2.1.  Clients generally
do not use boundaries longer than 55 characters.