### PR TITLE
Update docs and remove a dead link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ git remote add upstream https://github.com/rack/rack.git
 Make sure your fork is up-to-date and create a topic branch for your feature or bug fix.
 
 ```
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git checkout -b my-feature-branch
 ```
 
@@ -110,11 +110,11 @@ Go to https://github.com/contributor/rack and select your feature branch. Click 
 
 #### Rebase
 
-If you've been working on a change for a while, rebase with upstream/master.
+If you've been working on a change for a while, rebase with upstream/main.
 
 ```
 git fetch upstream
-git rebase upstream/master
+git rebase upstream/main
 git push origin my-feature-branch -f
 ```
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 {<img src="https://github.com/rack/rack/workflows/Development/badge.svg" alt="GitHub Actions status" />}[https://github.com/rack/rack/actions?query=workflow%3ADevelopment]
 {<img src="https://badge.fury.io/rb/rack.svg" alt="Gem Version" />}[http://badge.fury.io/rb/rack]
-{<img src="http://inch-ci.org/github/rack/rack.svg?branch=master" alt="Inline docs" />}[http://inch-ci.org/github/rack/rack]
+{<img src="http://inch-ci.org/github/rack/rack.svg?branch=main" alt="Inline docs" />}[http://inch-ci.org/github/rack/rack]
 
 \Rack provides a minimal, modular, and adaptable interface for developing
 web applications in Ruby. By wrapping HTTP requests and responses in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-New features will only be added to the master branch and will not be made available in point releases.
+New features will only be added to the main branch and will not be made available in point releases.
 
 ### Bug fixes
 

--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -393,7 +393,6 @@ module Rack
 
       def parse_options(args)
         # Don't evaluate CGI ISINDEX parameters.
-        # http://www.meb.uni-bonn.de/docs/cgi/cl.html
         args.clear if ENV.include?(REQUEST_METHOD)
 
         @options = opt_parser.parse!(args)

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/rack/rack/issues",
-    "changelog_uri" => "https://github.com/rack/rack/blob/master/CHANGELOG.md",
+    "changelog_uri" => "https://github.com/rack/rack/blob/main/CHANGELOG.md",
     "documentation_uri" => "https://rubydoc.info/github/rack/rack",
     "source_code_uri"   => "https://github.com/rack/rack"
   }


### PR DESCRIPTION
This PR does two things. 

First, it replaces references to the
master branch with main (which seems to be the default now).

It also removes a bad link in a comment as a reference for
not parsing CGI ISINDEX parameters. I could not find a
viable alternative link to defend this assertion. If there is
one I'd be happy to add it.