### PR TITLE
Correct the year number in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [2.2.6.2] - 2022-01-17
+## [2.2.6.2] - 2023-01-17
 
 - [CVE-2022-44570] Fix ReDoS in Rack::Utils.get_byte_ranges
 
-## [2.2.6.1] - 2022-01-17
+## [2.2.6.1] - 2023-01-17
 
 - [CVE-2022-44571] Fix ReDoS vulnerability in multipart parser
 - [CVE-2022-44572] Forbid control characters in attributes (also ReDoS)
 
-## [2.2.6] - 2022-01-17
+## [2.2.6] - 2023-01-17
 
 - Extend `Rack::MethodOverride` to handle `QueryParser::ParamsTooDeepError` error. ([#2011](https://github.com/rack/rack/pull/2011), [@byroot](https://github.com/byroot))
 


### PR DESCRIPTION
Hello.

Regarding the changelog in v.2.2.6, I think the year is incorrect.
I think 2023 is correct.

