### PR TITLE
Don't assume 1xx (101) should have the (streaming) body stripped by `Rack::Response`.

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -114,7 +114,10 @@ module Rack
       end
     end
 
-    alias to_a finish           # For *response
+    # Generate a response array consistent with the requirements of the SPEC.
+    def to_a
+      [@status, @headers, @body]
+    end
 
     def each(&callback)
       @body.each(&callback)

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -537,7 +537,11 @@ module Rack
     }
 
     # Responses with HTTP status codes that should not have an entity body
-    STATUS_WITH_NO_ENTITY_BODY = Hash[((100..199).to_a << 204 << 304).product([true])]
+    STATUS_WITH_NO_ENTITY_BODY = {
+      100 => true,
+      204 => true,
+      304 => true
+    }
 
     SYMBOL_TO_STATUS_CODE = Hash[*HTTP_STATUS_CODES.map { |code, message|
       [message.downcase.gsub(/\s|-|'/, '_').to_sym, code]

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -444,7 +444,7 @@ describe Rack::Lint do
     # }.must_raise(Rack::Lint::LintError).
     #   message.must_match(/No content-type/)
 
-    [100, 101, 204, 304].each do |status|
+    [100, 204, 304].each do |status|
       lambda {
         Rack::Lint.new(lambda { |env|
                          [status, { "content-type" => "text/plain", "content-length" => "0" }, []]
@@ -455,7 +455,7 @@ describe Rack::Lint do
   end
 
   it "notice content-length errors" do
-    [100, 101, 204, 304].each do |status|
+    [100, 204, 304].each do |status|
       lambda {
         Rack::Lint.new(lambda { |env|
                          [status, { "content-length" => "0" }, []]


### PR DESCRIPTION
This is required to use `Rack::Response` for generating streaming responses. Otherwise, for 101 status codes, it will strip the body.

Alternatives include changing `Rack::Response#finish` to not do any stripping, and leave it up to the sever (to fail would probably be the best, generating content for a No Content or Not Changed response seems at best weird and at worst a bug).