### PR TITLE
Use "pre-wrap" format and monospace font for exception messages

### DIFF
--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -163,7 +163,7 @@ module Rack
           div.commands { margin-left: 40px; }
           div.commands a { color:black; text-decoration:none; }
           #summary { background: #ffc; }
-          #summary h2 { font-weight: normal; color: #666; }
+          #summary h2 { font-family: monospace; font-weight: normal; color: #666; white-space: pre; }
           #summary ul#quicklinks { list-style-type: none; margin-bottom: 2em; }
           #summary ul#quicklinks li { float: left; padding: 0 1em; }
           #summary ul#quicklinks>li+li { border-left: 1px #666 solid; }

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -163,7 +163,7 @@ module Rack
           div.commands { margin-left: 40px; }
           div.commands a { color:black; text-decoration:none; }
           #summary { background: #ffc; }
-          #summary h2 { font-family: monospace; font-weight: normal; color: #666; white-space: pre; }
+          #summary h2 { font-family: monospace; font-weight: normal; color: #666; white-space: pre-wrap; }
           #summary ul#quicklinks { list-style-type: none; margin-bottom: 2em; }
           #summary ul#quicklinks li { float: left; padding: 0 1em; }
           #summary ul#quicklinks>li+li { border-left: 1px #666 solid; }


### PR DESCRIPTION
This PR makes `Rack::ShowExceptions` friendly to Ruby 3.1's error_highlight. An exception message should be rendered by a monospace font and in "pre" format, i.e., whitespaces are preserved and newlines are respected.

Before:

<img width="643" alt="image" src="https://user-images.githubusercontent.com/21557/177955957-9de18c49-7f1f-4a4b-a95a-01e33de31bc0.png">

After:

<img width="376" alt="image" src="https://user-images.githubusercontent.com/21557/177955845-3895083d-2609-4eb8-8779-39c88d103378.png">