### PR TITLE
Allow passing through streaming bodies.

### DIFF
--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -96,7 +96,7 @@ module Rack
     end
 
     def no_entity_body?
-      # The response body is an enumerable body and it is not allowed to have an entity body.,
+      # The response body is an enumerable body and it is not allowed to have an entity body.
       @body.respond_to?(:each) && STATUS_WITH_NO_ENTITY_BODY[@status]
     end
     

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -95,16 +95,9 @@ module Rack
       CHUNKED == get_header(TRANSFER_ENCODING)
     end
 
-    def enumerable_body?
-      @body.respond_to?(:each)
-    end
-
-    def streaming_body?
-      !enumerable_body?
-    end
-
     def no_entity_body?
-      enumerable_body? && STATUS_WITH_NO_ENTITY_BODY[@status]
+      # The response body is an enumerable body and it is not allowed to have an entity body.,
+      @body.respond_to?(:each) && STATUS_WITH_NO_ENTITY_BODY[@status]
     end
     
     # Generate a response array consistent with the requirements of the SPEC.

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -95,11 +95,23 @@ module Rack
       CHUNKED == get_header(TRANSFER_ENCODING)
     end
 
+    def enumerable_body?
+      @body.respond_to?(:each)
+    end
+
+    def streaming_body?
+      !enumerable_body?
+    end
+
+    def no_entity_body?
+      enumerable_body? && STATUS_WITH_NO_ENTITY_BODY[@status]
+    end
+    
     # Generate a response array consistent with the requirements of the SPEC.
     # @return [Array] a 3-tuple suitable of `[status, headers, body]`
     # which is suitable to be returned from the middleware `#call(env)` method.
     def finish(&block)
-      if STATUS_WITH_NO_ENTITY_BODY[@status]
+      if no_entity_body?
         delete_header CONTENT_TYPE
         delete_header CONTENT_LENGTH
         close

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -638,6 +638,16 @@ describe Rack::Response do
     res.body.wont_be :closed?
   end
 
+  it "doesn't clear #body when 101 and streaming" do
+    res = Rack::Response.new
+
+    streaming_body = proc{|stream| stream.close}
+    res.body = streaming_body
+    res.status = 101
+    res.finish
+    res.body.must_equal streaming_body
+  end
+
   it "flatten doesn't cause infinite loop" do
     # https://github.com/rack/rack/issues/419
     res = Rack::Response.new("Hello World")


### PR DESCRIPTION
An alternative to https://github.com/rack/rack/pull/1987 which allows passing through streaming bodies without considering status code (e.g. allowing 101 response with streaming body).