### PR TITLE
Fix Regexp deprecated third argument with Regexp::NOENCODING

### DIFF
--- a/lib/rack/urlmap.rb
+++ b/lib/rack/urlmap.rb
@@ -37,7 +37,7 @@ module Rack
         end
 
         location = location.chomp('/')
-        match = Regexp.new("^#{Regexp.quote(location).gsub('/', '/+')}(.*)", nil, 'n')
+        match = Regexp.new("^#{Regexp.quote(location).gsub('/', '/+')}(.*)", Regexp::NOENCODING)
 
         [host, location, match, app]
       }.sort_by do |(host, location, _, _)|


### PR DESCRIPTION
Just upgraded to Ruby 3.2.0 and started seeing this deprecated warning message in my tests.

<img width="1150" alt="CleanShot 2022-12-26 at 12 05 33@2x" src="https://user-images.githubusercontent.com/40255418/209498753-18a54d06-f2a4-40a1-bdda-b2854d863845.png">

Related:
- On Ruby issue tracker
    - [Third argument to Regexp.new is a bit broken](https://bugs.ruby-lang.org/issues/18797)
- [PR](https://github.com/ruby/ruby/pull/6976) that added that deprecated message