### PR TITLE
[2.2-stable] Rack::MethodOverride handle QueryParser::ParamsTooDeepError

### DIFF
--- a/lib/rack/method_override.rb
+++ b/lib/rack/method_override.rb
@@ -43,7 +43,7 @@ module Rack
 
     def method_override_param(req)
       req.POST[METHOD_OVERRIDE_PARAM_KEY]
-    rescue Utils::InvalidParameterError, Utils::ParameterTypeError
+    rescue Utils::InvalidParameterError, Utils::ParameterTypeError, QueryParser::ParamsTooDeepError
       req.get_header(RACK_ERRORS).puts "Invalid or incomplete POST params"
     rescue EOFError
       req.get_header(RACK_ERRORS).puts "Bad request content body"

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -100,6 +100,13 @@ EOF
     env[Rack::RACK_ERRORS].read.must_match /Bad request content body/
   end
 
+  it "not modify REQUEST_METHOD for POST requests when the params are unparseable because too deep" do
+    env = Rack::MockRequest.env_for("/", method: "POST", input: ("[a]" * 36) + "=1")
+    app.call env
+
+    env["REQUEST_METHOD"].must_equal "POST"
+  end
+
   it "not modify REQUEST_METHOD for POST requests when the params are unparseable" do
     env = Rack::MockRequest.env_for("/", method: "POST", input: "(%bad-params%)")
     app.call env


### PR DESCRIPTION
Backport: https://github.com/rack/rack/pull/2006

This middleware already handle two types of parsing issues but somehow not this one.

As discussed with @ioquatix 