### PR TITLE
Clarify handling of body and add optional `error` argument to `close`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. For info on
 - Response header keys can no longer include uppercase characters.
 - Response header values can be an `Array` to handle multiple values (and no longer supports `\n` encoded headers).
 - Response body can now respond to `#call` (streaming body) instead of `#each` (enumerable body), for the equivalent of response hijacking in previous versions.
+- Response body `#close(error = nil)` takes optional error argument which indicates a failure fully consume the body.
 - Middleware must no longer call `#each` on the body, but they can call `#to_ary` on the body if it responds to `#to_ary`.
 - `rack.input` is no longer required to be rewindable.
 - `rack.multithread/rack.multiprocess/rack.run_once` are no longer required environment keys.

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -282,26 +282,43 @@ The Body is typically an +Array+ of +String+ instances, an enumerable
 that yields +String+ instances, a +Proc+ instance, or a File-like
 object.
 
-The Body must respond to +each+ or +call+. It may optionally respond to
-+to_path+.
+The Body must respond to +each+ or +call+. It may optionally respond
+to +to_path+ or +to_ary+. A Body that responds to +each+ is considered
+to be an Enumerable Body. A Body that responds to +call+ is considered
+to be a Streaming Body.
 
-A Body that responds to +each+ is considered to be an Enumerable Body.
-
-A Body that responds to +call+ is considered to be a Streaming Body.
-
-A Body that responds to +to_path+ is expected to generate the same
-content as would be produced by reading a local file opened with the
-path returned by calling +to_path+.
-
-A body that responds to both +each+ and +call+ must be treated as an
+A Body that responds to both +each+ and +call+ must be treated as an
 Enumerable Body, not a Streaming Body. If it responds to +each+, you
-must call +each+ and not +call+. If the body doesn't respond to
+must call +each+ and not +call+. If the Body doesn't respond to
 +each+, then you can assume it responds to +call+.
+
+A Body must either be consumed or returned. The Body is consumed by
+optinally calling one of +each+, +call+, +to_path+, or +to_ary+.
+Then, if the Body responds to +close+, it must be called to release
+any resources associated with the generation of the body.
+
+When consuming the Body, if an error occurs (e.g. writing the data to
+the network), the +close+ method should be called as above with the
+error (e.g. +IOError+) given as the argument.
+
+After calling +close+, the Body is considered closed and should not
+be closed, used or consumed again.
+If the original Body is replaced by a new Body, the new Body must
+also consome the original Body.
+If the Body responds to both +to_ary+ and +close+, its
+implementation of +to_ary+ must call +close+.
+
+If the Body responds to +to_path+, it must return a +String+
+path for the local file system whose contents are identical
+to that produced by calling +each+; this may be used by the
+server as an alternative, possibly more efficient way to
+transport the response.
 
 ==== Enumerable Body
 
 The Enumerable Body must respond to +each+.
 It must only be called once.
+It must not be called after being closed.
 and must only yield String values.
 
 The Body itself should not be an instance of String, as this will
@@ -311,30 +328,16 @@ Middleware must not call +each+ directly on the Body.
 Instead, middleware can return a new Body that calls +each+ on the
 original Body, yielding at least once per iteration.
 
-If the Body responds to +to_ary+, it must return an Array whose
+If the Body responds to +to_ary+, it must return an +Array+ whose
 contents are identical to that produced by calling +each+.
 Middleware may call +to_ary+ directly on the Body and return a new Body in its place.
 In other words, middleware can only process the Body directly if it responds to +to_ary+.
-
-If the Body responds to +close+, it will be called after iteration. If
-the original Body is replaced by a new Body, the new Body
-must close the original Body after iteration, if it responds to +close+.
-If the Body responds to both +to_ary+ and +close+, its
-implementation of +to_ary+ must call +close+ after iteration.
-
-If the Body responds to +to_path+, it must return a String
-identifying the location of a file whose contents are identical
-to that produced by calling +each+; this may be used by the
-server as an alternative, possibly more efficient way to
-transport the response.
-
-The Body commonly is an Array of Strings, the application
-instance itself, or a File-like object.
 
 ==== Streaming Body
 
 The Streaming Body must respond to +call+.
 It must only be called once.
+It must not be called after being closed.
 It takes a +stream+ argument.
 
 The +stream+ argument must implement:

--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -20,13 +20,13 @@ module Rack
 
     # If not already closed, close the wrapped body and
     # then call the block the proxy was initialized with.
-    def close
+    def close(error = nil)
       return if @closed
       @closed = true
       begin
-        @body.close if @body.respond_to? :close
+        @body.close(error) if @body.respond_to?(:close)
       ensure
-        @block.call
+        @block.call(error)
       end
     end
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -779,8 +779,9 @@ module Rack
       def close(error = nil)
         ##
         ## After calling +close+, the Body is considered closed and should not
-        ## be closed, used or consumed again.
-        raise LintError, "The body is already closed" if @closed
+        ## be consumed again.
+        return if @closed
+
         @closed = true
 
         ## If the original Body is replaced by a new Body, the new Body must

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -758,21 +758,56 @@ module Rack
       ## that yields +String+ instances, a +Proc+ instance, or a File-like
       ## object.
       ##
-      ## The Body must respond to +each+ or +call+. It may optionally respond to
-      ## +to_path+.
+      ## The Body must respond to +each+ or +call+. It may optionally respond
+      ## to +to_path+ or +to_ary+. A Body that responds to +each+ is considered
+      ## to be an Enumerable Body. A Body that responds to +call+ is considered
+      ## to be a Streaming Body.
       ##
-      ## A Body that responds to +each+ is considered to be an Enumerable Body.
-      ##
-      ## A Body that responds to +call+ is considered to be a Streaming Body.
-      ##
-      ## A Body that responds to +to_path+ is expected to generate the same
-      ## content as would be produced by reading a local file opened with the
-      ## path returned by calling +to_path+.
-      ##
-      ## A body that responds to both +each+ and +call+ must be treated as an
+      ## A Body that responds to both +each+ and +call+ must be treated as an
       ## Enumerable Body, not a Streaming Body. If it responds to +each+, you
-      ## must call +each+ and not +call+. If the body doesn't respond to
+      ## must call +each+ and not +call+. If the Body doesn't respond to
       ## +each+, then you can assume it responds to +call+.
+      ##
+      ## A Body must either be consumed or returned. The Body is consumed by
+      ## optinally calling one of +each+, +call+, +to_path+, or +to_ary+.
+      ## Then, if the Body responds to +close+, it must be called to release
+      ## any resources associated with the generation of the body.
+      ##
+      ## When consuming the Body, if an error occurs (e.g. writing the data to
+      ## the network), the +close+ method should be called as above with the
+      ## error (e.g. +IOError+) given as the argument.
+      def close(error = nil)
+        ##
+        ## After calling +close+, the Body is considered closed and should not
+        ## be closed, used or consumed again.
+        raise LintError, "The body is already closed" if @closed
+        @closed = true
+
+        ## If the original Body is replaced by a new Body, the new Body must
+        ## also consome the original Body.
+        ## If the Body responds to both +to_ary+ and +close+, its
+        ## implementation of +to_ary+ must call +close+.
+
+        @body.close(error) if @body.respond_to?(:close)
+        index = @lint.index(self)
+        unless @env['rack.lint'][0..index].all? {|lint| lint.instance_variable_get(:@closed)}
+          raise LintError, "Body has not been closed"
+        end
+      end
+
+      def verify_to_path
+        ##
+        ## If the Body responds to +to_path+, it must return a +String+
+        ## path for the local file system whose contents are identical
+        ## to that produced by calling +each+; this may be used by the
+        ## server as an alternative, possibly more efficient way to
+        ## transport the response.
+        if @body.respond_to?(:to_path)
+          unless ::File.exist? @body.to_path
+            raise LintError, "The file identified by body.to_path does not exist"
+          end
+        end
+      end
 
       ##
       ## ==== Enumerable Body
@@ -783,6 +818,9 @@ module Rack
 
         ## It must only be called once.
         raise LintError, "Response body must only be invoked once (#{@invoked})" unless @invoked.nil?
+
+        ## It must not be called after being closed.
+        raise LintError, "Response body is already closed" if @closed
 
         @invoked = :each
 
@@ -825,7 +863,7 @@ module Rack
       end
 
       ##
-      ## If the Body responds to +to_ary+, it must return an Array whose
+      ## If the Body responds to +to_ary+, it must return an +Array+ whose
       ## contents are identical to that produced by calling +each+.
       ## Middleware may call +to_ary+ directly on the Body and return a new Body in its place.
       ## In other words, middleware can only process the Body directly if it responds to +to_ary+.
@@ -840,39 +878,6 @@ module Rack
       end
 
       ##
-      ## If the Body responds to +close+, it will be called after iteration. If
-      ## the original Body is replaced by a new Body, the new Body
-      ## must close the original Body after iteration, if it responds to +close+.
-      ## If the Body responds to both +to_ary+ and +close+, its
-      ## implementation of +to_ary+ must call +close+ after iteration.
-      def close
-        @closed = true
-        @body.close if @body.respond_to?(:close)
-        index = @lint.index(self)
-        unless @env['rack.lint'][0..index].all? {|lint| lint.instance_variable_get(:@closed)}
-          raise LintError, "Body has not been closed"
-        end
-      end
-
-      def verify_to_path
-        ##
-        ## If the Body responds to +to_path+, it must return a String
-        ## identifying the location of a file whose contents are identical
-        ## to that produced by calling +each+; this may be used by the
-        ## server as an alternative, possibly more efficient way to
-        ## transport the response.
-        if @body.respond_to?(:to_path)
-          unless ::File.exist? @body.to_path
-            raise LintError, "The file identified by body.to_path does not exist"
-          end
-        end
-
-        ##
-        ## The Body commonly is an Array of Strings, the application
-        ## instance itself, or a File-like object.
-      end
-
-      ##
       ## ==== Streaming Body
       ##
       def call(stream)
@@ -881,6 +886,9 @@ module Rack
 
         ## It must only be called once.
         raise LintError, "Response body must only be invoked once (#{@invoked})" unless @invoked.nil?
+
+        ## It must not be called after being closed.
+        raise LintError, "Response body is already closed" if @closed
 
         @invoked = :call
 


### PR DESCRIPTION
This is an attempt to clarify the behaviour of `body.close` and expose any failure to consume said body via `close`.

This general approach has been used in `async-http` for several years and has proven itself to be invaluable to certain cases like streaming and error propagation.

https://github.com/rack/rack/pull/1932