### PR TITLE
Support parsing multiple files for one form field

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -132,6 +132,12 @@ module Rack
       if after == ''
         if k == '[]' && depth != 0
           return [v]
+        elsif !params[k].nil? && !v.nil? && depth == 0
+          if params[k].is_a?(Array)
+            params[k] << v
+          else
+            params[k] = [params[k], v]
+          end
         else
           params[k] = v
         end

--- a/test/multipart/multiple_files
+++ b/test/multipart/multiple_files
@@ -1,0 +1,16 @@
+--AaB03x
+content-disposition: form-data; name="files"; filename="file1.txt"
+content-type: text/plain
+
+foo
+--AaB03x
+content-disposition: form-data; name="files"; filename="file2.txt"
+content-type: text/plain
+
+bar
+--AaB03x
+content-disposition: form-data; name="files"; filename="file3.txt"
+content-type: text/plain
+
+quux
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -518,6 +518,18 @@ describe Rack::Multipart do
     params["files"].size.must_equal 252
   end
 
+  it "parses multiple files with same name" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:multiple_files))
+    params = Rack::Multipart.parse_multipart(env)
+    params["files"].must_be_instance_of Array
+    params["files"][0][:filename].must_equal "file1.txt"
+    params["files"][0][:tempfile].read.must_equal "foo"
+    params["files"][1][:filename].must_equal "file2.txt"
+    params["files"][1][:tempfile].read.must_equal "bar"
+    params["files"][2][:filename].must_equal "file3.txt"
+    params["files"][2][:tempfile].read.must_equal "quux"
+  end
+
   it "parses IE multipart upload and cleans up the filename" do
     env = Rack::MockRequest.env_for("/", multipart_fixture(:ie))
     params = Rack::Multipart.parse_multipart(env)

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -150,7 +150,7 @@ describe Rack::Utils do
       must_equal "foo" => "\"bar\""
 
     Rack::Utils.parse_nested_query("foo=bar&foo=quux").
-      must_equal "foo" => "quux"
+      must_equal "foo" => ["bar", "quux"]
     Rack::Utils.parse_nested_query("foo&foo=").
       must_equal "foo" => ""
     Rack::Utils.parse_nested_query("foo=1&bar=2").


### PR DESCRIPTION
This implements support for parsing multipart requests that contain multiple files with the same name.

From [RFC7578 Section 4.3](https://www.rfc-editor.org/rfc/rfc7578#section-4.3):

> To match widely deployed implementations, multiple files MUST be sent by supplying each file in a separate part but all with the same "name" parameter.

This isn't strictly backwards compatible because it affects `Rack::Utils.parse_nested_query`, however I would argue the existing behaviour there is a bug on the basis that a) it's not a *feature* to have data silently dropped/overwritten so not something many are likely to be relying upon, and b) `parse_nested_query` doesn't currently match the behaviour of `parse_query` which does the correct thing:

    $ irb -r rack
    irb(main):001> Rack::Utils.parse_query('foo=1&foo=2')
    => {"foo"=>["1", "2"]}
    irb(main):002> Rack::Utils.parse_nested_query('foo=1&foo=2')
    => {"foo"=>"2"}

You can test out uploading multiple files from browsers using something like this:

```ruby
require 'sinatra'
require 'json'

get '/' do
  <<-HTML
    <form action="/" method="post" enctype="multipart/form-data">
      <input type="file" name="field" multiple>

      <button type="submit">Upload</button>
    </form>
  HTML
end

post '/' do
  <<-HTML
    <pre>#{JSON.pretty_generate(request.POST)}</pre>
  HTML
end
```
