### PR TITLE
Move `rack/handler` back to Rack

### DIFF
--- a/lib/rack/handler.rb
+++ b/lib/rack/handler.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2022-2023, by Samuel Williams.
+
+warn "Rack::Handler is deprecated and replaced by Rackup::Handler"
+begin
+  require 'rackup'
+rescue LoadError => e
+  warn "You don't have the `rackup` gem installed. Please add it to your Gemfile and run bundle install"
+  exit
+end
+
+module Rack
+	Handler = ::Rackup::Handler
+end


### PR DESCRIPTION
Running the following ruby script with Rack 2 works fine:

```ruby
require 'rack'

app = -> (env) do
  [200, {}, ["Hello World"]]
end

Rack::Handler::WEBrick.run app
```

Running it with Rack 3 results in the following error:

```
<internal:~/.rubies/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:159:in `require': cannot load such file -- rack/handler (LoadError)
```

This happens because it tries to load `Rack::Handler` on the following line: https://github.com/rack/rack/blob/696ed9e8f48053683a0a19fc68eb49f094c0efcb/lib/rack.rb#L34

But `rack/handler` is defined in the `rackup` gem instead so it cannot be loaded: https://github.com/rack/rackup/blob/eaea24a3d64a1b117df943a9d06779e659bb61af/lib/rack/handler.rb#L1-L10

By adding `rack/handler` to Rack itself we can avoid a confusing error when anyone tries the upgrade to Rack 3.