### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: 
+        os:
           - ubuntu-latest
-        ruby: 
+        ruby:
           - '2.4'
           - '2.5'
           - '2.6'

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -325,11 +325,11 @@ def call(env)
     headers[ETAG_STRING] = %(W/"#{digest}") if digest
   end
 
-  return [status, headers, body]  
+  return [status, headers, body]
 end
 ```
 
-### Middleware should not directly modify the response body 
+### Middleware should not directly modify the response body
 
 Be aware that the response body might not respond to `#each` and you must now
 check if the body responds to `#each` or not to determine if it is an enumerable

--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -14,7 +14,7 @@ module Rack
   SERVER_NAME       = 'SERVER_NAME'
   SERVER_PORT       = 'SERVER_PORT'
   HTTP_COOKIE       = 'HTTP_COOKIE'
-  
+
   # Response Header Keys
   CACHE_CONTROL     = 'cache-control'
   CONTENT_LENGTH    = 'content-length'

--- a/lib/rack/headers.rb
+++ b/lib/rack/headers.rb
@@ -31,7 +31,7 @@ module Rack
       super(key.downcase.freeze, value)
     end
     alias store []=
-    
+
     def assoc(key)
       super(downcase_key(key))
     end
@@ -43,7 +43,7 @@ module Rack
     def delete(key)
       super(downcase_key(key))
     end
-    
+
     def dig(key, *a)
       super(downcase_key(key), *a)
     end
@@ -52,7 +52,7 @@ module Rack
       key = downcase_key(key)
       super
     end
-    
+
     def fetch_values(*a)
       super(*a.map!{|key| downcase_key(key)})
     end
@@ -63,34 +63,34 @@ module Rack
     alias include? has_key?
     alias key? has_key?
     alias member? has_key?
-    
+
     def invert
       hash = self.class.new
       each{|key, value| hash[value] = key}
       hash
     end
-    
+
     def merge(hash, &block)
       dup.merge!(hash, &block)
     end
-    
+
     def reject(&block)
       hash = dup
       hash.reject!(&block)
       hash
     end
-    
+
     def replace(hash)
       clear
       update(hash)
     end
-    
+
     def select(&block)
       hash = dup
       hash.select!(&block)
       hash
     end
-    
+
     def to_proc
       lambda{|x| self[x]}
     end
@@ -100,10 +100,10 @@ module Rack
     end
 
     def update(hash, &block)
-      hash.each do |key, value| 
+      hash.each do |key, value|
         self[key] = if block_given? && include?(key)
           block.call(key, self[key], value)
-        else 
+        else
           value
         end
       end
@@ -114,7 +114,7 @@ module Rack
     def values_at(*keys)
       keys.map{|key| self[key]}
     end
-    
+
     # :nocov:
     if RUBY_VERSION >= '2.5'
     # :nocov:

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -629,7 +629,7 @@ module Rack
         unless headers.kind_of?(Hash)
           raise LintError, "headers object should be a hash, but isn't (got #{headers.class} as headers)"
         end
-        
+
         if headers.frozen?
           raise LintError, "headers object should not be frozen, but is"
         end
@@ -889,7 +889,7 @@ module Rack
 
         def initialize(stream)
           @stream = stream
-          
+
           REQUIRED_METHODS.each do |method_name|
             raise LintError, "Stream must respond to #{method_name}" unless stream.respond_to?(method_name)
           end

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -44,7 +44,7 @@ module Rack
     @x_forwarded_proto_priority = [:proto, :scheme]
 
     valid_ipv4_octet = /\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])/
-    
+
     trusted_proxies = Regexp.union(
       /\A127#{valid_ipv4_octet}{3}\z/,                          # localhost IPv4 range 127.x.x.x, per RFC-3330
       /\A::1\z/,                                                # localhost IPv6 ::1
@@ -54,7 +54,7 @@ module Rack
       /\A192\.168#{valid_ipv4_octet}{2}\z/,                     # private IPv4 range 192.168.x.x
       /\Alocalhost\z|\Aunix(\z|:)/i,                            # localhost hostname, and unix domain sockets
     )
-    
+
     self.ip_filter = lambda { |ip| trusted_proxies.match?(ip) }
 
     ALLOWED_SCHEMES = %w(https http wss ws).freeze

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -36,7 +36,7 @@ module Rack
     #
     # If the +body+ is +nil+, construct an empty response object with internal
     # buffering.
-    # 
+    #
     # If the +body+ responds to +to_str+, assume it's a string-like object and
     # construct a buffered response object containing using that string as the
     # initial contents of the buffer.
@@ -326,7 +326,7 @@ module Rack
             end
 
             body.close if body.respond_to?(:close)
-            
+
             @buffered = true
           else
             @buffered = false

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -254,7 +254,7 @@ module Rack
     # If the cookie +value+ is an instance of +Hash+, it considers the following
     # cookie attribute keys: +domain+, +max_age+, +expires+ (must be instance
     # of +Time+), +secure+, +http_only+, +same_site+ and +value+. For more
-    # details about the interpretation of these fields, consult 
+    # details about the interpretation of these fields, consult
     # [RFC6265 Section 5.2](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2).
     #
     # An extra cookie attribute +escape_key+ can be provided to control whether

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -277,7 +277,7 @@ describe Rack::Builder do
     it "strips leading unicode byte order mark when present" do
       enc = Encoding.default_external
       begin
-        verbose, $VERBOSE = $VERBOSE, nil 
+        verbose, $VERBOSE = $VERBOSE, nil
         Encoding.default_external = 'UTF-8'
         app, _ = Rack::Builder.parse_file config_file('bom.ru')
         Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'OK'

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -275,7 +275,7 @@ describe Rack::Deflater do
         'PATH_INFO' => '/foo/bar'
       }
     }
-    
+
     app_body3 = [app_body]
     closed = false
     app_body3.define_singleton_method(:close){closed = true}

--- a/test/spec_headers.rb
+++ b/test/spec_headers.rb
@@ -18,7 +18,7 @@ class RackHeadersTest < Minitest::Spec
     assert_empty(headers_methods - hash_methods)
     assert_empty(hash_methods - headers_methods)
   end
-  
+
   def test_class_aref
     assert_equal Hash[], Rack::Headers[]
     assert_equal Hash['a'=>'2'], Rack::Headers['A'=>'2']
@@ -27,7 +27,7 @@ class RackHeadersTest < Minitest::Spec
     assert_raises(ArgumentError){Rack::Headers['A']}
     assert_raises(ArgumentError){Rack::Headers['A',2,'B']}
   end
-    
+
   def test_default_values
     h, ch = Hash.new, Rack::Headers.new
     assert_equal h, ch
@@ -48,29 +48,29 @@ class RackHeadersTest < Minitest::Spec
     assert_equal '3', Rack::Headers.new('3').default
     assert_nil Rack::Headers.new('3').default_proc
     assert_equal '3', Rack::Headers.new('3')['1']
-    
+
     @fh.default = '4'
     assert_equal '4', @fh.default
     assert_nil  @fh.default_proc
     assert_equal '4', @fh['55']
-    
+
     h = Rack::Headers.new('5')
     assert_equal '5', h.default
     assert_nil  h.default_proc
     assert_equal '5', h['55']
-    
+
     h = Rack::Headers.new{|hash, key| '1234'}
     assert_nil  h.default
     refute_equal nil, h.default_proc
     assert_equal '1234', h['55']
-    
+
     h = Rack::Headers.new{|hash, key| hash[key] = '1234'; nil}
     assert_nil  h.default
     refute_equal nil, h.default_proc
     assert_nil  h['Ac']
     assert_equal '1234', h['aC']
   end
-  
+
   def test_store_and_retrieve
     assert_nil  @h['a']
     @h['A'] = '2'
@@ -88,14 +88,14 @@ class RackHeadersTest < Minitest::Spec
     assert_equal '8', @h['c']
     assert_equal '8', @h['C']
   end
-  
+
   def test_clear
     assert_equal 3, @fh.length
     @fh.clear
     assert_equal Hash[], @fh
     assert_equal 0, @fh.length
   end
-  
+
   def test_delete
     assert_equal 3, @fh.length
     assert_equal '1', @fh.delete('aB')
@@ -103,7 +103,7 @@ class RackHeadersTest < Minitest::Spec
     assert_nil @fh.delete('Ab')
     assert_equal 2, @fh.length
   end
-  
+
   def test_delete_if_and_reject
     assert_equal 3, @fh.length
     hash = @fh.reject{|key, value| key == 'ab' || key == 'cd'}
@@ -135,49 +135,49 @@ class RackHeadersTest < Minitest::Spec
     assert_equal '2', h2['a']
     assert_equal '3', h3['b']
   end
-  
+
   def test_each
     i = 0
     @h.each{i+=1}
     assert_equal 0, i
     items = [['ab','1'], ['cd','2'], ['3','4']]
-    @fh.each do |k,v| 
+    @fh.each do |k,v|
       assert items.include?([k,v])
       items -= [[k,v]]
     end
     assert_equal [], items
   end
-  
+
   def test_each_key
     i = 0
     @h.each{i+=1}
     assert_equal 0, i
     keys = ['ab', 'cd', '3']
-    @fh.each_key do |k| 
+    @fh.each_key do |k|
       assert keys.include?(k)
       assert k.frozen?
       keys -= [k]
     end
     assert_equal [], keys
   end
-  
+
   def test_each_value
     i = 0
     @h.each{i+=1}
     assert_equal 0, i
     values = ['1', '2', '4']
-    @fh.each_value do |v| 
+    @fh.each_value do |v|
       assert values.include?(v)
       values -= [v]
     end
     assert_equal [], values
   end
-  
+
   def test_empty
     assert @h.empty?
     assert !@fh.empty?
   end
-  
+
   def test_fetch
     assert_raises(ArgumentError){@h.fetch(1,2,3)}
     assert_raises(ArgumentError){@h.fetch(1,2,3){4}}
@@ -194,7 +194,7 @@ class RackHeadersTest < Minitest::Spec
     assert_equal '4', @fh.fetch("3"){|k| k*3}
     assert_raises(IndexError){Rack::Headers.new{34}.fetch(1)}
   end
-  
+
   def test_has_key
     %i'include? has_key? key? member?'.each do |meth|
       assert !@h.send(meth,1)
@@ -207,7 +207,7 @@ class RackHeadersTest < Minitest::Spec
       assert !@fh.send(meth,1)
     end
   end
-  
+
   def test_has_value
     %i'value? has_value?'.each do |meth|
       assert !@h.send(meth,'1')
@@ -217,14 +217,14 @@ class RackHeadersTest < Minitest::Spec
       assert !@fh.send(meth,'3')
     end
   end
-  
+
   def test_inspect
     %i'inspect to_s'.each do |meth|
       assert_equal '{}', @h.send(meth)
       assert_equal '{"ab"=>"1", "cd"=>"2", "3"=>"4"}', @fh.send(meth)
     end
   end
-  
+
   def test_invert
     assert_kind_of(Rack::Headers, @h.invert)
     assert_equal({}, @h.invert)
@@ -232,19 +232,19 @@ class RackHeadersTest < Minitest::Spec
     assert_equal({'cd'=>'ab'}, Rack::Headers['AB'=>'CD'].invert)
     assert_equal({'cd'=>'xy'}, Rack::Headers['AB'=>'Cd', 'xY'=>'cD'].invert)
   end
-  
+
   def test_keys
     assert_equal [], @h.keys
     assert_equal %w'ab cd 3', @fh.keys
   end
-  
+
   def test_length
     %i'length size'.each do |meth|
       assert_equal 0, @h.send(meth)
       assert_equal 3, @fh.send(meth)
     end
   end
-  
+
   def test_merge_and_update
     assert_equal @h, @h.merge({})
     assert_equal @fh, @fh.merge({})
@@ -263,7 +263,7 @@ class RackHeadersTest < Minitest::Spec
     assert_equal Rack::Headers['ab'=>'abssabss55', 'cd'=>'2', '3'=>'4'], @fh.merge!({'ab'=>'ss'}){|k,ov,nv| [k,nv,ov].join}
     assert_equal Rack::Headers['ab'=>'abssabss55', 'cd'=>'2', '3'=>'4'], @fh
   end
-  
+
   def test_replace
     h = @h.dup
     fh = @fh.dup
@@ -278,7 +278,7 @@ class RackHeadersTest < Minitest::Spec
     assert_equal @h, fh.replace({})
     assert_equal @fh, h.replace('AB'=>'1', 'cd'=>'2', '3'=>'4')
   end
-  
+
   def test_select
     assert_equal({}, @h.select{true})
     assert_equal({}, @h.select{false})
@@ -287,7 +287,7 @@ class RackHeadersTest < Minitest::Spec
     assert_equal({'cd' => '2'}, @fh.select{|k,v| k.start_with?('c')})
     assert_equal({'3' => '4'}, @fh.select{|k,v| v == '4'})
   end
-  
+
   def test_shift
     assert_nil @h.shift
     array = @fh.to_a
@@ -307,29 +307,29 @@ class RackHeadersTest < Minitest::Spec
     assert_equal [], array
     assert_equal 0, i
   end
-  
+
   def test_sort
     assert_equal [], @h.sort
     assert_equal [], @h.sort{|a,b| a.to_s<=>b.to_s}
     assert_equal [['ab', '1'], ['cd', '4'], ['ef', '2']], Rack::Headers['CD','4','AB','1','EF','2'].sort
     assert_equal [['3', '4'], ['ab', '1'], ['cd', '2']], @fh.sort{|(ak,av),(bk,bv)| ak.to_s<=>bk.to_s}
   end
-  
+
   def test_to_a
     assert_equal [], @h.to_a
     assert_equal [['ab', '1'], ['cd', '2'], ['3', '4']], @fh.to_a
   end
-  
+
   def test_to_hash
     assert_equal Hash[], @h.to_hash
     assert_equal Hash['3','4','ab','1','cd','2'], @fh.to_hash
   end
-  
+
   def test_values
     assert_equal [], @h.values
     assert_equal ['f', 'c'], Rack::Headers['aB','f','1','c'].values
   end
-  
+
   def test_values_at
     assert_equal [], @h.values_at()
     assert_equal [nil], @h.values_at(1)

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -291,14 +291,14 @@ describe Rack::Response do
       "foo=bar; domain=example.com.example.com",
       "foo=bar; domain=example.com"
     ]
-    
+
     response.delete_cookie "foo", { domain: "example.com" }
     response["set-cookie"].must_equal [
       "foo=bar; domain=example.com.example.com",
       "foo=bar; domain=example.com",
       "foo=; domain=example.com; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"
     ]
-    
+
     response.delete_cookie "foo", { domain: "example.com.example.com" }
     response["set-cookie"].must_equal [
       "foo=bar; domain=example.com.example.com",


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all in one go, it helps keep future diffs cleaner and eases new contributions by avoiding spurious white space changes on unrelated lines.