### PR TITLE
backport #2104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+- Return empty when parsing a multi-part POST with only one end delimiter. ([#2104](https://github.com/rack/rack/pull/2104), [@alpaca-tc])
+
 ## [2.2.8] - 2023-07-31
 
 - Regenerate SPEC ([#2102](https://github.com/rack/rack/pull/2102), [@skipkayhil](https://github.com/skipkayhil))

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1009,6 +1009,24 @@ EOF
     f[:tempfile].size.must_equal 76
   end
 
+  it "parse multipart delimiter-only boundary" do
+    input = <<EOF
+--AaB03x--\r
+EOF
+    mr = Rack::MockRequest.env_for(
+      "/",
+      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+      "CONTENT_LENGTH" => input.size,
+      :input => input
+    )
+
+    req = make_request mr
+    req.query_string.must_equal ""
+    req.GET.must_be :empty?
+    req.POST.must_be :empty?
+    req.params.must_equal({})
+  end
+
   it "MultipartPartLimitError when request has too many multipart file parts if limit set" do
     begin
       data = 10000.times.map { "--AaB03x\r\nContent-Type: text/plain\r\nContent-Disposition: attachment; name=#{SecureRandom.hex(10)}; filename=#{SecureRandom.hex(10)}\r\n\r\ncontents\r\n" }.join("\r\n")


### PR DESCRIPTION
Bug fix #2104 backported to 2-2stable because rack3.0 is not available in Rails 7.0.

Since the implementation of `lib/rack/multipart/parser.rb` is very different between rack 2.0 and 3.0, the backported changes have been corrected a bit.