### PR TITLE
Revert "chore: Included github-actions in the dependabot config (#1910)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This reverts commit afc43f2fc355ee10b4002c5befd0703ba016290a.