### PR TITLE
Don't close body prematurely in Rack::Deflater

### DIFF
--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -116,7 +116,7 @@ module Rack
           }
         end
       ensure
-        gzip.close
+        gzip.finish
       end
 
       # Call the block passed to #each with the gzipped data.

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -510,4 +510,13 @@ describe Rack::Deflater do
       raw_bytes.must_be(:<, content.bytesize)
     end
   end
+
+  it 'does not close the response body prematurely' do
+    app_body = Object.new
+    class << app_body; attr_reader :closed; def each; yield('foo'); yield('bar'); end; def close; @closed = true; end; end
+
+    verify(200, 'foobar', deflate_or_gzip, { 'app_body' => app_body }) do |status, headers, body|
+      assert_nil app_body.closed
+    end
+  end
 end


### PR DESCRIPTION
[Zlib::GzipWriter#close](https://ruby-doc.org/stdlib-3.1.2/libdoc/zlib/rdoc/Zlib/GzipFile.html#method-i-close) also closes the underlying IO, which in turn [closes the wrapped response body](https://github.com/rack/rack/blob/63ca628d7809758b332021e2f1f9ee69f4252441/lib/rack/deflater.rb#L127-L130). If that body is a [Rack::BodyProxy](https://github.com/rack/rack/blob/63ca628d7809758b332021e2f1f9ee69f4252441/lib/rack/body_proxy.rb), the associated block will run too early, before control has returned to the app server.

[Zlib::GzipWriter#finish](https://ruby-doc.org/stdlib-3.1.2/libdoc/zlib/rdoc/Zlib/GzipFile.html#method-i-finish) closes the gzip stream, but not the underlying IO. The response body will then be closed by the app server after iteration.

In practice, the previous behaviour meant that the client would have to wait until after any Rack::BodyProxy blocks had run before it could finish reading the response.