### PR TITLE
Better handling of multipart parsing when request is missing body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### SPEC Changes
+
+- `rack.input` is now optional. ([#1997](https://github.com/rack/rack/pull/1997), [@ioquatix])
+
+### Changed
+
+- Improved handling of multipart requests. `rack.input` is now optional, and if missing, will raise an error which includes `module Rack::BadRequest`. Several other exceptions also include this module. ([#1997](https://github.com/rack/rack/pull/1997), [@ioquatix])
+
 ## [3.0.3] - 2022-12-07
 
 ### Fixed

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -121,7 +121,7 @@ If the string values for CGI keys contain non-ASCII characters,
 they should use ASCII-8BIT encoding.
 There are the following restrictions:
 * <tt>rack.url_scheme</tt> must either be +http+ or +https+.
-* There must be a valid input stream in <tt>rack.input</tt>.
+* There may be a valid input stream in <tt>rack.input</tt>.
 * There must be a valid error stream in <tt>rack.errors</tt>.
 * There may be a valid hijack callback in <tt>rack.hijack</tt>
 * The <tt>REQUEST_METHOD</tt> must be a valid token.

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -15,6 +15,7 @@ require_relative 'rack/version'
 require_relative 'rack/constants'
 
 module Rack
+  autoload :BadRequest, "rack/bad_request"
   autoload :Builder, "rack/builder"
   autoload :BodyProxy, "rack/body_proxy"
   autoload :Cascade, "rack/cascade"

--- a/lib/rack/bad_request.rb
+++ b/lib/rack/bad_request.rb
@@ -1,0 +1,4 @@
+module Rack
+  module BadRequest
+  end
+end

--- a/lib/rack/mock_request.rb
+++ b/lib/rack/mock_request.rb
@@ -41,11 +41,6 @@ module Rack
       end
     end
 
-    DEFAULT_ENV = {
-      RACK_INPUT        => StringIO.new,
-      RACK_ERRORS       => StringIO.new,
-    }.freeze
-
     def initialize(app)
       @app = app
     end
@@ -104,7 +99,7 @@ module Rack
       uri = parse_uri_rfc2396(uri)
       uri.path = "/#{uri.path}" unless uri.path[0] == ?/
 
-      env = DEFAULT_ENV.dup
+      env = {}
 
       env[REQUEST_METHOD]  = (opts[:method] ? opts[:method].to_s.upcase : GET).b
       env[SERVER_NAME]     = (uri.host || "example.org").b
@@ -144,20 +139,21 @@ module Rack
         end
       end
 
-      opts[:input] ||= String.new
       if String === opts[:input]
         rack_input = StringIO.new(opts[:input])
       else
         rack_input = opts[:input]
       end
 
-      rack_input.set_encoding(Encoding::BINARY)
-      env[RACK_INPUT] = rack_input
+      if rack_input
+        rack_input.set_encoding(Encoding::BINARY)
+        env[RACK_INPUT] = rack_input
 
-      env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s if env[RACK_INPUT].respond_to?(:size)
+        env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s if env[RACK_INPUT].respond_to?(:size)
+      end
 
       opts.each { |field, value|
-        env[field] = value  if String === field
+        env[field] = value if String === field
       }
 
       env

--- a/lib/rack/multipart.rb
+++ b/lib/rack/multipart.rb
@@ -6,6 +6,8 @@ require_relative 'utils'
 require_relative 'multipart/parser'
 require_relative 'multipart/generator'
 
+require_relative 'bad_request'
+
 module Rack
   # A multipart form data parser, adapted from IOWA.
   #
@@ -13,9 +15,15 @@ module Rack
   module Multipart
     MULTIPART_BOUNDARY = "AaB03x"
 
+    class MissingInputError < StandardError
+      include BadRequest
+    end
+
     class << self
       def parse_multipart(env, params = Rack::Utils.default_query_parser)
-        io = env[RACK_INPUT]
+        unless io = env[RACK_INPUT]
+          raise MissingInputError, "Missing input stream!"
+        end
 
         if content_length = env['CONTENT_LENGTH']
           content_length = content_length.to_i

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'bad_request'
+
 module Rack
   class QueryParser
     DEFAULT_SEP = /[&] */n
@@ -7,16 +9,22 @@ module Rack
 
     # ParameterTypeError is the error that is raised when incoming structural
     # parameters (parsed by parse_nested_query) contain conflicting types.
-    class ParameterTypeError < TypeError; end
+    class ParameterTypeError < TypeError
+      include BadRequest
+    end
 
     # InvalidParameterError is the error that is raised when incoming structural
     # parameters (parsed by parse_nested_query) contain invalid format or byte
     # sequence.
-    class InvalidParameterError < ArgumentError; end
+    class InvalidParameterError < ArgumentError
+      include BadRequest
+    end
 
     # ParamsTooDeepError is the error that is raised when params are recursively
     # nested over the specified limit.
-    class ParamsTooDeepError < RangeError; end
+    class ParamsTooDeepError < RangeError
+      include BadRequest
+    end
 
     def self.make_default(param_depth_limit)
       new Params, param_depth_limit

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -13,8 +13,12 @@ describe Rack::Lint do
     [200, { "content-type" => "test/plain", "content-length" => "3" }, ["foo"]]
   end
 
-  def env(*args)
-    Rack::MockRequest.env_for("/", *args)
+  def env(options = {})
+    unless options.key?(:input)
+      options[:input] = String.new
+    end
+
+    Rack::MockRequest.env_for("/", options)
   end
 
   it "pass valid request" do

--- a/test/spec_mock_request.rb
+++ b/test/spec_mock_request.rb
@@ -14,7 +14,10 @@ end
 app = Rack::Lint.new(lambda { |env|
   req = Rack::Request.new(env)
 
-  env["mock.postdata"] = env["rack.input"].read
+  if input = env["rack.input"]
+    env["mock.postdata"] = input.read
+  end
+
   if req.GET["error"]
     env["rack.errors"].puts req.GET["error"]
     env["rack.errors"].flush
@@ -46,7 +49,7 @@ describe Rack::MockRequest do
   end
 
   it "should handle a non-GET request with both :input and :params" do
-    env = Rack::MockRequest.env_for("/", method: :post, input: nil, params: {})
+    env = Rack::MockRequest.env_for("/", method: :post, input: "", params: {})
     env["PATH_INFO"].must_equal "/"
     env.must_be_kind_of Hash
     env['rack.input'].read.must_equal ''
@@ -71,7 +74,7 @@ describe Rack::MockRequest do
     env["PATH_INFO"].must_equal "/"
     env["SCRIPT_NAME"].must_equal ""
     env["rack.url_scheme"].must_equal "http"
-    env["mock.postdata"].must_be :empty?
+    env["mock.postdata"].must_be_nil
   end
 
   it "allow GET/POST/PUT/DELETE/HEAD" do
@@ -194,7 +197,7 @@ describe Rack::MockRequest do
     env["QUERY_STRING"].must_include "baz=2"
     env["QUERY_STRING"].must_include "foo%5Bbar%5D=1"
     env["PATH_INFO"].must_equal "/foo"
-    env["mock.postdata"].must_equal ""
+    env["mock.postdata"].must_be_nil
   end
 
   it "accept raw input in params for GET requests" do
@@ -204,7 +207,7 @@ describe Rack::MockRequest do
     env["QUERY_STRING"].must_include "baz=2"
     env["QUERY_STRING"].must_include "foo%5Bbar%5D=1"
     env["PATH_INFO"].must_equal "/foo"
-    env["mock.postdata"].must_equal ""
+    env["mock.postdata"].must_be_nil
   end
 
   it "accept params and build url encoded params for POST requests" do

--- a/test/spec_mock_response.rb
+++ b/test/spec_mock_response.rb
@@ -14,7 +14,10 @@ end
 app = Rack::Lint.new(lambda { |env|
   req = Rack::Request.new(env)
 
-  env["mock.postdata"] = env["rack.input"].read
+  if input = env["rack.input"]
+    env["mock.postdata"] = input.read
+  end
+
   if req.GET["error"]
     env["rack.errors"].puts req.GET["error"]
     env["rack.errors"].flush

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -30,8 +30,7 @@ describe Rack::Multipart do
   end
 
   it "return nil if content type is not multipart" do
-    env = Rack::MockRequest.env_for("/",
-            "CONTENT_TYPE" => 'application/x-www-form-urlencoded')
+    env = Rack::MockRequest.env_for("/", "CONTENT_TYPE" => 'application/x-www-form-urlencoded', :input => "")
     Rack::Multipart.parse_multipart(env).must_be_nil
   end
 
@@ -39,7 +38,14 @@ describe Rack::Multipart do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_filename, "A"*71))
     lambda {
       Rack::Multipart.parse_multipart(env)
-    }.must_raise Rack::Multipart::Error
+    }.must_raise Rack::Multipart::BoundaryTooLongError
+  end
+
+  it "raises a bad request exception if no body is given but content type indicates a multipart body" do
+    env = Rack::MockRequest.env_for("/", "CONTENT_TYPE" => 'multipart/form-data; boundary=BurgerBurger', :input => nil)
+    lambda {
+      Rack::Multipart.parse_multipart(env)
+    }.must_raise Rack::BadRequest
   end
 
   it "parse multipart content when content type present but disposition is not" do

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -113,7 +113,7 @@ class RackRequestTest < Minitest::Spec
   it "wrap the rack variables" do
     req = make_request(Rack::MockRequest.env_for("http://example.com:8080/"))
 
-    req.body.must_respond_to :gets
+    req.body.must_be_nil
     req.scheme.must_equal "http"
     req.request_method.must_equal "GET"
 
@@ -131,7 +131,7 @@ class RackRequestTest < Minitest::Spec
     req.host.must_equal "example.com"
     req.port.must_equal 8080
 
-    req.content_length.must_equal "0"
+    req.content_length.must_be_nil
     req.content_type.must_be_nil
   end
 
@@ -696,9 +696,9 @@ class RackRequestTest < Minitest::Spec
       message.must_equal "invalid %-encoding (a%)"
   end
 
-  it "raise if rack.input is missing" do
+  it "return empty POST data if rack.input is missing" do
     req = make_request({})
-    lambda { req.POST }.must_raise RuntimeError
+    req.POST.must_be_empty
   end
 
   it "parse POST data when method is POST and no content-type given" do


### PR DESCRIPTION
- Introduce `module Rack::BadRequest` for unified exception handling.
- Make `env['rack.input']` optional.

`rack.input` feels like a hangover from the CGI days when `$stdin` was always present and open. But in modern servers, we know that there is no entity body in most cases where it's relevant. However, we still need to allocate something which fails on the first call to `read` (`EOFError`, `IOError` or something else). There is actually no way to detect that there is no entity body. So, I'd like to fix that, as it makes handling the multipart error more straight forward.

If you think there are any other Rack error classes that should include `BadRequest`, please feel free to suggest it.

Fixes #1994. Fixes #1995. Fixes #1996.