### PR TITLE
updated escape_html not to escape forward slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 ### SPEC Changes
 
 - `rack.input` is now optional. ([#1997](https://github.com/rack/rack/pull/1997), [@ioquatix])
+- `Rack::Utils.escape_html` doesn't escape forward slash (`/`) now. ([#2097](https://github.com/rack/rack/pull/2097), [@JunichiIto])
 
 ### Changed
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -179,15 +179,14 @@ module Rack
       "<" => "&lt;",
       ">" => "&gt;",
       "'" => "&#x27;",
-      '"' => "&quot;",
-      "/" => "&#x2F;"
+      '"' => "&quot;"
     }
 
     ESCAPE_HTML_PATTERN = Regexp.union(*ESCAPE_HTML.keys)
 
     # Escape ampersands, brackets and quotes to their HTML/XML entities.
     def escape_html(string)
-      string.to_s.gsub(ESCAPE_HTML_PATTERN){|c| ESCAPE_HTML[c] }
+      string.to_s.gsub(ESCAPE_HTML_PATTERN, ESCAPE_HTML)
     end
 
     def select_best_encoding(available_encodings, accept_encoding)

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -477,8 +477,7 @@ describe Rack::Utils do
     Rack::Utils.escape_html("f>o").must_equal "f&gt;o"
     Rack::Utils.escape_html("f'o").must_equal "f&#x27;o"
     Rack::Utils.escape_html('f"o').must_equal "f&quot;o"
-    Rack::Utils.escape_html("f/o").must_equal "f&#x2F;o"
-    Rack::Utils.escape_html("<foo></foo>").must_equal "&lt;foo&gt;&lt;&#x2F;foo&gt;"
+    Rack::Utils.escape_html("<foo></foo>").must_equal "&lt;foo&gt;&lt;/foo&gt;"
   end
 
   it "escape html entities even on MRI when it's bugged" do


### PR DESCRIPTION
fix: https://github.com/rack/rack/issues/2096

NOTE: This PR will break backwards compatibility.