### PR TITLE
Add `QueryParser#missing_value` for handling missing values + tests.

### DIFF
--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -41,6 +41,7 @@ module Rack
   autoload :MethodOverride, "rack/method_override"
   autoload :Mime, "rack/mime"
   autoload :NullLogger, "rack/null_logger"
+  autoload :QueryParser, "rack/query_parser"
   autoload :Recursive, "rack/recursive"
   autoload :Reloader, "rack/reloader"
   autoload :RewindableInput, "rack/rewindable_input"

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'bad_request'
+require 'uri'
 
 module Rack
   class QueryParser
@@ -111,6 +112,14 @@ module Rack
       _normalize_params(params, name, v, 0)
     end
 
+    # This value is used by default when a parameter is missing (nil). This
+    # usually happens when a parameter is specified without an `=value` part.
+    # The default value is an empty string, but this can be overridden by
+    # subclasses.
+    def missing_value
+      String.new
+    end
+
     private def _normalize_params(params, name, v, depth)
       raise ParamsTooDeepError if depth >= param_depth_limit
 
@@ -145,7 +154,7 @@ module Rack
 
       return if k.empty?
 
-      v ||= String.new
+      v ||= missing_value
 
       if after == ''
         if k == '[]' && depth != 0
@@ -207,8 +216,8 @@ module Rack
       true
     end
 
-    def unescape(s)
-      Utils.unescape(s)
+    def unescape(string, encoding = Encoding::UTF_8)
+      URI.decode_www_form_component(string, encoding)
     end
 
     class Params < Hash

--- a/test/spec_query_parser.rb
+++ b/test/spec_query_parser.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+separate_testing do
+  require_relative '../lib/rack/query_parser'
+end
+
+describe Rack::QueryParser do
+  def query_parser
+    @query_parser ||= Rack::QueryParser.new(Rack::QueryParser::Params, 8)
+  end
+
+  it "has a default value" do
+    assert_equal "", query_parser.missing_value
+  end
+
+  it "can normalize values with missing values" do
+    query_parser.parse_nested_query("a=a").must_equal({"a" => "a"})
+    query_parser.parse_nested_query("a=").must_equal({"a" => ""})
+    query_parser.parse_nested_query("a").must_equal({"a" => ""})
+  end
+
+  it "can override default missing value" do
+    def query_parser.missing_value
+      nil
+    end
+
+    query_parser.parse_nested_query("a=a").must_equal({"a" => "a"})
+    query_parser.parse_nested_query("a=").must_equal({"a" => ""})
+    query_parser.parse_nested_query("a").must_equal({"a" => nil})
+  end
+end


### PR DESCRIPTION
This is required for customizing how `Rack::QueryParser` handles missing values and make it easy for sub-classes to change this behaviour. Based on <https://github.com/rack/rack/pull/2038#issuecomment-1436060688>.

For the purpose of Rails:

```ruby
module ActionDispatch
  class Request
    # ...
    if Rack.release >= "3"
      class QueryParser < ::Rack::QueryParser
        def missing_value
          nil
        end
      end

      def query_parser
        QueryParser
      end
    end
```

A different design option would be to make this an argument, e.g. `QueryParser.new(missing_value: nil)`.

cc @matthewd @tenderlove 