### PR TITLE
Better error handling in `MockRequest.env_for` w.r.t. input encodings.

### DIFF
--- a/lib/rack/mock_request.rb
+++ b/lib/rack/mock_request.rb
@@ -139,11 +139,15 @@ module Rack
         end
       end
 
-      if String === opts[:input]
-        rack_input = StringIO.new(opts[:input])
+      input = opts[:input]
+      if String === input
+        rack_input = StringIO.new(input)
         rack_input.set_encoding(Encoding::BINARY)
       else
-        rack_input = opts[:input]
+        if input.respond_to?(:encoding) && input.encoding != Encoding::BINARY
+          raise ArgumentError, "input must be binary"
+        end
+        rack_input = input
       end
 
       if rack_input

--- a/lib/rack/mock_request.rb
+++ b/lib/rack/mock_request.rb
@@ -141,12 +141,12 @@ module Rack
 
       if String === opts[:input]
         rack_input = StringIO.new(opts[:input])
+        rack_input.set_encoding(Encoding::BINARY)
       else
         rack_input = opts[:input]
       end
 
       if rack_input
-        rack_input.set_encoding(Encoding::BINARY)
         env[RACK_INPUT] = rack_input
 
         env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s if env[RACK_INPUT].respond_to?(:size)

--- a/lib/rack/mock_request.rb
+++ b/lib/rack/mock_request.rb
@@ -145,7 +145,12 @@ module Rack
         rack_input.set_encoding(Encoding::BINARY)
       else
         if input.respond_to?(:encoding) && input.encoding != Encoding::BINARY
-          raise ArgumentError, "input must be binary"
+          warn "input encoding not binary", uplevel: 1
+          if input.respond_to?(:set_encoding)
+            input.set_encoding(Encoding::BINARY)
+          else
+            raise ArgumentError, "could not coerce input to binary encoding"
+          end
         end
         rack_input = input
       end

--- a/test/spec_mock_request.rb
+++ b/test/spec_mock_request.rb
@@ -124,7 +124,7 @@ describe Rack::MockRequest do
     env = YAML.unsafe_load(res.body)
     env["mock.postdata"].must_equal "foo"
 
-    res = Rack::MockRequest.new(app).post("", input: StringIO.new("foo"))
+    res = Rack::MockRequest.new(app).post("", input: StringIO.new("foo".b))
     env = YAML.unsafe_load(res.body)
     env["mock.postdata"].must_equal "foo"
   end


### PR DESCRIPTION
Previously, we would try to invoke `#set_encoding` on all input bodies. Let's be more specific and issue more valuable errors when dealing with non-binary input bodies.

Fixes <https://github.com/rack/rack/pull/2115>.

See also <https://github.com/rack/rack/pull/2116>.