### PR TITLE
Revert the unapproved QueryParser#unescape change

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'bad_request'
-require 'uri'
 
 module Rack
   class QueryParser
@@ -216,8 +215,8 @@ module Rack
       true
     end
 
-    def unescape(string, encoding = Encoding::UTF_8)
-      URI.decode_www_form_component(string, encoding)
+    def unescape(s)
+      Utils.unescape(s) 
     end
 
     class Params < Hash
@@ -225,3 +224,5 @@ module Rack
     end
   end
 end
+
+require_relative 'utils' unless defined?(Rack::Utils)

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -7,7 +7,6 @@ require 'set'
 require 'tempfile'
 require 'time'
 
-require_relative 'query_parser'
 require_relative 'mime'
 require_relative 'headers'
 require_relative 'constants'
@@ -17,6 +16,8 @@ module Rack
   # applications adopted from all kinds of Ruby libraries.
 
   module Utils
+    require_relative 'query_parser' unless defined?(QueryParser)
+
     ParameterTypeError = QueryParser::ParameterTypeError
     InvalidParameterError = QueryParser::InvalidParameterError
     ParamsTooDeepError = QueryParser::ParamsTooDeepError


### PR DESCRIPTION
This change was only made because @ioquatix couldn't figure out how to make the tests pass without the change.  This reverts the code and fixes the tests.