### PR TITLE
`Rack::Request#POST` should consistently raise errors.

### DIFF
--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -55,6 +55,7 @@ module Rack
   RACK_REQUEST_FORM_INPUT             = 'rack.request.form_input'
   RACK_REQUEST_FORM_HASH              = 'rack.request.form_hash'
   RACK_REQUEST_FORM_VARS              = 'rack.request.form_vars'
+  RACK_REQUEST_FORM_ERROR             = 'rack.request.form_error'
   RACK_REQUEST_COOKIE_HASH            = 'rack.request.cookie_hash'
   RACK_REQUEST_COOKIE_STRING          = 'rack.request.cookie_string'
   RACK_REQUEST_QUERY_HASH             = 'rack.request.query_hash'

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -497,7 +497,7 @@ module Rack
       # multipart/form-data.
       def POST
         if error = get_header(RACK_REQUEST_FORM_ERROR)
-          raise error
+          raise error.class, error.message, cause: error
         end
 
         begin

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -496,26 +496,35 @@ module Rack
       # This method support both application/x-www-form-urlencoded and
       # multipart/form-data.
       def POST
-        if get_header(RACK_INPUT).nil?
-          raise "Missing rack.input"
-        elsif get_header(RACK_REQUEST_FORM_INPUT) == get_header(RACK_INPUT)
-          get_header(RACK_REQUEST_FORM_HASH)
-        elsif form_data? || parseable_data?
-          unless set_header(RACK_REQUEST_FORM_HASH, parse_multipart)
-            form_vars = get_header(RACK_INPUT).read
+        if error = get_header(RACK_REQUEST_FORM_ERROR)
+          raise error
+        end
 
-            # Fix for Safari Ajax postings that always append \0
-            # form_vars.sub!(/\0\z/, '') # performance replacement:
-            form_vars.slice!(-1) if form_vars.end_with?("\0")
+        begin
+          if get_header(RACK_INPUT).nil?
+            raise "Missing rack.input"
+          elsif get_header(RACK_REQUEST_FORM_INPUT) == get_header(RACK_INPUT)
+            get_header(RACK_REQUEST_FORM_HASH)
+          elsif form_data? || parseable_data?
+            unless set_header(RACK_REQUEST_FORM_HASH, parse_multipart)
+              form_vars = get_header(RACK_INPUT).read
 
-            set_header RACK_REQUEST_FORM_VARS, form_vars
-            set_header RACK_REQUEST_FORM_HASH, parse_query(form_vars, '&')
+              # Fix for Safari Ajax postings that always append \0
+              # form_vars.sub!(/\0\z/, '') # performance replacement:
+              form_vars.slice!(-1) if form_vars.end_with?("\0")
+
+              set_header RACK_REQUEST_FORM_VARS, form_vars
+              set_header RACK_REQUEST_FORM_HASH, parse_query(form_vars, '&')
+            end
+            set_header RACK_REQUEST_FORM_INPUT, get_header(RACK_INPUT)
+            get_header RACK_REQUEST_FORM_HASH
+          else
+            set_header RACK_REQUEST_FORM_INPUT, get_header(RACK_INPUT)
+            set_header(RACK_REQUEST_FORM_HASH, {})
           end
-          set_header RACK_REQUEST_FORM_INPUT, get_header(RACK_INPUT)
-          get_header RACK_REQUEST_FORM_HASH
-        else
-          set_header RACK_REQUEST_FORM_INPUT, get_header(RACK_INPUT)
-          set_header(RACK_REQUEST_FORM_HASH, {})
+        rescue => error
+          set_header(RACK_REQUEST_FORM_ERROR, error)
+          raise
         end
       end
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -497,7 +497,7 @@ module Rack
       # multipart/form-data.
       def POST
         if error = get_header(RACK_REQUEST_FORM_ERROR)
-          raise error.class, error.message, cause: error
+          raise error.class, error.message, cause: error.cause
         end
 
         begin

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1218,6 +1218,22 @@ class RackRequestTest < Minitest::Spec
       req.media_type_params['weird'].must_equal 'lol"'
   end
 
+  it "returns the same error for invalid post inputs" do
+    env = {
+      'REQUEST_METHOD' => 'POST',
+      'PATH_INFO' => '/foo',
+      'rack.input' => StringIO.new('invalid=bar&invalid[foo]=bar'),
+      'HTTP_CONTENT_TYPE' => "application/x-www-form-urlencoded",
+    }
+    
+    2.times do
+      # The actual exception type here is unimportant - just that it fails.
+      assert_raises(Rack::Utils::ParameterTypeError) do
+        Rack::Request.new(env).POST
+      end
+    end
+  end
+
   it "parse with junk before boundary" do
     # Adapted from RFC 1867.
     input = <<EOF


### PR DESCRIPTION
Cache errors that occur when invoking `Rack::Request#POST` so they can be raised again later (consistently).

I propose we backport this to `3-0-stable` as this is a regression on 2.2 behaviour.

Fixes <https://github.com/rack/rack/issues/2009>.