### PR TITLE
Use latest RubyGems in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,5 +33,6 @@ jobs:
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
+        rubygems: latest
 
     - run: bundle exec rake


### PR DESCRIPTION
Workaround for the situation described in https://github.com/ruby/setup-ruby/pull/264#issuecomment-1014094445

It also happened to us in the Puma repo: https://github.com/puma/puma/pull/2782#issuecomment-1003388499

...and it also just happened for #1962: https://github.com/rack/rack/runs/8235638380?check_suite_focus=true#step:3:56