### PR TITLE
Fix Rack::Lint error message for HTTP_CONTENT_TYPE and HTTP_CONTENT_LENGTH

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -303,7 +303,7 @@ module Rack
         ## (use the versions without <tt>HTTP_</tt>).
         %w[HTTP_CONTENT_TYPE HTTP_CONTENT_LENGTH].each { |header|
           if env.include? header
-            raise LintError, "env contains #{header}, must use #{header[5, -1]}"
+            raise LintError, "env contains #{header}, must use #{header[5..-1]}"
           end
         }
 


### PR DESCRIPTION
Currently it's printing:

```
Rack::Lint::LintError: env contains HTTP_CONTENT_TYPE, must use
```

Which had me puzzled for quite a while.