### PR TITLE
Remove base64 dependency

### DIFF
--- a/lib/rack/auth/basic.rb
+++ b/lib/rack/auth/basic.rb
@@ -2,7 +2,6 @@
 
 require_relative 'abstract/handler'
 require_relative 'abstract/request'
-require 'base64'
 
 module Rack
   module Auth
@@ -46,7 +45,7 @@ module Rack
         end
 
         def credentials
-          @credentials ||= Base64.decode64(params).split(':', 2)
+          @credentials ||= params.unpack1('m').split(':', 2)
         end
 
         def username


### PR DESCRIPTION
base64 will be removed from the default gems in Ruby 3.4. Switch to using String#unpack1 instead.