### PR TITLE
Remove deprecated base64 in favour of pack/unpack (2-2-stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. For info on
 
 ## Unreleased
 
+- Remove `Base64` use in favour of `pack`/`unpack` ([#2174](https://github.com/rack/rack/pull/2174), [@adam12](https://github.com/adam12))
+
 ## [2.2.9] - 2023-03-21
 
 - Return empty when parsing a multi-part POST with only one end delimiter. ([#2104](https://github.com/rack/rack/pull/2104), [@alpaca-tc])

--- a/lib/rack/auth/basic.rb
+++ b/lib/rack/auth/basic.rb
@@ -2,7 +2,6 @@
 
 require_relative 'abstract/handler'
 require_relative 'abstract/request'
-require 'base64'
 
 module Rack
   module Auth
@@ -48,7 +47,7 @@ module Rack
         end
 
         def credentials
-          @credentials ||= Base64.decode64(params).split(':', 2)
+          @credentials ||= params.unpack("m").first.split(':', 2)
         end
 
         def username

--- a/lib/rack/auth/digest/nonce.rb
+++ b/lib/rack/auth/digest/nonce.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'digest/md5'
-require 'base64'
 
 module Rack
   module Auth
@@ -21,7 +20,7 @@ module Rack
         end
 
         def self.parse(string)
-          new(*Base64.decode64(string).split(' ', 2))
+          new(*string.unpack("m").first.split(' ', 2))
         end
 
         def initialize(timestamp = Time.now, given_digest = nil)
@@ -29,7 +28,7 @@ module Rack
         end
 
         def to_s
-          Base64.encode64("#{@timestamp} #{digest}").strip
+          ["#{@timestamp} #{digest}"].pack("m0")
         end
 
         def digest

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -4,7 +4,6 @@ require 'openssl'
 require 'zlib'
 require_relative 'abstract/id'
 require 'json'
-require 'base64'
 require 'delegate'
 
 module Rack
@@ -51,11 +50,11 @@ module Rack
       # Encode session cookies as Base64
       class Base64
         def encode(str)
-          ::Base64.strict_encode64(str)
+          [str].pack("m0")
         end
 
         def decode(str)
-          ::Base64.decode64(str)
+          str.unpack("m").first
         end
 
         # Encode session cookies as Marshaled Base64 data


### PR DESCRIPTION
The base64 library is external as of Ruby 3.4 and is no longer available by default in Ruby. The pack/unpack methods support encoding as base64 and can be used in its place.

String#unpack.first was preferred here to support Ruby 2.3, which didn't yet have String#unpack1 introduced in Ruby 2.4.