### PR TITLE
Fix `respond_to?(:each)` with `Rack::Lint` with streaming bodies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Fixed
 
 - `MethodOverride` does not look for an override if a request does not include form/parseable data.
+- `Rack::Lint::Wrapper` correctly handles `respond_to?` with `to_ary`, `each`, `call` and `to_path`, forwarding to the body. ([#1981](https://github.com/rack/rack/pull/1981), [@ioquatix])
 
 ## [3.0.0] - 2022-09-06
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -819,6 +819,10 @@ module Rack
 
       BODY_METHODS = {to_ary: true, each: true, to_path: true}
 
+      def to_path
+        @body.to_path
+      end
+
       def respond_to?(name, *)
         if BODY_METHODS.key?(name)
           @body.respond_to?(name)

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -817,8 +817,10 @@ module Rack
         verify_to_path
       end
 
+      BODY_METHODS = {to_ary: true, each: true, to_path: true}
+
       def respond_to?(name, *)
-        if name == :to_ary
+        if BODY_METHODS.key?(name)
           @body.respond_to?(name)
         else
           super

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -817,7 +817,7 @@ module Rack
         verify_to_path
       end
 
-      BODY_METHODS = {to_ary: true, each: true, to_path: true}
+      BODY_METHODS = {to_ary: true, each: true, call: true, to_path: true}
 
       def to_path
         @body.to_path

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -33,7 +33,6 @@ describe Rack::Lint do
     lambda { Rack::Lint.new(nil).call({}.freeze) }.must_raise(Rack::Lint::LintError).
       message.must_match(/env should not be frozen, but is/)
 
-
     lambda {
       e = env
       e.delete("REQUEST_METHOD")
@@ -471,6 +470,17 @@ describe Rack::Lint do
                      }).call(env({}))[2].each { }
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/content-length header was 1, but should be 0/)
+  end
+
+  it "responds to to_path" do
+    body = Object.new
+    def body.each; end
+    def body.to_path; __FILE__ end
+    app = lambda { |env| [200, {}, body] }
+
+    status, headers, body = Rack::Lint.new(app).call(env({}))
+    body.must_respond_to(:to_path)
+    body.to_path.must_equal __FILE__
   end
 
   it "notice body errors" do


### PR DESCRIPTION
This is the last piece required to get webrick passing the conformance test suite with Rack 3.