### PR TITLE
Avoid rebuilding regex per-request part

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -225,6 +225,7 @@ module Rack
 
         @sbuf = StringScanner.new("".dup)
         @body_regex = /(?:#{EOL}|\A)--#{Regexp.quote(boundary)}(?:#{EOL}|--)/m
+        @body_regex_at_end = /#{@body_regex}\z/m
         @rx_max_size = boundary.bytesize + 6 # (\r\n-- at start, either \r\n or -- at finish)
         @head_regex = /(.*?#{EOL})#{EOL}/m
       end
@@ -334,7 +335,7 @@ module Rack
 
       def handle_mime_body
         if (body_with_boundary = @sbuf.check_until(@body_regex)) # check but do not advance the pointer yet
-          body = body_with_boundary.sub(/#{@body_regex}\z/m, '') # remove the boundary from the string
+          body = body_with_boundary.sub(@body_regex_at_end, '') # remove the boundary from the string
           @collector.on_mime_body @mime_index, body
           @sbuf.pos += body.length + 2 # skip \r\n after the content
           @state = :CONSUME_TOKEN


### PR DESCRIPTION
This was spotted while working on CVE-2023-27530 (https://github.com/rack/rack/commit/8e8869d625e73e16b576b6d31b50208e9ec8002f), though itself not a security issue (we chose not to include it in the patch release).

Previously we would rebuild this regex once per-part. We can instead compile it once per-request, which can save significant processing time on requests with many parts.