### PR TITLE
Add frozen_string_literal magic comment to all .rb files

### DIFF
--- a/lib/rack/bad_request.rb
+++ b/lib/rack/bad_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Represents a 400 Bad Request error when input data fails to meet the
   # requirements.

--- a/lib/rack/headers.rb
+++ b/lib/rack/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   # Rack::Headers is a Hash subclass that downcases all keys.  It's designed
   # to be used by rack applications that don't implement the Rack 3 SPEC

--- a/test/psych_fix.rb
+++ b/test/psych_fix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Work correctly with older versions of Psych, having
 # unsafe_load call load (in older versions, load operates
 # as unsafe_load in current version).


### PR DESCRIPTION
The PR title says it all, and tests are green on my machine.

There are four Strings that'll be frozen with this change:
`"odd number of arguments for Rack::Headers"`, `"Rack::Headers cannot compare by identity, use regular Hash"`, `'2.5'`, `'3.0'`, and I don't think this would break anything.