### PR TITLE
Enhance documentation in `builder.rb`

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -53,12 +53,12 @@ module Rack
     #   Rack::Builder.parse_file('app.rb')
     #   # requires app.rb, which can be anywhere in Ruby's
     #   # load path. After requiring, assumes App constant
-    #   # contains Rack application
+    #   # is a Rack application
     #
     #   Rack::Builder.parse_file('./my_app.rb')
     #   # requires ./my_app.rb, which should be in the
     #   # process's current directory.  After requiring,
-    #   # assumes MyApp constant contains Rack application
+    #   # assumes MyApp constant is a Rack application
     def self.parse_file(path)
       if path.end_with?('.ru')
         return self.load_file(path)


### PR DESCRIPTION
> After requiring, assumes App constant contains Rack application
> After requiring, assumes MyApp constant contains Rack application

~Since we assume these constants contain Rack applications and are not ones, the comments should `run` instances of these classes and not the classes themselves.~

EDIT: The word `contains` is replaced by `is a` for more clarity.