### PR TITLE
Skip a test that is flaky on JRuby

### DIFF
--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -522,7 +522,7 @@ describe Rack::Server do
     Process.kill(:INT, $$)
     t.join
     open(pidfile.path) { |f| f.read.must_equal $$.to_s }
-  end if RUBY_VERSION >= "2.6"
+  end if RUBY_VERSION >= "2.6" && RUBY_ENGINE == "ruby"
 
   it "check pid file presence and running process" do
     pidfile = Tempfile.open('pidfile') { |f| f.write($$); break f }.path


### PR DESCRIPTION
It's already skipped on Ruby 2.4 and 2.5, so it's not like we
expect this to pass in all cases anyway.  If it is fixed on JRuby,
we can renable.  But it's better to not generate false negatives
in CI for unrelated changes.