### PR TITLE
Backport "Fix some unused variable verbose warnings"

### DIFF
--- a/lib/rack/sendfile.rb
+++ b/lib/rack/sendfile.rb
@@ -111,7 +111,7 @@ module Rack
     end
 
     def call(env)
-      status, headers, body = response = @app.call(env)
+      _, headers, body = response = @app.call(env)
 
       if body.respond_to?(:to_path)
         case type = variation(env)

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -478,7 +478,7 @@ describe Rack::Lint do
     def body.to_path; __FILE__ end
     app = lambda { |env| [200, {}, body] }
 
-    status, headers, body = Rack::Lint.new(app).call(env({}))
+    body = Rack::Lint.new(app).call(env({}))[2]
     body.must_respond_to(:to_path)
     body.to_path.must_equal __FILE__
   end


### PR DESCRIPTION
Fixes `/usr/local/bundle/gems/rack-3.0.7/lib/rack/sendfile.rb:114: warning: assigned but unused variable - status`