### PR TITLE
Ignore Range header if served file is 0 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file. For info on
 - `set_cookie_header` utility now supports the `partitioned` cookie attribute. This is required by Chrome in some embedded contexts. ([#2131](https://github.com/rack/rack/pull/2131), [@flavio-b])
 - Remove non-standard status codes 306, 509, & 510 and update descriptions for 413, 422, & 451. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
 - Add fallback lookup and deprecation warning for obsolete status symbols. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
+- In `Rack::Files`, ignore the `Range` header if served file is 0 bytes. ([#2159](https://github.com/rack/rack/pull/2159), [@zarqman])
 
 ## [3.0.9] - 2024-01-31
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -388,6 +388,8 @@ module Rack
 
     def get_byte_ranges(http_range, size)
       # See <http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35>
+      # Ignore Range when file size is 0 to avoid a 416 error.
+      return nil if size.zero?
       return nil unless http_range && http_range =~ /bytes=([^;]+)/
       ranges = []
       $1.split(/,\s*/).each do |range_spec|

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -241,6 +241,15 @@ content-range: bytes 60-80/209\r
     res["content-range"].must_equal "bytes */209"
   end
 
+  it "ignores range when file is 0 bytes" do
+    env = Rack::MockRequest.env_for("/cgi/assets/images/favicon.ico")
+    env["HTTP_RANGE"] = "bytes=0-1234"
+    res = Rack::MockResponse.new(*files(DOCROOT).call(env))
+
+    res.status.must_equal 200
+    res["content-range"].must_be_nil
+  end
+
   it "support custom http headers" do
     env = Rack::MockRequest.env_for("/cgi/test")
     status, heads, _ = files(DOCROOT, 'cache-control' => 'public, max-age=38',

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -733,11 +733,11 @@ describe Rack::Utils, "get_byte_ranges" do
   end
 
   it "handle byte ranges of empty files" do
-    Rack::Utils.get_byte_ranges("bytes=123-456", 0).must_equal []
-    Rack::Utils.get_byte_ranges("bytes=0-", 0).must_equal []
-    Rack::Utils.get_byte_ranges("bytes=-100", 0).must_equal []
-    Rack::Utils.get_byte_ranges("bytes=0-0", 0).must_equal []
-    Rack::Utils.get_byte_ranges("bytes=-0", 0).must_equal []
+    Rack::Utils.get_byte_ranges("bytes=123-456", 0).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=0-", 0).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=-100", 0).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=0-0", 0).must_be_nil
+    Rack::Utils.get_byte_ranges("bytes=-0", 0).must_be_nil
   end
 end
 


### PR DESCRIPTION
Normally `Rack::Files` truncates a byte range to fit a file's contents--as long as at least some bytes are within range. However, an empty (0 byte) file is a special case since there are no requested bytes that can be within range. 

Previously, 0 byte files requested with a Range header always resulted in a 416 error. This PR changes 0 byte files to ignore the Range header and return the empty file.

Ignoring the Range header is allowed per [RFC 9110 §14.2](https://www.rfc-editor.org/rfc/rfc9110#section-14.2-7).

This improves compatibility with clients that speculatively request files with byte ranges. For example, Nginx's slice / slice_range feature causes all requests to utilize Range. 

Slightly ironically, this also results in a smaller response. (On this basis, it could even be argued to ignore Range for files below 50-100 bytes.)

#### Before
```bash
$ curl -i -H 'Range: bytes=0-1023' http://localhost:3000/favicon.ico
HTTP/1.1 416 Range Not Satisfiable
content-type: image/vnd.microsoft.icon
x-cascade: pass
content-range: bytes */0
Content-Length: 25

Byte range unsatisfiable
```

#### After
```bash
$ curl -i -H 'Range: bytes=0-1023' http://localhost:3000/favicon.ico
HTTP/1.1 200 OK
last-modified: Tue, 15 Jan 2019 21:51:01 GMT
content-type: image/vnd.microsoft.icon
Content-Length: 0
```
