### PR TITLE
Do not add lib to load path when running separate tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,12 +12,12 @@ if ENV.delete('COVERAGE')
   end
 end
 
-$:.unshift(File.expand_path('../lib', __dir__))
 if ENV['SEPARATE']
   def self.separate_testing
     yield
   end
 else
+  $:.unshift(File.expand_path('../lib', __dir__))
   require_relative '../lib/rack'
 
   def self.separate_testing


### PR DESCRIPTION
This is a better check that the internals are correctly using
require_relative and not relying on autoload.