### PR TITLE
Clarify use of `@buffered` and only update `content-length` when `#finish`.

### DIFF
--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -200,8 +200,10 @@ describe Rack::Files do
     end.new(DOCROOT)
 
     res = Rack::MockResponse.new(*files.call(env))
-
     res.status.must_equal 206
+    res.length.must_equal 209
+    res.finish
+
     res["content-length"].must_equal "209"
     res["content-range"].must_equal "bytes 0-3300/10000"
   end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -591,13 +591,15 @@ describe Rack::Response do
     res.headers["content-length"].must_equal "10"
   end
 
-  it "updates content-length when body appended to using #write" do
+  it "updates length when body appended to using #write" do
     res = Rack::Response.new
     res.status = 200
-    res.headers["content-length"].must_be_nil
+    res.length.must_equal 0
     res.write "Hi"
-    res.headers["content-length"].must_equal "2"
+    res.length.must_equal 2
     res.write " there"
+    res.length.must_equal 8
+    res.finish
     res.headers["content-length"].must_equal "8"
   end
 


### PR DESCRIPTION
See <https://github.com/rack/rack/issues/2148> for background context.

This change adjusts `Rack::Response` so that the internal `@length` variable is used until the request is finished, at which point `@headers['content-length']` is added if appropriate. This simplifies the internal logic and avoids any potential synchronisation issues.