### PR TITLE
Add mjs MIME type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. For info on
 - `rack.input` is now optional, and if missing, will raise an error. Use this to fail on multipart parsing a request without an input body. ([#2018](https://github.com/rack/rack/pull/2018), [@ioquatix])
 - Introduce `module Rack::BadRequest` which is included in multipart and query parser errors. ([#2019](https://github.com/rack/rack/pull/2019), [@ioquatix])
 - MIME type for JavaScript files (`.js`) changed from `application/javascript` to `text/javascript` ([`1bd0f15`](https://github.com/rack/rack/commit/1bd0f1597d8f4a90d47115f3e156a8ce7870c9c8))
+- Add `.mjs` MIME type ([#2057](https://github.com/rack/rack/pull/2057), [@axilleas])
 
 ## [3.0.4.1] - 2023-01-17
 

--- a/lib/rack/mime.rb
+++ b/lib/rack/mime.rb
@@ -338,6 +338,7 @@ module Rack
       ".mif"       => "application/vnd.mif",
       ".mime"      => "message/rfc822",
       ".mj2"       => "video/mj2",
+      ".mjs"       => "text/javascript",
       ".mlp"       => "application/vnd.dolby.mlp",
       ".mmd"       => "application/vnd.chipnuts.karaoke-mmd",
       ".mmf"       => "application/vnd.smaf",


### PR DESCRIPTION
`mjs` is a JavaScript module and has the same MIME type as JavaScript. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types.