### PR TITLE
Fix content-length calcuation in Rack:Response#write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file. For info on
 - `set_cookie_header` utility now supports the `partitioned` cookie attribute. This is required by Chrome in some embedded contexts. ([#2131](https://github.com/rack/rack/pull/2131), [@flavio-b])
 - Remove non-standard status codes 306, 509, & 510 and update descriptions for 413, 422, & 451. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
 - Add fallback lookup and deprecation warning for obsolete status symbols. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
+- Fix incorrect content-length header that was emitted when `Rack::Response#write` was used in some situations. ([#2150](https://github.com/rack/rack/pull/2150), [@mattbrictson])
 
 ## [3.0.8] - 2023-06-14
 

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -321,6 +321,8 @@ module Rack
             @body.each do |part|
               @length += part.to_s.bytesize
             end
+
+            @buffered = true
           elsif @body.respond_to?(:each)
             # Turn the user supplied body into a buffered array:
             body = @body


### PR DESCRIPTION
When `Rack::Response` is initialized with an Array, it properly sets its internal `@length` value and emitted content-length header on the first use of `write`. But every subsequent time `write` is called, it increments the length incorrectly, resulting in an incorrect content-length header.

This commit fixes the accumulation bug, and fixes/adds specs to properly test the scenario where `write` is used multiple times.

Fixes #2148 