### PR TITLE
Use Exception#detailed_message if available

### DIFF
--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -59,7 +59,12 @@ module Rack
     private :accepts_html?
 
     def dump_exception(exception)
-      string = "#{exception.class}: #{exception.message}\n".dup
+      if exception.respond_to?(:detailed_message)
+        message = exception.detailed_message(highlight: false)
+      else
+        message = exception.message
+      end
+      string = "#{exception.class}: #{message}\n".dup
       string << exception.backtrace.map { |l| "\t#{l}" }.join("\n")
       string
     end
@@ -231,7 +236,11 @@ module Rack
 
       <div id="summary">
         <h1><%=h exception.class %> at <%=h path %></h1>
+      <% if exception.respond_to?(:detailed_message) %>
+        <h2><%=h exception.detailed_message(highlight: false) %></h2>
+      <% else %>
         <h2><%=h exception.message %></h2>
+      <% end %>
         <table><tr>
           <th>Ruby</th>
           <td>


### PR DESCRIPTION
Ruby 3.2 will provide `Exception#detailed_message` which returns more
informative message including hints for debugging.

https://bugs.ruby-lang.org/issues/18564

The did_you_mean gem and error_highlight gem is planned to use the
method to add their hints in Ruby 3.2. So using `Exception#message` will
not include did_you_mean and error_highlight hints.

This changeset uses `Exception#detailed_message` if available to show
exceptions.