### PR TITLE
Do not allow BodyProxy to respond to to_ary or to_str

### DIFF
--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -16,7 +16,7 @@ module Rack
     # Return whether the wrapped body responds to the method.
     def respond_to_missing?(method_name, include_all = false)
       case method_name
-      when :to_str, :to_ary
+      when :to_str
         false
       else
         super or @body.respond_to?(method_name, include_all)
@@ -44,8 +44,14 @@ module Rack
     # Delegate missing methods to the wrapped body.
     def method_missing(method_name, *args, &block)
       case method_name
-      when :to_str, :to_ary
+      when :to_str
         super
+      when :to_ary
+        begin
+          @body.__send__(method_name, *args, &block)
+        ensure
+          close
+        end
       else
         @body.__send__(method_name, *args, &block)
       end

--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -15,7 +15,12 @@ module Rack
 
     # Return whether the wrapped body responds to the method.
     def respond_to_missing?(method_name, include_all = false)
-      super or @body.respond_to?(method_name, include_all)
+      case method_name
+      when :to_str, :to_ary
+        false
+      else
+        super or @body.respond_to?(method_name, include_all)
+      end
     end
 
     # If not already closed, close the wrapped body and
@@ -38,7 +43,12 @@ module Rack
 
     # Delegate missing methods to the wrapped body.
     def method_missing(method_name, *args, &block)
-      @body.__send__(method_name, *args, &block)
+      case method_name
+      when :to_str, :to_ary
+        super
+      else
+        @body.__send__(method_name, *args, &block)
+      end
     end
     # :nocov:
     ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -74,8 +74,17 @@ describe Rack::BodyProxy do
     proxy.banana(foo: 1).must_equal 1
   end
 
-  it 'not respond to :to_ary' do
-    proxy = Rack::BodyProxy.new([]) { }
+  it 'respond to :to_ary if body does responds to it, and have to_ary call close' do
+    proxy_closed = false
+    proxy = Rack::BodyProxy.new([]) { proxy_closed = true }
+    proxy.respond_to?(:to_ary).must_equal true
+    proxy_closed.must_equal false
+    proxy.to_ary.must_equal []
+    proxy_closed.must_equal true
+  end
+
+  it 'not respond to :to_ary if body does not respond to it' do
+    proxy = Rack::BodyProxy.new([].map) { }
     proxy.respond_to?(:to_ary).must_equal false
     proc do
       proxy.to_ary

--- a/test/spec_body_proxy.rb
+++ b/test/spec_body_proxy.rb
@@ -75,12 +75,27 @@ describe Rack::BodyProxy do
   end
 
   it 'not respond to :to_ary' do
-    body = Object.new.tap { |o| def o.to_ary() end }
-    body.respond_to?(:to_ary).must_equal true
+    proxy = Rack::BodyProxy.new([]) { }
+    proxy.respond_to?(:to_ary).must_equal false
+    proc do
+      proxy.to_ary
+    end.must_raise NoMethodError
+  end
 
-    proxy = Rack::BodyProxy.new(body) { }
-    x = [proxy]
-    assert_equal x, x.flatten
+  it 'not respond to :to_str' do
+    proxy = Rack::BodyProxy.new("string body") { }
+    proxy.respond_to?(:to_str).must_equal false
+    proc do
+      proxy.to_str
+    end.must_raise NoMethodError
+  end
+
+  it 'not respond to :to_path if body does not respond to it' do
+    proxy = Rack::BodyProxy.new("string body") { }
+    proxy.respond_to?(:to_path).must_equal false
+    proc do
+      proxy.to_path
+    end.must_raise NoMethodError
   end
 
   it 'not close more than one time' do


### PR DESCRIPTION
This methods could trigger different behavior in rack that is undesired when using BodyProxy.  When using BodyProxy, you always want the caller to iterate through the body using each.

See https://github.com/rack/rack-test/issues/335 for an example where allowing BodyProxy to respond to to_str (when provided an invalid rack body) complicated debugging.

BodyProxy already had a spec with a description "not respond to :to_ary".  While you would assume that this checked whether the body actually responded to to_ary, it did not.  This fixes that, making sure that respond_to?(:to_ary) is false, and calling to_ary raises a NoMethodError.  It adds a similar spec for to_str.