### PR TITLE
Support underscore in host names for Rack 2.2 (Fixes #2070)

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -608,7 +608,7 @@ module Rack
           (?<ip4>[\d\.]+)
           |
           # A hostname:
-          (?<name>[a-zA-Z0-9\.\-]+)
+          (?<name>[a-zA-Z0-9\.\-_]+)
         )
         # The optional port:
         (:(?<port>\d+))?

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -122,6 +122,11 @@ class RackRequestTest < Minitest::Spec
     req.hostname.must_equal "123foo.example.com"
 
     req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "some_service:3001")
+    req.host.must_equal "some_service"
+    req.hostname.must_equal "some_service"
+
+    req = make_request \
       Rack::MockRequest.env_for("/", "SERVER_NAME" => "example.org", "SERVER_PORT" => "9292")
     req.host.must_equal "example.org"
     req.hostname.must_equal "example.org"
@@ -155,6 +160,10 @@ class RackRequestTest < Minitest::Spec
     req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "www2.example.org:81")
     req.port.must_equal 81
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "some_service:3001")
+    req.port.must_equal 3001
 
     req = make_request \
       Rack::MockRequest.env_for("/", "SERVER_NAME" => "example.org", "SERVER_PORT" => "9292")


### PR DESCRIPTION
This makes Rack 2.2 behavior similar to Rack 2.1 and Rack 3.0 in regards to underscore in host names.