### PR TITLE
add SSL_ variables description to the rack spec

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -71,6 +71,9 @@ below.
                            request. See
                            {RFC3875 section 4.1.18}[https://tools.ietf.org/html/rfc3875#section-4.1.18]
                            for specific behavior.
+<tt>SSL_</tt> Variables:: If TLS is in use, these variables correspond to the
+                          server or gateway-supplied SSL-related variables, as defined by
+                          {Apache mod_ssl}[http://www.modssl.org/docs/2.8/ssl_reference.html#ToC25].
 In addition to this, the Rack environment must include these
 Rack-specific variables:
 <tt>rack.url_scheme</tt>:: +http+ or +https+, depending on the


### PR DESCRIPTION
While they should already "just work", the spec still lacks definition about what their special meaning. This is in contrast to [PEP-0333](https://peps.python.org/pep-0333/), where it is clearly stated that these belong to the mod_ssl family of SSL vars.

This follow [this MR in webrick](https://github.com/ruby/webrick/pull/107).

Discussed in https://github.com/rack/rack/discussions/2028