### PR TITLE
Fix a mistake in a spec name

### DIFF
--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -106,14 +106,14 @@ EOF
     env[Rack::RACK_ERRORS].read.must_include 'Bad request content body'
   end
 
-  it "not modify REQUEST_METHOD for POST requests when the params are unparseable" do
+  it "not modify REQUEST_METHOD for POST requests when the params are unparseable because too deep" do
     env = Rack::MockRequest.env_for("/", method: "POST", input: ("[a]" * 36) + "=1")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "POST"
   end
 
-  it "not modify REQUEST_METHOD for POST requests when the params are unparseable because too deep" do
+  it "not modify REQUEST_METHOD for POST requests when the params are unparseable" do
     env = Rack::MockRequest.env_for("/", method: "POST", input: "(%bad-params%)")
     app.call env
 


### PR DESCRIPTION
Followup: https://github.com/rack/rack/pull/2006

I renamed the wrong spec.

cc @ioquatix 