### PR TITLE
Fix minor typo in SPEC.rdoc

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -301,7 +301,7 @@ the body.
 
 The Enumerable Body must respond to +each+.
 It must only be called once.
-It must not be called after being closed.
+It must not be called after being closed,
 and must only yield String values.
 
 The Body itself should not be an instance of String, as this will

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -301,7 +301,7 @@ the body.
 
 The Enumerable Body must respond to +each+.
 It must only be called once.
-It must not be called after being closed,
+It must not be called after being closed.
 and must only yield String values.
 
 The Body itself should not be an instance of String, as this will

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -785,7 +785,7 @@ module Rack
         ## It must only be called once.
         raise LintError, "Response body must only be invoked once (#{@invoked})" unless @invoked.nil?
 
-        ## It must not be called after being closed.
+        ## It must not be called after being closed,
         raise LintError, "Response body is already closed" if @closed
 
         @invoked = :each


### PR DESCRIPTION
Hello! I found a super minor typo while reading the spec. There's a period `.` that should be a comma `,`.