### PR TITLE
Updated simplest run sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ $ gem install rack-session rackup
 Create a file called `config.ru` with the following contents:
 
 ```ruby
-run do |env|
+run ->(env) {
   [200, {}, ["Hello World"]]
-end
+}
 ```
 
 Run this using the rackup gem or another [supported web


### PR DESCRIPTION
Current version gives:
```ruby
...gems/rack-2.2.4/lib/rack/builder.rb:176:in `run': wrong number of arguments (given 0, expected 1) (ArgumentError)
```