### PR TITLE
Make query parameters without = have empty string values

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -129,6 +129,8 @@ module Rack
 
       return if k.empty?
 
+      v ||= String.new
+
       if after == ''
         if k == '[]' && depth != 0
           return [v]

--- a/test/spec_query_parser.rb
+++ b/test/spec_query_parser.rb
@@ -12,6 +12,6 @@ describe Rack::QueryParser do
   it "can normalize values with missing values" do
     query_parser.parse_nested_query("a=a").must_equal({"a" => "a"})
     query_parser.parse_nested_query("a=").must_equal({"a" => ""})
-    query_parser.parse_nested_query("a").must_equal({"a" => nil})
+    query_parser.parse_nested_query("a").must_equal({"a" => ""})
   end
 end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -583,9 +583,9 @@ class RackRequestTest < Minitest::Spec
   it "parse the query string" do
     request = make_request(Rack::MockRequest.env_for("/?foo=bar&quux=bla&nothing&empty="))
     request.query_string.must_equal "foo=bar&quux=bla&nothing&empty="
-    request.GET.must_equal "foo" => "bar", "quux" => "bla", "nothing" => nil, "empty" => ""
+    request.GET.must_equal "foo" => "bar", "quux" => "bla", "nothing" => "", "empty" => ""
     request.POST.must_be :empty?
-    request.params.must_equal "foo" => "bar", "quux" => "bla", "nothing" => nil, "empty" => ""
+    request.params.must_equal "foo" => "bar", "quux" => "bla", "nothing" => "", "empty" => ""
   end
 
   it "handles invalid unicode in query string value" do

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -141,7 +141,7 @@ describe Rack::Utils do
 
   it "parse nested query strings correctly" do
     Rack::Utils.parse_nested_query("foo").
-      must_equal "foo" => nil
+      must_equal "foo" => ""
     Rack::Utils.parse_nested_query("foo=").
       must_equal "foo" => ""
     Rack::Utils.parse_nested_query("foo=bar").
@@ -158,7 +158,7 @@ describe Rack::Utils do
     Rack::Utils.parse_nested_query("&foo=1&&bar=2").
       must_equal "foo" => "1", "bar" => "2"
     Rack::Utils.parse_nested_query("foo&bar=").
-      must_equal "foo" => nil, "bar" => ""
+      must_equal "foo" => "", "bar" => ""
     Rack::Utils.parse_nested_query("foo=bar&baz=").
       must_equal "foo" => "bar", "baz" => ""
     Rack::Utils.parse_nested_query("my+weird+field=q1%212%22%27w%245%267%2Fz8%29%3F").
@@ -168,19 +168,19 @@ describe Rack::Utils do
       must_equal "pid=1234" => "1023", "a" => "b"
 
     Rack::Utils.parse_nested_query("foo[]").
-      must_equal "foo" => [nil]
+      must_equal "foo" => [""]
     Rack::Utils.parse_nested_query("foo[]=").
       must_equal "foo" => [""]
     Rack::Utils.parse_nested_query("foo[]=bar").
       must_equal "foo" => ["bar"]
     Rack::Utils.parse_nested_query("foo[]=bar&foo").
-      must_equal "foo" => nil
+      must_equal "foo" => ""
     Rack::Utils.parse_nested_query("foo[]=bar&foo[").
-      must_equal "foo" => ["bar"], "foo[" => nil
+      must_equal "foo" => ["bar"], "foo[" => ""
     Rack::Utils.parse_nested_query("foo[]=bar&foo[=baz").
       must_equal "foo" => ["bar"], "foo[" => "baz"
     Rack::Utils.parse_nested_query("foo[]=bar&foo[]").
-      must_equal "foo" => ["bar", nil]
+      must_equal "foo" => ["bar", ""]
     Rack::Utils.parse_nested_query("foo[]=bar&foo[]=").
       must_equal "foo" => ["bar", ""]
 
@@ -192,7 +192,7 @@ describe Rack::Utils do
       must_equal "foo" => ["bar"], "baz" => ["1", "2", "3"]
 
     Rack::Utils.parse_nested_query("x[y][z]").
-      must_equal "x" => { "y" => { "z" => nil } }
+      must_equal "x" => { "y" => { "z" => ""} }
     Rack::Utils.parse_nested_query("x[y][z]=1").
       must_equal "x" => { "y" => { "z" => "1" } }
     Rack::Utils.parse_nested_query("x[y][z][]=1").


### PR DESCRIPTION
This was reverted in 77cf0579ddd53da6e1a449a26850464284a75aec so that Rails could have historical Rack behavior without the complexity of splitting form/query parsing.

Now that splitting form/query parsing has been added back in 3855d1d2638af92193c0636107247bc31c98b2f1, this changes the behavior to what originally shipped in Rack 3.

This matches URL spec section 5.1.3.3.  Frameworks that want Rack's historical behavior of using nil values instead of empty string values can reparse QUERY_STRING and use rack.request.form_pairs to get the behavior they want.