### PR TITLE
Bump version to "3.0.0".

### DIFF
--- a/lib/rack/server.rb
+++ b/lib/rack/server.rb
@@ -119,7 +119,7 @@ module Rack
           end
 
           opts.on_tail("--version", "Show version") do
-            puts "Rack #{Rack.version} (Release: #{Rack.release})"
+            puts "Rack #{Rack.release}"
             exit
           end
         end

--- a/lib/rack/version.rb
+++ b/lib/rack/version.rb
@@ -13,17 +13,34 @@
 
 module Rack
   # The Rack protocol version number implemented.
-  VERSION = "3.0.0"
+  VERSION = String.new("3.0.0")
+
+  def VERSION.join(separator)
+    warn "Rack::Version is now a String, use it directly!", uplevel: 1
+    VERSION.split('.').join(separator)
+  end
+
+  def VERSION.[](index)
+    warn "Rack::Version is now a String, use it directly!", uplevel: 1
+    VERSION.split('.')[index]
+  end
+
+  VERSION.freeze
 
   # Return the Rack protocol version as a dotted string.
   def self.version
+    # In a future release, say, 3.1?
+    # warn "Rack::VERSION is now a String, use it directly!", uplevel: 1
     VERSION
   end
 
   RELEASE = VERSION
-
+  deprecate_constant :RELEASE
+  
   # Return the Rack release as a dotted string.
   def self.release
+    # In a future release, say, 3.1?
+    # warn "Rack::VERSION is now a String, use it directly!", uplevel: 1
     VERSION
   end
 end

--- a/lib/rack/version.rb
+++ b/lib/rack/version.rb
@@ -13,18 +13,17 @@
 
 module Rack
   # The Rack protocol version number implemented.
-  VERSION = [1, 3].freeze
-  VERSION_STRING = VERSION.join(".").freeze
+  VERSION = "3.0.0"
 
   # Return the Rack protocol version as a dotted string.
   def self.version
-    VERSION_STRING
+    VERSION
   end
 
-  RELEASE = "2.3.0"
+  RELEASE = VERSION
 
   # Return the Rack release as a dotted string.
   def self.release
-    RELEASE
+    VERSION
   end
 end

--- a/lib/rack/version.rb
+++ b/lib/rack/version.rb
@@ -13,34 +13,22 @@
 
 module Rack
   # The Rack protocol version number implemented.
-  VERSION = String.new("3.0.0")
+  VERSION = [1, 3].freeze
+  deprecate_constant :VERSION
 
-  def VERSION.join(separator)
-    warn "Rack::Version is now a String, use it directly!", uplevel: 1
-    VERSION.split('.').join(separator)
-  end
+  VERSION_STRING = "1.3".freeze
+  deprecate_constant :VERSION_STRING
 
-  def VERSION.[](index)
-    warn "Rack::Version is now a String, use it directly!", uplevel: 1
-    VERSION.split('.')[index]
-  end
-
-  VERSION.freeze
-
-  # Return the Rack protocol version as a dotted string.
+  # The Rack protocol version number implemented.
   def self.version
-    # In a future release, say, 3.1?
-    # warn "Rack::VERSION is now a String, use it directly!", uplevel: 1
+    warn "Rack.version is deprecated and will be removed in Rack 3.1!", uplevel: 1
     VERSION
   end
 
-  RELEASE = VERSION
-  deprecate_constant :RELEASE
-  
+  RELEASE = "3.0.0"
+
   # Return the Rack release as a dotted string.
   def self.release
-    # In a future release, say, 3.1?
-    # warn "Rack::VERSION is now a String, use it directly!", uplevel: 1
-    VERSION
+    RELEASE
   end
 end

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/rack/version'
 
 Gem::Specification.new do |s|
   s.name = "rack"
-  s.version = Rack::VERSION
+  s.version = Rack::RELEASE
   s.platform = Gem::Platform::RUBY
   s.summary = "A modular Ruby webserver interface."
   s.license = "MIT"

--- a/rack.gemspec
+++ b/rack.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/rack/version'
 
 Gem::Specification.new do |s|
   s.name = "rack"
-  s.version = Rack::RELEASE
+  s.version = Rack::VERSION
   s.platform = Gem::Platform::RUBY
   s.summary = "A modular Ruby webserver interface."
   s.license = "MIT"

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -275,7 +275,7 @@ describe Rack::Server do
   end
 
   it "support -v option to get version" do
-    test_options_server('-v').must_match(/\ARack \d\.\d \(Release: \d+\.\d+\.\d+\)\nexited\z/)
+    test_options_server('-v').must_match(/\ARack \d+\.\d+.\d+ \(Release: \d+\.\d+\.\d+\)\nexited\z/)
   end
 
   it "warn for invalid --profile-mode option" do

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -275,7 +275,7 @@ describe Rack::Server do
   end
 
   it "support -v option to get version" do
-    test_options_server('-v').must_match(/\ARack \d+\.\d+.\d+ \(Release: \d+\.\d+\.\d+\)\nexited\z/)
+    test_options_server('-v').must_match(/\ARack \d+\.\d+.\d+\nexited\z/)
   end
 
   it "warn for invalid --profile-mode option" do

--- a/test/spec_version.rb
+++ b/test/spec_version.rb
@@ -8,8 +8,8 @@ end
 
 describe Rack do
   describe 'version' do
-    it 'defaults to a hard-coded api version' do
-      Rack.version.must_match(/\d+\.\d+\.\d+/)
+    it 'is a version string' do
+      Rack::RELEASE.must_match(/\d+\.\d+\.\d+/)
     end
   end
 end

--- a/test/spec_version.rb
+++ b/test/spec_version.rb
@@ -9,7 +9,7 @@ end
 describe Rack do
   describe 'version' do
     it 'defaults to a hard-coded api version' do
-      Rack.version.must_equal "1.3"
+      Rack.version.must_match(/\d+\.\d+\.\d+/)
     end
   end
 end


### PR DESCRIPTION
I know the change to `VERSION` from Array to String could be a compatibility issue, but I'd like to propose it and then see if anything breaks. I'd rather just be consistent with the standard `GemName::VERSION` which basically every other gem in the world follows.

`Rack::VERSION` has never been a useful constant for any real world situations anyway, so I don't think any real world code would be depending on it. In Rack 2, this was provided by the request `env`, but I guess it's possible some code was checking `Rack::VERSION`.

I don't think we should have "VERSION" and "RELEASE" as separate things. It seems like a snowflake thing to do, added complexity, no value.