### PR TITLE
Undeprecate Utils#byte_ranges

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -418,7 +418,6 @@ module Rack
     # Returns nil if the header is missing or syntactically invalid.
     # Returns an empty array if none of the ranges are satisfiable.
     def byte_ranges(env, size)
-      warn("`byte_ranges` is deprecated and will be removed in Rack 3.1, please use `get_byte_ranges`", uplevel: 1)
       get_byte_ranges env['HTTP_RANGE'], size
     end
 


### PR DESCRIPTION
Similar to the changes made in 6d18e5183b7bbc34dc406b63ff98a377a85d5ec3,
we shouldn't deprecate this without an appropriate replacement.

Fixes #1845