### PR TITLE
Update HTTP status codes and associated symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add `.mjs` MIME type ([#2057](https://github.com/rack/rack/pull/2057), [@axilleas])
 - Update MIME types associated to `.ttf`, `.woff`, `.woff2` and `.otf` extensions to use mondern `font/*` types. ([#2065](https://github.com/rack/rack/pull/2065), [@davidstosik])
 - `set_cookie_header` utility now supports the `partitioned` cookie attribute. This is required by Chrome in some embedded contexts. ([#2131](https://github.com/rack/rack/pull/2131), [@flavio-b])
+- Remove non-standard status codes 306, 509, & 510 and update descriptions for 413, 422, & 451. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
 
 ## [3.0.8] - 2023-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. For info on
 - Update MIME types associated to `.ttf`, `.woff`, `.woff2` and `.otf` extensions to use mondern `font/*` types. ([#2065](https://github.com/rack/rack/pull/2065), [@davidstosik])
 - `set_cookie_header` utility now supports the `partitioned` cookie attribute. This is required by Chrome in some embedded contexts. ([#2131](https://github.com/rack/rack/pull/2131), [@flavio-b])
 - Remove non-standard status codes 306, 509, & 510 and update descriptions for 413, 422, & 451. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
+- Add fallback lookup and deprecation warning for obsolete status symbols. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
 
 ## [3.0.8] - 2023-06-14
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -468,9 +468,10 @@ module Rack
 
     # Every standard HTTP code mapped to the appropriate message.
     # Generated with:
-    #   curl -s https://www.iana.org/assignments/http-status-codes/http-status-codes-1.csv | \
-    #     ruby -ne 'm = /^(\d{3}),(?!Unassigned|\(Unused\))([^,]+)/.match($_) and \
-    #               puts "#{m[1]} => \x27#{m[2].strip}\x27,"'
+    #   curl -s https://www.iana.org/assignments/http-status-codes/http-status-codes-1.csv \
+    #     | ruby -rcsv -e "puts CSV.parse(STDIN, headers: true) \
+    #     .reject {|v| v['Description'] == 'Unassigned' or v['Description'].include? '(' } \
+    #     .map {|v| %Q/#{v['Value']} => '#{v['Description']}'/ }.join(','+?\n)"
     HTTP_STATUS_CODES = {
       100 => 'Continue',
       101 => 'Switching Protocols',
@@ -492,7 +493,6 @@ module Rack
       303 => 'See Other',
       304 => 'Not Modified',
       305 => 'Use Proxy',
-      306 => '(Unused)',
       307 => 'Temporary Redirect',
       308 => 'Permanent Redirect',
       400 => 'Bad Request',
@@ -508,13 +508,13 @@ module Rack
       410 => 'Gone',
       411 => 'Length Required',
       412 => 'Precondition Failed',
-      413 => 'Payload Too Large',
+      413 => 'Content Too Large',
       414 => 'URI Too Long',
       415 => 'Unsupported Media Type',
       416 => 'Range Not Satisfiable',
       417 => 'Expectation Failed',
       421 => 'Misdirected Request',
-      422 => 'Unprocessable Entity',
+      422 => 'Unprocessable Content',
       423 => 'Locked',
       424 => 'Failed Dependency',
       425 => 'Too Early',
@@ -522,7 +522,7 @@ module Rack
       428 => 'Precondition Required',
       429 => 'Too Many Requests',
       431 => 'Request Header Fields Too Large',
-      451 => 'Unavailable for Legal Reasons',
+      451 => 'Unavailable For Legal Reasons',
       500 => 'Internal Server Error',
       501 => 'Not Implemented',
       502 => 'Bad Gateway',
@@ -532,8 +532,6 @@ module Rack
       506 => 'Variant Also Negotiates',
       507 => 'Insufficient Storage',
       508 => 'Loop Detected',
-      509 => 'Bandwidth Limit Exceeded',
-      510 => 'Not Extended',
       511 => 'Network Authentication Required'
     }
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -541,7 +541,7 @@ module Rack
     STATUS_WITH_NO_ENTITY_BODY = Hash[((100..199).to_a << 204 << 304).product([true])]
 
     SYMBOL_TO_STATUS_CODE = Hash[*HTTP_STATUS_CODES.map { |code, message|
-      [message.downcase.gsub(/\s|-|'/, '_').to_sym, code]
+      [message.downcase.gsub(/\s|-/, '_').to_sym, code]
     }.flatten]
 
     def status_code(status)

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -529,9 +529,10 @@ describe Rack::Utils do
   end
 
   it "raise an error for an invalid symbol" do
-    assert_raises(ArgumentError, "Unrecognized status code :foobar") do
+    error = assert_raises(ArgumentError) do
       Rack::Utils.status_code(:foobar)
     end
+    error.message.must_equal "Unrecognized status code :foobar"
   end
 
   it "return rfc2822 format from rfc2822 helper" do

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -528,6 +528,33 @@ describe Rack::Utils do
     Rack::Utils.status_code(:ok).must_equal 200
   end
 
+  it "return status code and give deprecation warning for obsolete symbols" do
+    replaced_statuses = {
+      payload_too_large: {status_code: 413, standard_symbol: :content_too_large},
+      unprocessable_entity: {status_code: 422, standard_symbol: :unprocessable_content}
+    }
+    dropped_statuses = {bandwidth_limit_exceeded: 509, not_extended: 510}
+    verbose = $VERBOSE
+    warn_arg = nil
+    Rack::Utils.define_singleton_method(:warn) do |*args|
+      warn_arg = args
+    end
+    begin
+      $VERBOSE = true
+      replaced_statuses.each do |symbol, value_hash|
+        Rack::Utils.status_code(symbol).must_equal value_hash[:status_code]
+        warn_arg.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack. Please use #{value_hash[:standard_symbol].inspect} instead.", { uplevel: 1 }]
+      end
+      dropped_statuses.each do |symbol, code|
+        Rack::Utils.status_code(symbol).must_equal code
+        warn_arg.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack.", { uplevel: 1 }]
+      end
+    ensure
+      $VERBOSE = verbose
+      Rack::Utils.singleton_class.remove_method :warn
+    end
+  end
+
   it "raise an error for an invalid symbol" do
     error = assert_raises(ArgumentError) do
       Rack::Utils.status_code(:foobar)


### PR DESCRIPTION
These commits bring Rack in sync with the [2022-06-08 version](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml) of the IANA HTTP Status Code Registry.

This change is notably impactful in that the symbol for HTTP status code 422 changes from `:unprocessable_entity` to `:unprocessable_content`. To mitigate the impact, I added legacy symbol lookup to `Rack::Utils.status_code`.

It seems that some Rubyists are in the habit of retrieving status codes from `Rack::Utils::SYMBOL_TO_STATUS_CODE` directly (examples: [here](https://github.com/rails/rails/blob/357a49d901a4a73c18911f28e1d9779ad4f8d4b2/actionpack/lib/action_dispatch/testing/assertion_response.rb#L39), [here](https://github.com/rubygems/rubygems.org/blob/2321d32c4314e2132b6217298faf7001164360f6/app/jobs/fastly_log_processor.rb#L54), [here](https://github.com/hanami/controller/blob/e3f73de4b542bdf94242cce514c0c17446252aa0/lib/hanami/http/status.rb#L24)) rather than using the public method. Admittedly, I've done this myself. Well, it can't be helped, but perhaps this pattern can be discouraged in the future.