### PR TITLE
Remove Ruby 1.9 references from the spec

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -143,7 +143,7 @@ exceptions. They should be invoked in reverse order of registration.
 The input stream is an IO-like object which contains the raw HTTP
 POST data.
 When applicable, its external encoding must be "ASCII-8BIT" and it
-must be opened in binary mode, for Ruby 1.9 compatibility.
+must be opened in binary mode.
 The input stream must respond to +gets+, +each+, and +read+.
 * +gets+ must be called without arguments and return a string,
   or +nil+ on EOF.
@@ -302,9 +302,6 @@ The Enumerable Body must respond to +each+.
 It must only be called once.
 It must not be called after being closed,
 and must only yield String values.
-
-The Body itself should not be an instance of String, as this will
-break in Ruby 1.9.
 
 Middleware must not call +each+ directly on the Body.
 Instead, middleware can return a new Body that calls +each+ on the

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -384,7 +384,7 @@ module Rack
       ## POST data.
       def check_input_stream(input)
         ## When applicable, its external encoding must be "ASCII-8BIT" and it
-        ## must be opened in binary mode, for Ruby 1.9 compatibility.
+        ## must be opened in binary mode.
         if input.respond_to?(:external_encoding) && input.external_encoding != Encoding::ASCII_8BIT
           raise LintError, "rack.input #{input} does not have ASCII-8BIT as its external encoding"
         end
@@ -791,9 +791,6 @@ module Rack
             raise LintError, "Body yielded non-string value #{chunk.inspect}"
           end
 
-          ##
-          ## The Body itself should not be an instance of String, as this will
-          ## break in Ruby 1.9.
           ##
           ## Middleware must not call +each+ directly on the Body.
           ## Instead, middleware can return a new Body that calls +each+ on the


### PR DESCRIPTION
A string doesn't respond to each anymore so that comment is redundant with the one a bit above.