### PR TITLE
Fix a typo in the spec

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -165,8 +165,8 @@ The input stream must respond to +gets+, +each+, and +read+.
   If +buffer+ is given, then the read data will be placed
   into +buffer+ instead of a newly created String object.
 * +each+ must be called without arguments and only yield Strings.
-* +close+ can be called on the input stream to indicate that the
-any remaining input is not needed.
+* +close+ can be called on the input stream to indicate that
+  any remaining input is not needed.
 
 === The Error Stream
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -476,8 +476,8 @@ module Rack
           }
         end
 
-        ## * +close+ can be called on the input stream to indicate that the
-        ## any remaining input is not needed.
+        ## * +close+ can be called on the input stream to indicate that
+        ##   any remaining input is not needed.
         def close(*args)
           @input.close(*args)
         end


### PR DESCRIPTION
I believe this makes more sense being on its own line

-----

![image](https://github.com/rack/rack/assets/14981592/e9b45d82-5c61-4051-b640-67cb1f0bae95)
