### PR TITLE
Allow calling close on `rack.input`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file. For info on
 - `rack.hijack?` (partial hijack) and `rack.hijack` (full hijack) are now independently optional.
 - `rack.hijack_io` has been removed completely.
 - `rack.response_finished` is an optional environment key which contains an array of callable objects that must accept `#call(env, status, headers, error)` and are invoked after the response is finished (either successfully or unsucessfully).
+- It is okay to call `#close` on `rack.input` to indicate that you no longer need or care about the input.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project will be documented in this file. For info on
 - Use lower case cookie attributes when creating cookies, and fold cookie attributes to lower case when reading cookies (specifically impacting `secure` and `httponly` attributes). ([#1849](https://github.com/rack/rack/pull/1849), [@ioquatix])
 - The response array must now be mutable (non-frozen) so middleware can modify it without allocating a new Array,therefore reducing object allocations. ([#1887](https://github.com/rack/rack/pull/1887), [#1927](https://github.com/rack/rack/pull/1927), [@amatsuda], [@ioquatix])
 - `rack.hijack?` (partial hijack) and `rack.hijack` (full hijack) are now independently optional. `rack.hijack_io` is no longer required/specified. ([#1939](https://github.com/rack/rack/pull/1939), [@ioquatix])
+- Allow calling close on `rack.input`. ([#1956](https://github.com/rack/rack/pull/1956), [@ioquatix])
 
 ### Fixed
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -166,7 +166,8 @@ The input stream must respond to +gets+, +each+, and +read+.
   If +buffer+ is given, then the read data will be placed
   into +buffer+ instead of a newly created String object.
 * +each+ must be called without arguments and only yield Strings.
-* +close+ must never be called on the input stream.
+* +close+ can be called on the input stream to indicate that the
+any remaining input is not needed.
 
 === The Error Stream
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -478,9 +478,10 @@ module Rack
           }
         end
 
-        ## * +close+ must never be called on the input stream.
+        ## * +close+ can be called on the input stream to indicate that the
+        ## any remaining input is not needed.
         def close(*args)
-          raise LintError, "rack.input#close must not be called"
+          @input.close(*args)
         end
       end
 

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -742,14 +742,6 @@ describe Rack::Lint do
                      }).call(env("rack.input" => eof_weirdio))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/read\(nil\) returned nil on EOF/)
-
-    lambda {
-      Rack::Lint.new(lambda { |env|
-                       env["rack.input"].close
-                       [201, { "content-type" => "text/plain", "content-length" => "0" }, []]
-                     }).call(env({}))
-    }.must_raise(Rack::Lint::LintError).
-      message.must_match(/close must not be called/)
   end
 
   it "notice error handling errors" do

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -744,6 +744,17 @@ describe Rack::Lint do
       message.must_match(/read\(nil\) returned nil on EOF/)
   end
 
+  it "can call close" do
+    app = lambda do |env|
+      env["rack.input"].close
+      [201, {"content-type" => "text/plain", "content-length" => "0"}, []]
+    end
+
+    response = Rack::Lint.new(app).call(env({}))
+
+    response.first.must_equal 201
+  end
+
   it "notice error handling errors" do
     lambda {
       Rack::Lint.new(lambda { |env|


### PR DESCRIPTION
My guess is this is a hang-over from CGI stdin/stdout model. It's advantageous to close the input if you don't need it to free any associated resources as soon as possible. I can't find any reason/justification as to why this is the way it is.