### PR TITLE
Remove outdated contributing guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,15 +27,6 @@ git pull upstream main
 git checkout -b my-feature-branch
 ```
 
-## Bundle Install and Quick Test
-
-Ensure that you can build the project and run quick tests.
-
-```
-bundle install --without extra
-bundle exec rake test
-```
-
 ## Running All Tests
 
 Install all dependencies.


### PR DESCRIPTION
There hasn't been an "extras" group in the Gemfile since 2020-05-25 so the step that mentions it hasn't been needed for almost two years. Also, since Bundler is deprecating the "without" behavior, modern Rubies issue a warning with their default version of Bundler.