### PR TITLE
adding middleware to use CloudFront-Forwarded-Proto in CSRF

### DIFF
--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -19,6 +19,7 @@ module Rack
   autoload :Builder, "rack/builder"
   autoload :BodyProxy, "rack/body_proxy"
   autoload :Cascade, "rack/cascade"
+  autoload :CloudfrontHttpsHeader, "rack/cloudfront_https_header"
   autoload :CommonLogger, "rack/common_logger"
   autoload :ConditionalGet, "rack/conditional_get"
   autoload :Config, "rack/config"

--- a/lib/rack/cloudfront_https_header.rb
+++ b/lib/rack/cloudfront_https_header.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Rack
+
+  # Middleware to set the X-Forwarded-Proto header to the value
+  # of the CloudFront-Forwarded-Proto header.
+  #
+  # AWS Cloudfront sets this header for you https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/adding-cloudfront-headers.html#cloudfront-headers-other
+  # and it can be used to ensure the scheme matches when comparing
+  # request.origin and request.base_url for CSRF checking.
+  class CloudfrontHttpsHeader
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      return @app.call(env) unless env['CloudFront-Forwarded-Proto']
+
+      env['HTTP_X_FORWARDED_PROTO'] = env['CloudFront-Forwarded-Proto']
+
+      @app.call(env)
+    end
+  end
+end

--- a/test/spec_cloudfront_https_header.rb
+++ b/test/spec_cloudfront_https_header.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+separate_testing do
+  require_relative '../lib/rack/lint'
+  require_relative '../lib/rack/mock_request'
+end
+
+describe Rack::CloudfrontHttpsHeader do
+  def cloudfront_https_header(app)
+    Rack::Lint.new Rack::CloudfrontHttpsHeader.new(app)
+  end
+
+  def app
+    Rack::Lint.new(Rack::CloudfrontHttpsHeader.new(lambda {|e|
+      [200, { "content-type" => "text/plain" }, []]
+    }))
+  end
+
+  it "does nothing if there is no Cloudfront header" do
+    env = Rack::MockRequest.env_for("/", "HTTP_X_FORWARDED_PROTO" => "http")
+    app.call env
+    env["HTTP_X_FORWARDED_PROTO"].must_equal "http"
+  end
+
+  it "copies the Cloudfront header value to X-Forwarded-Proto" do
+
+    env = Rack::MockRequest.env_for("/", "CloudFront-Forwarded-Proto" => "https")
+    app.call env
+    env["HTTP_X_FORWARDED_PROTO"].must_equal "https"
+  end
+end


### PR DESCRIPTION
In response to https://github.com/rack/rack/issues/2080 is this the kind of thing you would find acceptable?