### PR TITLE
Hex escape unprintable bytes in common logger

### DIFF
--- a/lib/rack/common_logger.rb
+++ b/lib/rack/common_logger.rb
@@ -65,7 +65,7 @@ module Rack
         length,
         Utils.clock_time - began_at)
 
-      msg.gsub!(/[^[:print:]\n]/) { |c| "\\x#{c.ord}" }
+      msg.gsub!(/[^[:print:]\n]/) { |c| sprintf("\\x%x", c.ord) }
 
       logger = @logger || request.get_header(RACK_ERRORS)
       # Standard library logger doesn't support write but it supports << which actually

--- a/test/spec_common_logger.rb
+++ b/test/spec_common_logger.rb
@@ -110,9 +110,9 @@ describe Rack::CommonLogger do
   it "escapes non printable characters except newline" do
     logdev = StringIO.new
     log = Logger.new(logdev)
-    Rack::MockRequest.new(Rack::CommonLogger.new(app_without_lint, log)).request("GET\b", "/hello")
+    Rack::MockRequest.new(Rack::CommonLogger.new(app_without_lint, log)).request("GET\x1f", "/hello")
 
-    logdev.string.must_match(/GET\\x8 \/hello HTTP\/1\.1/)
+    logdev.string.must_match(/GET\\x1f \/hello HTTP\/1\.1/)
   end
 
   it "log path with PATH_INFO" do


### PR DESCRIPTION
When using \x prefix, users would expect hex escaping.