### PR TITLE
Replace OpenStruct with Struct

### DIFF
--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -19,6 +19,11 @@ module Rack
   class ShowExceptions
     CONTEXT = 7
 
+    Frame = Struct.new(:filename, :lineno, :function,
+                       :pre_context_lineno, :pre_context,
+                       :context_line, :post_context_lineno,
+                       :post_context)
+
     def initialize(app)
       @app = app
     end
@@ -79,7 +84,7 @@ module Rack
       # This double assignment is to prevent an "unused variable" warning.
       # Yes, it is dumb, but I don't like Ruby yelling at me.
       frames = frames = exception.backtrace.map { |line|
-        frame = OpenStruct.new
+        frame = Frame.new
         if line =~ /(.*?):(\d+)(:in `(.*)')?/
           frame.filename = $1
           frame.lineno = $2.to_i


### PR DESCRIPTION
Using OpenStruct is not recommended from a performance or bug-prone standpoint.

Ref: https://docs.ruby-lang.org/en/3.2/OpenStruct.html#class-OpenStruct-label-Caveats

# Performance

Add `Frame` class by Struct, and replace https://github.com/rack/rack/blob/v3.0.3/lib/rack/show_exceptions.rb#L81-L103 with the following code.

```ruby
require "benchmark"
frames = nil
Benchmark.bm 10 do |r|
  r.report "OpenStruct" do
    frames = frames = exception.backtrace.map { |line|
      frame = OpenStruct.new
      if line =~ /(.*?):(\d+)(:in `(.*)')?/
        frame.filename = $1
        frame.lineno = $2.to_i
        frame.function = $4

        begin
          lineno = frame.lineno - 1
          lines = ::File.readlines(frame.filename)
          frame.pre_context_lineno = [lineno - CONTEXT, 0].max
          frame.pre_context = lines[frame.pre_context_lineno...lineno]
          frame.context_line = lines[lineno].chomp
          frame.post_context_lineno = [lineno + CONTEXT, lines.size].min
          frame.post_context = lines[lineno + 1..frame.post_context_lineno]
        rescue
        end

        frame
      else
        nil
      end
    }.compact
  end

  r.report "Struct" do
    frames = frames = exception.backtrace.map { |line|
      frame = Frame.new
      if line =~ /(.*?):(\d+)(:in `(.*)')?/
        frame.filename = $1
        frame.lineno = $2.to_i
        frame.function = $4

        begin
          lineno = frame.lineno - 1
          lines = ::File.readlines(frame.filename)
          frame.pre_context_lineno = [lineno - CONTEXT, 0].max
          frame.pre_context = lines[frame.pre_context_lineno...lineno]
          frame.context_line = lines[lineno].chomp
          frame.post_context_lineno = [lineno + CONTEXT, lines.size].min
          frame.post_context = lines[lineno + 1..frame.post_context_lineno]
        rescue
        end

        frame
      else
        nil
      end
    }.compact
  end
end
```

Add the following tests to `test/spec_show_exceptions.rb`, then run it.

```ruby
  it "benchmark OpenStruct and Struct" do
    res = nil

    req = Rack::MockRequest.new(
      show_exceptions(
        lambda{|env| raise RuntimeError, "foo", ["nonexistent.rb:2:in `a': adf (RuntimeError)"] * 100 }
      ))

    res = req.get("/", "HTTP_ACCEPT" => "text/html")
  end
```

The result in my environment (Ruby 3.2.0 on macOS Big Sur), is the following.

```
# Running:

                 user     system      total        real
OpenStruct   0.001566   0.000113   0.001679 (  0.001678)
Struct       0.000351   0.000073   0.000424 (  0.000424)
.

Finished in 0.010989s, 91.0001 runs/s, 0.0000 assertions/s.

1 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

A backtrace of about 100 lines is not dramatically slow to begin with, but it is effective.