### PR TITLE
This behaviour is not the same as Rack 2.x - is that acceptable?

### DIFF
--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -572,11 +572,27 @@ class RackRequestTest < Minitest::Spec
   end
 
   it "parse the query string" do
-    req = make_request(Rack::MockRequest.env_for("/?foo=bar&quux=bla"))
-    req.query_string.must_equal "foo=bar&quux=bla"
-    req.GET.must_equal "foo" => "bar", "quux" => "bla"
-    req.POST.must_be :empty?
-    req.params.must_equal "foo" => "bar", "quux" => "bla"
+    request = make_request(Rack::MockRequest.env_for("/?foo=bar&quux=bla"))
+    request.query_string.must_equal "foo=bar&quux=bla"
+    request.GET.must_equal "foo" => "bar", "quux" => "bla"
+    request.POST.must_be :empty?
+    request.params.must_equal "foo" => "bar", "quux" => "bla"
+  end
+
+  it "handles invalid unicode in query string value" do
+    request = make_request(Rack::MockRequest.env_for(qs = "/?foo=%81E"))
+    request.query_string.must_equal "foo=%81E"
+    request.GET.must_equal "foo" => "\x81E"
+    request.POST.must_be :empty?
+    request.params.must_equal "foo" => "\x81E"
+  end
+
+  it "handles invalid unicode in query string key" do
+    request = make_request(Rack::MockRequest.env_for("/?foo%81E=1"))
+    request.query_string.must_equal "foo%81E=1"
+    request.GET.must_equal "foo\x81E" => "1"
+    request.POST.must_be :empty?
+    request.params.must_equal "foo\x81E" => "1"
   end
 
   it "not truncate query strings containing semi-colons #543 only in POST" do

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -240,9 +240,10 @@ describe Rack::Utils do
     lambda { Rack::Utils.parse_nested_query("x[y]=1&x[y][][w]=2") }.
       must_raise(Rack::Utils::ParameterTypeError).
       message.must_equal "expected Array (got String) for param `y'"
+  end
 
-    Rack::Utils.parse_nested_query("foo%81E=1").
-      must_equal "foo\x81E"=>"1"
+  it "can parse a query string with a key that has invalid UTF-8 encoded bytes" do
+    Rack::Utils.parse_nested_query("foo%81E=1").must_equal "foo\x81E"=>"1"
   end
 
   it "only moves to a new array when the full key has been seen" do


### PR DESCRIPTION
URI specifications mostly assume UTF-8 encoded URIs.

I don't have a strong opinion, but these tests confirm the current implementation behaviour - i.e. invalid UTF-8 attribute keys and values in the query string is acceptable.

Do we want to be more strict?