### PR TITLE
Rack request cache key

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -523,7 +523,7 @@ module Rack
       # behaviour. This includes sub-classes that override query_parser or
       # expand_params.
       def cache_key
-        query_parser.class
+        query_parser
       end
 
       # Given a current input value, and a validity key, check if the cache
@@ -560,7 +560,8 @@ module Rack
 
         # If the cache was not defined for this cache key, then create a new cache:
         unless cache
-          set_header(key, cache = {})
+          cache = Hash.new.compare_by_identity
+          set_header(key, cache)
         end
 
         begin


### PR DESCRIPTION
There were concerns that the caching based on the class may cause unexpected behaviour: https://github.com/rack/rack/pull/2056#discussion_r1137372892

So we change to cache based on the identity of the object.

This still has some short-comings, e.g. it's easy to modify the query parser AFTER it's used which won't invalidate the cache, but I think no matter how you cut this, the problem still exists.