### PR TITLE
Remove unused `ostruct` require

### DIFF
--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
 require 'erb'
 
 require_relative 'constants'


### PR DESCRIPTION
OpenStruct usage was removed in #2004 but this was missed.

In Ruby 3.4 this is likely to trigger a warning, see https://github.com/ruby/ruby/pull/10428 / https://bugs.ruby-lang.org/issues/20309