### PR TITLE
Delegate `Rack::Utils.escape_html` to `CGI.escapeHTML`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 ### SPEC Changes
 
 - `rack.input` is now optional. ([#1997](https://github.com/rack/rack/pull/1997), [@ioquatix])
-- `Rack::Utils.escape_html` doesn't escape forward slash (`/`) now. ([#2097](https://github.com/rack/rack/pull/2097), [@JunichiIto])
+- `Rack::Utils.escape_html` is now delegated to `CGI.escapeHTML`. `'` is escaped to `#39;` instead of `#x27;`. (decimal vs hexadecimal) ([#2099](https://github.com/rack/rack/pull/2099), [@JunichiIto])
 
 ### Changed
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -6,6 +6,7 @@ require 'fileutils'
 require 'set'
 require 'tempfile'
 require 'time'
+require 'cgi/escape'
 
 require_relative 'query_parser'
 require_relative 'mime'
@@ -174,20 +175,8 @@ module Rack
       matches&.first
     end
 
-    ESCAPE_HTML = {
-      "&" => "&amp;",
-      "<" => "&lt;",
-      ">" => "&gt;",
-      "'" => "&#x27;",
-      '"' => "&quot;"
-    }
-
-    ESCAPE_HTML_PATTERN = Regexp.union(*ESCAPE_HTML.keys)
-
     # Escape ampersands, brackets and quotes to their HTML/XML entities.
-    def escape_html(string)
-      string.to_s.gsub(ESCAPE_HTML_PATTERN, ESCAPE_HTML)
-    end
+    define_method(:escape_html, CGI.method(:escapeHTML))
 
     def select_best_encoding(available_encodings, accept_encoding)
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -475,17 +475,10 @@ describe Rack::Utils do
     Rack::Utils.escape_html("f&o").must_equal "f&amp;o"
     Rack::Utils.escape_html("f<o").must_equal "f&lt;o"
     Rack::Utils.escape_html("f>o").must_equal "f&gt;o"
-    Rack::Utils.escape_html("f'o").must_equal "f&#x27;o"
+    Rack::Utils.escape_html("f'o").must_equal "f&#39;o"
     Rack::Utils.escape_html('f"o').must_equal "f&quot;o"
     Rack::Utils.escape_html("<foo></foo>").must_equal "&lt;foo&gt;&lt;/foo&gt;"
-  end
-
-  it "escape html entities even on MRI when it's bugged" do
-    test_escape = lambda do
-      Rack::Utils.escape_html("\300<").must_equal "\300&lt;"
-    end
-
-    test_escape.must_raise ArgumentError
+    Rack::Utils.escape_html("\300<").must_equal "\300&lt;"
   end
 
   it "escape html entities in unicode strings" do


### PR DESCRIPTION
This PR improves the performance of `Rack::Utils.escape_html`.

## Background
https://github.com/rack/rack/pull/2097#issuecomment-1639050856

## Benchmark

I defined two methods:

```ruby
    def escape_html(string)
      CGI.escapeHTML(string)
    end

    def escape_html_old(string)
      string.to_s.gsub(ESCAPE_HTML_PATTERN, ESCAPE_HTML)
    end
```

I wrote benchmark script:

```ruby
require 'benchmark'
require 'rack/utils'

# Generated by ChatGPT
HTML_EXAMPLES = <<HTML.lines(chomp: true)
<p>It's a beautiful day.</p>
<a href="https://example.com/page?id=123&category=5">Link</a>
<button onclick="alert('Hello, world!')">Click me</button>
<input type="text" value="It's my text">
<div class='container'>Content goes here</div>
<span>5 &times; 10 = 50</span>
<img src='image.jpg' alt="Nature's beauty">
<p style='color: red;'>This text is red.</p>
<a href='javascript:alert("XSS attack!");'>Click here</a>
<input type='text' placeholder='Enter your name & email'>
HTML
targets = (HTML_EXAMPLES * 10).shuffle

num_iteration = 10_000

Benchmark.bm 5 do |r|
  r.report "new" do
    num_iteration.times do
      targets.each do |string|
        Rack::Utils.escape_html(string)
      end
    end
  end

  r.report "old" do
    num_iteration.times do
      targets.each do |string|
        Rack::Utils.escape_html_old(string)
      end
    end
  end
end
```

Here is the result on my local machine:

```
$ bundle exec ruby benchmark.rb
            user     system      total        real
new     0.257449   0.001930   0.259379 (  0.259876)
old     1.706600   0.004664   1.711264 (  1.711273)
```

The new version is 6.6 times faster than old one.

## Requirements
Requires Ruby 2.3.0 or higher since it depends on 'cgi/escape' library.

> CGI.escapeHTML is optimized with C extention. https://github.com/ruby/ruby/pull/1164
>
> https://github.com/ruby/ruby/blob/v2_3_0/NEWS

I'm not sure if rack should support Ruby 2.2.x or older.

## Backward compatibility
`'` is now escaped to `#39;` instead of `#x27;` (decimal vs hexadecimal)
