### PR TITLE
Expect additional optional version segment in version test.

### DIFF
--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -162,7 +162,7 @@ describe Rack::Server do
   end
 
   it "support -v option to get version" do
-    test_options_server('-v').must_match(/\ARack \d\.\d \(Release: \d+\.\d+\.\d+\)\nexited\z/)
+    test_options_server('-v').must_match(/\ARack \d\.\d \(Release: \d+\.\d+\.\d+(\.\d+)?\)\nexited\z/)
   end
 
   it "warn for invalid --profile-mode option" do


### PR DESCRIPTION
Last release (2.2.3.1) has added fourth segment of version string which wasn't expected by one test related to `rackup -v`. I have updated test to expect fourth (optional) segment.

CI fail was introduced by https://github.com/rack/rack/commit/f705eaced23649fb29222adbd70d5f658998953b.