### PR TITLE
Remove leading dot to fix compatibility with latest cgi gem.

### DIFF
--- a/test/spec_mock_request.rb
+++ b/test/spec_mock_request.rb
@@ -26,8 +26,8 @@ app = Rack::Lint.new(lambda { |env|
     req.GET["status"] || 200,
     "content-type" => "text/yaml"
   )
-  response.set_cookie("session_test", { value: "session_test", domain: ".test.com", path: "/" })
-  response.set_cookie("secure_test", { value: "secure_test", domain: ".test.com",  path: "/", secure: true })
+  response.set_cookie("session_test", { value: "session_test", domain: "test.com", path: "/" })
+  response.set_cookie("secure_test", { value: "secure_test", domain: "test.com",  path: "/", secure: true })
   response.set_cookie("persistent_test", { value: "persistent_test", max_age: 15552000, path: "/" })
   response.set_cookie("persistent_with_expires_test", { value: "persistent_with_expires_test", expires: Time.httpdate("Thu, 31 Oct 2021 07:28:00 GMT"), path: "/" })
   response.set_cookie("expires_and_max-age_test", { value: "expires_and_max-age_test", expires: Time.now + 15552000 * 2, max_age: 15552000, path: "/" })

--- a/test/spec_mock_response.rb
+++ b/test/spec_mock_response.rb
@@ -26,8 +26,8 @@ app = Rack::Lint.new(lambda { |env|
     req.GET["status"] || 200,
     "content-type" => "text/yaml"
   )
-  response.set_cookie("session_test", { value: "session_test", domain: ".test.com", path: "/" })
-  response.set_cookie("secure_test", { value: "secure_test", domain: ".test.com",  path: "/", secure: true })
+  response.set_cookie("session_test", { value: "session_test", domain: "test.com", path: "/" })
+  response.set_cookie("secure_test", { value: "secure_test", domain: "test.com",  path: "/", secure: true })
   response.set_cookie("persistent_test", { value: "persistent_test", max_age: 15552000, path: "/" })
   response.set_cookie("persistent_with_expires_test", { value: "persistent_with_expires_test", expires: Time.httpdate("Thu, 31 Oct 2021 07:28:00 GMT"), path: "/" })
   response.set_cookie("expires_and_max-age_test", { value: "expires_and_max-age_test", expires: Time.now + 15552000 * 2, max_age: 15552000, path: "/" })
@@ -82,7 +82,7 @@ describe Rack::MockResponse do
     res = Rack::MockRequest.new(app).get("")
     session_cookie = res.cookie("session_test")
     session_cookie.value[0].must_equal "session_test"
-    session_cookie.domain.must_equal ".test.com"
+    session_cookie.domain.must_equal "test.com"
     session_cookie.path.must_equal "/"
     session_cookie.secure.must_equal false
     session_cookie.expires.must_be_nil
@@ -122,7 +122,7 @@ describe Rack::MockResponse do
     res = Rack::MockRequest.new(app).get("")
     secure_cookie = res.cookie("secure_test")
     secure_cookie.value[0].must_equal "secure_test"
-    secure_cookie.domain.must_equal ".test.com"
+    secure_cookie.domain.must_equal "test.com"
     secure_cookie.path.must_equal "/"
     secure_cookie.secure.must_equal true
     secure_cookie.expires.must_be_nil


### PR DESCRIPTION
This is now failing:

```
ArgumentError: invalid domain: ".test.com"
    /opt/hostedtoolcache/Ruby/3.0.5/x64/lib/ruby/3.0.0/cgi/cookie.rb:128:in `domain='
    /opt/hostedtoolcache/Ruby/3.0.5/x64/lib/ruby/3.0.0/cgi/cookie.rb:95:in `initialize'
```