### PR TITLE
When parsing a multi-part POST, retain original pairs

### DIFF
--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -54,6 +54,7 @@ module Rack
   RACK_RESPONSE_FINISHED              = 'rack.response_finished'
   RACK_REQUEST_FORM_INPUT             = 'rack.request.form_input'
   RACK_REQUEST_FORM_HASH              = 'rack.request.form_hash'
+  RACK_REQUEST_FORM_PAIRS             = 'rack.request.form_pairs'
   RACK_REQUEST_FORM_VARS              = 'rack.request.form_vars'
   RACK_REQUEST_FORM_ERROR             = 'rack.request.form_error'
   RACK_REQUEST_COOKIE_HASH            = 'rack.request.cookie_hash'

--- a/lib/rack/multipart.rb
+++ b/lib/rack/multipart.rb
@@ -19,6 +19,31 @@ module Rack
       include BadRequest
     end
 
+    # Accumulator for multipart form data, conforming to the QueryParser API.
+    # In future, the Parser could return the pair list directly, but that would
+    # change its API.
+    class ParamList # :nodoc:
+      def self.make_params
+        new
+      end
+
+      def self.normalize_params(params, key, value)
+        params << [key, value]
+      end
+
+      def initialize
+        @pairs = []
+      end
+
+      def <<(pair)
+        @pairs << pair
+      end
+
+      def to_params_hash
+        @pairs
+      end
+    end
+
     class << self
       def parse_multipart(env, params = Rack::Utils.default_query_parser)
         unless io = env[RACK_INPUT]

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1359,6 +1359,8 @@ EOF
     f[:filename].must_equal "dj.jpg"
     f.must_include :tempfile
     f[:tempfile].size.must_equal 76
+
+    req.env['rack.request.form_pairs'].must_equal [["reply", "yes"], ["fileupload", f]]
   end
 
   it "MultipartPartLimitError when request has too many multipart file parts if limit set" do


### PR DESCRIPTION
The input is not guaranteed to be rewindable, and the default parameter expansion loses details of the parameter names.

For form-encoded data, we (already) retain the full string: it contains only simple key/value pairs, and will be of a manageable size.

Multipart data may contain uploaded files, so we don't wish to retain the full input string -- that's why we dropped the rewindability requirement on the input stream. Instead, we retain an array of two-element arrays representing the "raw" key-value pairs as we parsed the stream. This minimizes additional memory use, because the values are the same objects we use in the params hash, while still allowing an interested consumer to apply their own logic to parameter name interpretation.

---

@jeremyevans @ioquatix I believe this is the minimal version of what we discussed at Kaigi. Apologies for the delay.

For a consumer to use it in this state, they'd need to call `Rack::Request#POST`, relying on its side-effect, then manually pull `rack.request.form_pairs`. Neither of those steps feels like a great API, so I think it would make sense to provide a `body_param_list`-like method as in #2038, but it might be easier to discuss that in a separate follow-up PR, if this seems independently reasonable as the direct implementation / extra retained values?