### PR TITLE
Remove Ruby 3.0 from test-external

### DIFF
--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.1', '3.2', '3.3']
 
     runs-on: ${{matrix.os}}
     env:


### PR DESCRIPTION
v0.5.1 of `protocol-rack` dropped support for Ruby 3.0

This causes CI failures like https://github.com/rack/rack/actions/runs/9019033212/job/24780981536

![image](https://github.com/rack/rack/assets/14981592/a5bf7161-1ff4-4536-ad0c-265d22083727)