### PR TITLE
Add `base64` to runtime dependency

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/rack/rack"
   }
 
+  s.add_dependency 'base64'
+
   s.add_development_dependency 'minitest', "~> 5.0"
   s.add_development_dependency 'minitest-global_expectations'
 


### PR DESCRIPTION
This PR adds `base64` to runtime dependency to suppress the following Ruby 3.3's warning:

```console
$ ruby -wve 'require "rack/auth/basic"'
ruby 3.3.0dev (2023-08-14T15:48:39Z master 52837fcec2) [x86_64-darwin22]
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rack-3.0.8/lib/rack/auth/basic.rb:5:
warning: base64 which will be not part of the default gems since Ruby 3.4.0
```

cf: https://github.com/rails/rails/pull/48907