### PR TITLE
Avoid unnecessary string allocation in Rack::MockRequest.env_for

### DIFF
--- a/lib/rack/mock.rb
+++ b/lib/rack/mock.rb
@@ -149,8 +149,7 @@ module Rack
         end
       end
 
-      empty_str = String.new
-      opts[:input] ||= empty_str
+      opts[:input] ||= String.new
       if String === opts[:input]
         rack_input = StringIO.new(opts[:input])
       else


### PR DESCRIPTION
If :input is already provided, this string allocation is unnecessary.