### PR TITLE
Add support for specifying options to builder and thus `config.ru`.

### DIFF
--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -34,6 +34,11 @@ describe Rack::Builder do
     Rack::Lint.new Rack::Builder.new(&block).to_app
   end
 
+  it "can provide options" do
+    builder = Rack::Builder.new(foo: :bar)
+    builder.options[:foo].must_equal :bar
+  end
+
   it "supports run with block" do
     app = builder_to_app do
       run {|env| [200, { "content-type" => "text/plain" }, ["OK"]]}


### PR DESCRIPTION
Rails 7.1 will introduce support for Rack 3.

Falcon supports Rack 2 and Rack 3, but the concurrency model is per-fiber, not per-thread or per-process as in other servers.

While in theory, the safest option for all code is to behave per-fiber (the smallest unit of simultaneous execution), this can break existing applications that depend on Rails state to be shared between fibers. However, this behaviour is not acceptable for request-per-fiber servers and can cause bugs due to unintentional sharing of, e.g. database transactions or per-request state.

Rails introduced `IsolatedExecutionState` in https://github.com/rails/rails/pull/43596 however this must be manually configured. I am concerned that this raises the bar for adoption of Falcon so I'd like to simplify it a bit.

This PR introduces `Rack::Builder#options` with a proposed `isolation` option which can one of `:process`, `:thread` or `:fiber`. We can discuss the exact semantics but I think we can leave the exact options to be server-specific metadata that is known at "build time".

By introducing this option, Falcon can publish `isolation => fiber` and Rails can use this to automatically configure itself correctly.

In the `config.ru` someone can just write:

```ruby
# config.ru

if isolation = options[:isolation]
  Rails.application.config.active_support.isolation_level = isolation
end
```

As this feature is primarily aimed at Rails 7.1, I'd like to propose we backport this to 3.0. Alternatively, maybe we can cut a 3.1 release of Rack from 3.0 stable... but I'm less enthusiastic about that. As a last resort, we could try to see whether Rails 7.1 is compatible with the Rack HEAD (i.e. 3.1).

cc @byroot @matthewd 
