### PR TITLE
Change v3.0.0.beta1 to v3.0.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![Rack](contrib/logo.webp)
 
-> **_NOTE:_** Rack v3.0.0.beta1 was recently released. Please check the [Upgrade
+> **_NOTE:_** Rack v3.0.0 was recently released. Please check the [Upgrade
 > Guide](UPGRADE-GUIDE.md) for more details about migrating your existing
 > servers, middlewares and applications. For detailed information on specific
 > changes, check the [Change Log](CHANGELOG.md).
@@ -23,7 +23,7 @@ by a [supported web framework](#supported-web-frameworks):
 $ gem install rack --pre
 
 # or, add it to your current application gemfile:
-$ bundle add rack --version 3.0.0.beta1
+$ bundle add rack --version 3.0.0
 ```
 
 If you need features from `Rack::Session` or `bin/rackup` please add those gems separately.


### PR DESCRIPTION
This mirrors the 3.0.0 official (non-beta) release.