### PR TITLE
Correct `Rack::MockRequest`/`Rack::Lint::Wrapper::InputWrapper` re `#set_encoding`

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -485,6 +485,11 @@ module Rack
         def close(*args)
           @input.close(*args)
         end
+
+        ## * +set_encoding+ just passes through to the underlying object.
+        def set_encoding(*args)
+          @input.set_encoding(*args) if @input.respond_to?(:set_encoding)
+        end
       end
 
       ##

--- a/lib/rack/mock_request.rb
+++ b/lib/rack/mock_request.rb
@@ -146,7 +146,8 @@ module Rack
       end
 
       if rack_input
-        rack_input.set_encoding(Encoding::BINARY)
+        # input is not guaranteed to respond to set_encoding
+        rack_input.set_encoding(Encoding::BINARY) if rack_input.respond_to?(:set_encoding)
         env[RACK_INPUT] = rack_input
 
         env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s if env[RACK_INPUT].respond_to?(:size)

--- a/test/spec_mock_request.rb
+++ b/test/spec_mock_request.rb
@@ -257,6 +257,10 @@ describe Rack::MockRequest do
     called.must_equal true
   end
 
+  it "doesn't complain if the input can't #set_encoding" do
+    env = Rack::MockRequest.env_for('/foo', input: Object.new)
+  end
+
   it "defaults encoding to ASCII 8BIT" do
     req = Rack::MockRequest.env_for("/foo")
 


### PR DESCRIPTION
`Rack::MockRequest.env_for` would crash if the input didn't respond to `#set_encoding`. `Rack::Lint::Wrapper::InputWrapper` likewise would not convey `#set_encoding` to its `@input` member. This patch adds a condition to the former and a pass-through method to the latter.