### PR TITLE
Add an initializer to Rack::Headers to make it behave like Rack::Utils::HeaderHash

### DIFF
--- a/lib/rack/headers.rb
+++ b/lib/rack/headers.rb
@@ -88,6 +88,11 @@ module Rack
       KNOWN_HEADERS[str] = KNOWN_HEADERS[downcased] = downcased
     end
 
+    def initialize(hash = {})
+      super()
+      hash.each { |k, v| self[k] = v }
+    end
+
     def self.[](*items)
       if items.length % 2 != 0
         if items.length == 1 && items.first.is_a?(Hash)


### PR DESCRIPTION
Hello,

I am trying to update a middleware to rack 3, and I got this warning:

```
warning: Rack::Utils::HeaderHash is deprecated and will be removed in Rack 3.1, switch to Rack::Headers
```

This middleware initializes the headers by passing it in the initializer, like this:

```ruby
headers = Rack::Utils::HeaderHash.new(headers)
```

However, just swapping out `Rack::Utils::HeaderHash` with `Rack::Headers` like the warning suggests does not work, since the initializer is not there so it inherits the `Hash` initializer.

It may be intended but I figured I'd open this PR and see what everyone thinks. I basically just copied the initializer from `Rack::Utils::HeaderHash` except for one line.

Thanks!
