### PR TITLE
Cloudfront forwarded proto header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add fallback lookup and deprecation warning for obsolete status symbols. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
 - In `Rack::Files`, ignore the `Range` header if served file is 0 bytes. ([#2159](https://github.com/rack/rack/pull/2159), [@zarqman])
 - rack.early_hints is now officially supported as an optional feature (already implemented by Unicorn, Puma, and Falcon). ([#1831](https://github.com/rack/rack/pull/1831), [@casperisfine, @jeremyevans])
+- - Add `Rack::SetXForwardedProtoHeader` middleware ([#2089](https://github.com/rack/rack/pull/2089), [@tomharvey])
 
 ## [3.0.11] - 2024-05-10
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ middleware:
   the request.
 * `Rack::Sendfile` for working with web servers that can use optimized file
   serving for file system paths.
+* `Rack::SetXForwardedProtoHeader` for using a vendor managed proxy which provides
+  X-Forwarded-Proto like headers.
 * `Rack::ShowException` for catching unhandled exceptions and presenting them in
   a nice and helpful way with clickable backtrace.
 * `Rack::ShowStatus` for using nice error pages for empty client error

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -50,6 +50,7 @@ module Rack
   autoload :RewindableInput, "rack/rewindable_input"
   autoload :Runtime, "rack/runtime"
   autoload :Sendfile, "rack/sendfile"
+  autoload :SetXForwardedProtoHeader, "rack/set_x_forwarded_proto_header"
   autoload :ShowExceptions, "rack/show_exceptions"
   autoload :ShowStatus, "rack/show_status"
   autoload :Static, "rack/static"

--- a/lib/rack/set_x_forwarded_proto_header.rb
+++ b/lib/rack/set_x_forwarded_proto_header.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Rack
+
+  # Middleware to set the X-Forwarded-Proto header to the value
+  # of another header.
+  #
+  # This header can be used to ensure the scheme matches when comparing
+  # request.origin and request.base_url for CSRF checking, but Rack
+  # expects that value to be in the X_FORWARDED_PROTO header.
+  #
+  # Example Rails usage:
+  # If you use a vendor managed proxy or CDN which sends the proto in a header add 
+  #`config.middleware.use Rack::SetXForwardedProtoHeader, 'Vendor-Forwarded-Proto-Header'`
+  # to your application.rb file
+  
+  class SetXForwardedProtoHeader
+    def initialize(app, vendor_forwarded_header)
+      @app = app
+      # Rack expects to see UPPER_UNDERSCORED_HEADERS, never SnakeCased-Dashed-Headers
+      @vendor_forwarded_header = "HTTP_#{vendor_forwarded_header.upcase.gsub "-", "_"}"
+    end
+
+    def call(env)
+      if value = env[@vendor_forwarded_header]
+        env["HTTP_X_FORWARDED_PROTO"] = value
+      end
+      @app.call(env)
+    end
+
+  end
+end

--- a/test/spec_set_x_forwarded_proto_header.rb
+++ b/test/spec_set_x_forwarded_proto_header.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+separate_testing do
+  require_relative '../lib/rack/set_x_forwarded_proto_header'
+  require_relative '../lib/rack/lint'
+  require_relative '../lib/rack/mock_request'
+end
+
+
+describe Rack::SetXForwardedProtoHeader do
+  response = lambda {|e| [200, {}, []]  }
+
+  it "leaves the value of X_FORWARDED_PROTO intact if there is no vendor header passed in the request" do
+    vendor_forwarded_header = "not passed in the request"
+    env = Rack::MockRequest.env_for("/", "HTTP_X_FORWARDED_PROTO" => "http")
+
+    Rack::Lint.new(Rack::SetXForwardedProtoHeader.new(response, vendor_forwarded_header)).call env
+
+    env["HTTP_X_FORWARDED_PROTO"].must_equal "http"
+  end
+
+  it "does not set X-Forwarded-Proto when there is no vendor header passed in the request" do
+    vendor_forwarded_header = "not passed in the request"
+    env = Rack::MockRequest.env_for("/", "FOO" => "bar")
+
+    Rack::Lint.new(Rack::SetXForwardedProtoHeader.new(response, vendor_forwarded_header)).call env
+
+    env["FOO"].must_equal "bar"
+    assert_nil(env["HTTP_X_FORWARDED_PROTO"])
+  end
+
+
+  it "copies the value of the header to X-Forwarded-Proto" do
+    env = Rack::MockRequest.env_for("/", "HTTP_VENDOR_FORWARDED_PROTO_HEADER" => "https")
+
+    Rack::Lint.new(Rack::SetXForwardedProtoHeader.new(response, "Vendor-Forwarded-Proto-Header")).call env
+
+    env["HTTP_X_FORWARDED_PROTO"].must_equal "https"
+  end
+
+  it "copies the value of the header to X-Forwarded-Proto overwriting an existing X-Forwarded-Proto" do
+    env = Rack::MockRequest.env_for("/", "HTTP_VENDOR_FORWARDED_PROTO_HEADER" => "https", "HTTP_X_FORWARDED_PROTO" => "http")
+
+    Rack::Lint.new(Rack::SetXForwardedProtoHeader.new(response, "Vendor-Forwarded-Proto-Header")).call env
+
+    env["HTTP_X_FORWARDED_PROTO"].must_equal "https"
+  end
+
+  
+end


### PR DESCRIPTION
Ok - taking another swing at solving https://github.com/rack/rack/issues/2080

This time where we can pass any header in and the value of that will be copied to the value of `HTTP_X_FORWARDED_PROTO`

This allows the user to rely on the value in `CloudFront-Forwarded-Proto` provided by AWS Cloudfront. If other vendors have custom headers for this, then this should also provide an option.

