### PR TITLE
Return empty when parsing a multi-part POST with only one end delimiter.

### DIFF
--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1363,6 +1363,24 @@ EOF
     req.env['rack.request.form_pairs'].must_equal [["reply", "yes"], ["fileupload", f]]
   end
 
+  it "parse multipart delimiter-only boundary" do
+    input = <<EOF
+--AaB03x--\r
+EOF
+    mr = Rack::MockRequest.env_for(
+      "/",
+      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+      "CONTENT_LENGTH" => input.size,
+      :input => input
+    )
+
+    req = make_request mr
+    req.query_string.must_equal ""
+    req.GET.must_be :empty?
+    req.POST.must_be :empty?
+    req.params.must_equal({})
+  end
+
   it "MultipartPartLimitError when request has too many multipart file parts if limit set" do
     begin
       data = 10000.times.map { "--AaB03x\r\ncontent-type: text/plain\r\ncontent-disposition: attachment; name=#{SecureRandom.hex(10)}; filename=#{SecureRandom.hex(10)}\r\n\r\ncontents\r\n" }.join("\r\n")


### PR DESCRIPTION
Fixed: #2103

Sending the following request in a browser generates a request with with only one end delimiter.

```javascript
const formData = new FormData();
const request = new Request('http://127.0.0.1:8080/', {
  method: 'POST',
  body: formData,
});
const response = fetch(request);
```

```
curl 'http://127.0.0.1:8080/' \
  -H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryR1LC4tR6ayskIXJm' \
  --data-raw $'------WebKitFormBoundaryR1LC4tR6ayskIXJm--\r\n'
```

This request is not compliant RFC7578, but is generated by major browsers such as FireFox and Chrome.
Supporting this request will cause the multipart parser to return an empty value.