### PR TITLE
Remove single-character classes from query parser

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -4,8 +4,8 @@ require_relative 'bad_request'
 
 module Rack
   class QueryParser
-    DEFAULT_SEP = /[&] */n
-    COMMON_SEP = { ";" => /[;] */n, ";," => /[;,] */n, "&" => /[&] */n }
+    DEFAULT_SEP = /& */n
+    COMMON_SEP = { ";" => /; */n, ";," => /[;,] */n, "&" => /& */n }
 
     # ParameterTypeError is the error that is raised when incoming structural
     # parameters (parsed by parse_nested_query) contain conflicting types.


### PR DESCRIPTION
When studying the code for how Rack handles parsing query strings, I was confused as to why there were character classes of a single character. Looking through the Git history this seemed to be because the original splitter split on both ampersands and semicolons and the style was kept around so they all _looked_ the same even though some of the others were single-character classes.

After checking that all of the tests passed, I was curious if there was any performance difference. There isn't, likely because there's no capture involved.

This change drops the redundant character classes to make it so no one else is confused by the presence of the character classes.