### PR TITLE
Optionally set encoding of `rack.input` in `MockRequest.env_for`.

### DIFF
--- a/lib/rack/mock_request.rb
+++ b/lib/rack/mock_request.rb
@@ -146,7 +146,7 @@ module Rack
       end
 
       if rack_input
-        rack_input.set_encoding(Encoding::BINARY)
+        rack_input.set_encoding(Encoding::BINARY) if rack_input.respond_to?(:set_encoding)
         env[RACK_INPUT] = rack_input
 
         env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s if env[RACK_INPUT].respond_to?(:size)


### PR DESCRIPTION
Possible fix for <https://github.com/rack/rack/pull/2115>.