### PR TITLE
Support for the `Partitioned` cookie attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. For info on
 - MIME type for JavaScript files (`.js`) changed from `application/javascript` to `text/javascript` ([`1bd0f15`](https://github.com/rack/rack/commit/1bd0f1597d8f4a90d47115f3e156a8ce7870c9c8))
 - Add `.mjs` MIME type ([#2057](https://github.com/rack/rack/pull/2057), [@axilleas])
 - Update MIME types associated to `.ttf`, `.woff`, `.woff2` and `.otf` extensions to use mondern `font/*` types. ([#2065](https://github.com/rack/rack/pull/2065), [@davidstosik])
+- `set_cookie_header` utility now supports the `partitioned` cookie attribute. This is required by Chrome in some embedded contexts. ([#2131](https://github.com/rack/rack/pull/2131), [@flavio-b])
 
 ## [3.0.8] - 2023-06-14
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -289,11 +289,7 @@ module Rack
           else
             raise ArgumentError, "Invalid :same_site value: #{value[:same_site].inspect}"
           end
-        partitioned =
-          if value[:partitioned]
-            raise ArgumentError, 'Partitioned cookies must be set with `secure`' unless value[:secure]
-            "; partitioned"
-          end
+        partitioned = "; partitioned" if value[:partitioned]
         value = value[:value]
       else
         key = escape(key)

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -289,6 +289,11 @@ module Rack
           else
             raise ArgumentError, "Invalid :same_site value: #{value[:same_site].inspect}"
           end
+        partitioned =
+          if value[:partitioned]
+            raise ArgumentError, 'Partitioned cookies must be set with `secure`' unless value[:secure]
+            "; partitioned"
+          end
         value = value[:value]
       else
         key = escape(key)
@@ -297,7 +302,7 @@ module Rack
       value = [value] unless Array === value
 
       return "#{key}=#{value.map { |v| escape v }.join('&')}#{domain}" \
-        "#{path}#{max_age}#{expires}#{secure}#{httponly}#{same_site}"
+        "#{path}#{max_age}#{expires}#{secure}#{httponly}#{same_site}#{partitioned}"
     end
 
     # :call-seq:

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -610,6 +610,15 @@ describe Rack::Utils, "cookies" do
     Rack::Utils.set_cookie_header('na e', value: 'value', escape_key: false).must_equal 'na e=value'
   end
 
+  it "sets partitioned cookie attribute" do
+    assert_raises(ArgumentError, 'Partitioned cookies must be set with `secure`') do
+      Rack::Utils.set_cookie_header('name', {value: 'value', partitioned: true})
+    end
+
+    Rack::Utils.set_cookie_header('name', {value: 'value', secure: true, partitioned: true})
+               .must_equal 'name=value; secure; partitioned'
+  end
+
   it "deletes cookies in header field" do
     header = []
 

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -611,12 +611,7 @@ describe Rack::Utils, "cookies" do
   end
 
   it "sets partitioned cookie attribute" do
-    assert_raises(ArgumentError, 'Partitioned cookies must be set with `secure`') do
-      Rack::Utils.set_cookie_header('name', {value: 'value', partitioned: true})
-    end
-
-    Rack::Utils.set_cookie_header('name', {value: 'value', secure: true, partitioned: true})
-               .must_equal 'name=value; secure; partitioned'
+    Rack::Utils.set_cookie_header('name', {value: 'value', partitioned: true}).must_equal 'name=value; partitioned'
   end
 
   it "deletes cookies in header field" do


### PR DESCRIPTION
Adds the option to include the `Partitioned` cookie attribute, required by Chrome in some contexts.