### PR TITLE
The stream argument must implement `#<<`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file. For info on
 - Support callable body for explicit streaming support and clarify streaming response body behaviour. ([#1745](https://github.com/rack/rack/pull/1745), [@ioquatix], [#1748](https://github.com/rack/rack/pull/1748), [@wjordan])
 - Allow `Rack::Builder#run` to take a block instead of an argument. ([#1942](https://github.com/rack/rack/pull/1942), [@ioquatix])
 - Add `rack.response_finished` to `Rack::Lint`. ([#1802](https://github.com/rack/rack/pull/1802), [@BlakeWilliams], [#1952](https://github.com/rack/rack/pull/1952), [@ioquatix])
+- The stream argument must implement `#<<`. ([#1959](https://github.com/rack/rack/pull/1959), [@ioquatix])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. For info on
 - `rack.hijack_io` has been removed completely.
 - `rack.response_finished` is an optional environment key which contains an array of callable objects that must accept `#call(env, status, headers, error)` and are invoked after the response is finished (either successfully or unsucessfully).
 - It is okay to call `#close` on `rack.input` to indicate that you no longer need or care about the input.
+- The stream argument to streaming responses and hijack must support `#<<` for writing output.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file. For info on
 - `rack.hijack_io` has been removed completely.
 - `rack.response_finished` is an optional environment key which contains an array of callable objects that must accept `#call(env, status, headers, error)` and are invoked after the response is finished (either successfully or unsucessfully).
 - It is okay to call `#close` on `rack.input` to indicate that you no longer need or care about the input.
-- The stream argument to streaming responses and hijack must support `#<<` for writing output.
+- The stream argument supplied to the streaming body and hijack must support `#<<` for writing output.
 
 ### Removed
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -327,7 +327,7 @@ It must not be called after being closed.
 It takes a +stream+ argument.
 
 The +stream+ argument must implement:
-<tt>read, write, flush, close, close_read, close_write, closed?</tt>
+<tt>read, write, <<, flush, close, close_read, close_write, closed?</tt>
 
 The semantics of these IO methods must be a best effort match to
 those of a normal Ruby IO or Socket object, using standard arguments

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -861,7 +861,7 @@ module Rack
         ## It takes a +stream+ argument.
         ##
         ## The +stream+ argument must implement:
-        ## <tt>read, write, flush, close, close_read, close_write, closed?</tt>
+        ## <tt>read, write, <<, flush, close, close_read, close_write, closed?</tt>
         ##
         @body.call(StreamWrapper.new(stream))
       end
@@ -875,7 +875,7 @@ module Rack
         ## pass on real IO objects, although it is recognized that this approach
         ## is not directly compatible with HTTP/2.
         REQUIRED_METHODS = [
-          :read, :write, :flush, :close,
+          :read, :write, :<<, :flush, :close,
           :close_read, :close_write, :closed?
         ]
 


### PR DESCRIPTION
This makes it easier to use the stream argument with template systems like ERB, Trenni, etc for real time template streaming/generation.