### PR TITLE
Fixed `Rack::Lint` incorrectly flagging `OPTIONS *`

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -126,7 +126,7 @@ There are the following restrictions:
 * There may be a valid hijack callback in <tt>rack.hijack</tt>
 * The <tt>REQUEST_METHOD</tt> must be a valid token.
 * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
-* The <tt>PATH_INFO</tt>, if non-empty (or not <tt>OPTIONS *</tt>), must start with <tt>/</tt>
+* The <tt>PATH_INFO</tt>, if non-empty (or the request is something other than <tt>OPTIONS *</tt>), must start with <tt>/</tt>
 * The <tt>CONTENT_LENGTH</tt>, if given, must consist of digits only.
 * One of <tt>SCRIPT_NAME</tt> or <tt>PATH_INFO</tt> must be
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -126,7 +126,7 @@ There are the following restrictions:
 * There may be a valid hijack callback in <tt>rack.hijack</tt>
 * The <tt>REQUEST_METHOD</tt> must be a valid token.
 * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
-* The <tt>PATH_INFO</tt>, if non-empty, must start with <tt>/</tt>
+* The <tt>PATH_INFO</tt>, if non-empty (or not <tt>OPTIONS *</tt>), must start with <tt>/</tt>
 * The <tt>CONTENT_LENGTH</tt>, if given, must consist of digits only.
 * One of <tt>SCRIPT_NAME</tt> or <tt>PATH_INFO</tt> must be
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -347,7 +347,7 @@ module Rack
           raise LintError, "SCRIPT_NAME must start with /"
         end
 
-        ## * The <tt>PATH_INFO</tt>, if non-empty (or not <tt>OPTIONS *</tt>), must start with <tt>/</tt>
+        ## * The <tt>PATH_INFO</tt>, if non-empty (or the request is something other than <tt>OPTIONS *</tt>), must start with <tt>/</tt>
         if env.include?(PATH_INFO) && !(env[REQUEST_METHOD] == OPTIONS && env[PATH_INFO] == ?*) && env[PATH_INFO] != "" && env[PATH_INFO] !~ /\A\//
           raise LintError, "PATH_INFO must start with /"
         end

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -346,8 +346,9 @@ module Rack
         if env.include?(SCRIPT_NAME) && env[SCRIPT_NAME] != "" && env[SCRIPT_NAME] !~ /\A\//
           raise LintError, "SCRIPT_NAME must start with /"
         end
-        ## * The <tt>PATH_INFO</tt>, if non-empty, must start with <tt>/</tt>
-        if env.include?(PATH_INFO) && env[PATH_INFO] != "" && env[PATH_INFO] !~ /\A\//
+
+        ## * The <tt>PATH_INFO</tt>, if non-empty (or not <tt>OPTIONS *</tt>), must start with <tt>/</tt>
+        if env.include?(PATH_INFO) && !(env[REQUEST_METHOD] == OPTIONS && env[PATH_INFO] == ?*) && env[PATH_INFO] != "" && env[PATH_INFO] !~ /\A\//
           raise LintError, "PATH_INFO must start with /"
         end
         ## * The <tt>CONTENT_LENGTH</tt>, if given, must consist of digits only.

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -225,6 +225,11 @@ describe Rack::Lint do
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/must start with/)
 
+    # XXX not actually sure what *should* happen in an OPTIONS * request.
+    lambda {
+      Rack::Lint.new(nil).call(env("REQUEST_METHOD" => "OPTIONS", "PATH_INFO" => ?*))
+    }.must_be_kind_of Proc
+
     lambda {
       Rack::Lint.new(nil).call(env("CONTENT_LENGTH" => "xcii"))
     }.must_raise(Rack::Lint::LintError).


### PR DESCRIPTION
`Rack::Lint` was incorrectly complaining about `PATH_INFO` not starting with a `/` pursuant to an `OPTIONS *` request (because it wouldn't). This patch fixes that.