### PR TITLE
Fine tune `PATH_INFO` validation in `Rack::Lint`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 ### SPEC Changes
 
 - `rack.input` is now optional. ([#1997](https://github.com/rack/rack/pull/1997), [@ioquatix])
+- `PATH_INFO` is now validated according to the HTTP/1.1 specification. ([#2117](https://github.com/rack/rack/pull/2117), [@ioquatix])
 
 ### Changed
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -128,9 +128,9 @@ There are the following restrictions:
 * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
 * The <tt>PATH_INFO</tt>, if provided, must be a valid request target.
   * Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to <tt>*</tt> (asterisk-form).
-  * Only <tt>CONNECT</tt> requests may have <tt>PATH_INFO</tt> set to an authority (authority-form).
+  * Only <tt>CONNECT</tt> requests may have <tt>PATH_INFO</tt> set to an authority (authority-form). Note that in HTTP/2+, the authority-form is not a valid request target.
   * <tt>CONNECT</tt> and <tt>OPTIONS</tt> requests must not have <tt>PATH_INFO</tt> set to a URI (absolute-form).
-  * Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> (origin-form).
+  * Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> and must not include a fragment part starting with '#' (origin-form).
 * The <tt>CONTENT_LENGTH</tt>, if given, must consist of digits only.
 * One of <tt>SCRIPT_NAME</tt> or <tt>PATH_INFO</tt> must be
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -127,10 +127,10 @@ There are the following restrictions:
 * The <tt>REQUEST_METHOD</tt> must be a valid token.
 * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
 * The <tt>PATH_INFO</tt>, if provided, must be a valid request target.
-  - Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to * (asterisk-form).
-  - <tt>CONNECT</tt> requests must have <tt>PATH_INFO</tt> set to an authority (authority-form).
-  - <tt>CONNECT</tt> and <tt>OPTIONS</tt> requests must not have <tt>PATH_INFO</tt> set to a URI (absolute-form).
-  - Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> (origin-form).
+  * Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to <tt>*</tt> (asterisk-form).
+  * Only <tt>CONNECT</tt> requests may have <tt>PATH_INFO</tt> set to an authority (authority-form).
+  * <tt>CONNECT</tt> and <tt>OPTIONS</tt> requests must not have <tt>PATH_INFO</tt> set to a URI (absolute-form).
+  * Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> (origin-form).
 * The <tt>CONTENT_LENGTH</tt>, if given, must consist of digits only.
 * One of <tt>SCRIPT_NAME</tt> or <tt>PATH_INFO</tt> must be
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -126,7 +126,11 @@ There are the following restrictions:
 * There may be a valid early hints callback in <tt>rack.early_hints</tt>
 * The <tt>REQUEST_METHOD</tt> must be a valid token.
 * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
-* The <tt>PATH_INFO</tt>, if non-empty (or the request is something other than <tt>OPTIONS *</tt>), must start with <tt>/</tt>
+* The <tt>PATH_INFO</tt>, if provided, must be a valid request target.
+  - Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to * (asterisk-form).
+  - <tt>CONNECT</tt> requests must have <tt>PATH_INFO</tt> set to an authority (authority-form).
+  - <tt>CONNECT</tt> and <tt>OPTIONS</tt> requests must not have <tt>PATH_INFO</tt> set to a URI (absolute-form).
+  - Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> (origin-form).
 * The <tt>CONTENT_LENGTH</tt>, if given, must consist of digits only.
 * One of <tt>SCRIPT_NAME</tt> or <tt>PATH_INFO</tt> must be
   set. <tt>PATH_INFO</tt> should be <tt>/</tt> if

--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -32,6 +32,7 @@ module Rack
   DELETE  = 'DELETE'
   HEAD    = 'HEAD'
   OPTIONS = 'OPTIONS'
+  CONNECT = 'CONNECT'
   LINK    = 'LINK'
   UNLINK  = 'UNLINK'
   TRACE   = 'TRACE'

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -14,7 +14,7 @@ module Rack
     REQUEST_PATH_ORIGIN_FORM = /\A\/[^?]*\??[^#]*\z/
     REQUEST_PATH_ABSOLUTE_FORM = /\A#{URI::regexp}\z/
     REQUEST_PATH_AUTHORITY_FORM = /\A(.*?)(:\d*)\z/
-    REQUEST_PATH_ASTERISK_FORM = /\A\*\z/
+    REQUEST_PATH_ASTERISK_FORM = '*'
 
     def initialize(app)
       @app = app

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -354,22 +354,22 @@ module Rack
         if env.include?(PATH_INFO)
           case env[PATH_INFO]
           when REQUEST_PATH_ASTERISK_FORM
-            ##   - Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to * (asterisk-form).
+            ##   * Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to <tt>*</tt> (asterisk-form).
             unless env[REQUEST_METHOD] == OPTIONS
               raise LintError, "Only OPTIONS requests may have PATH_INFO set to * (asterisk-form)"
             end
           when REQUEST_PATH_AUTHORITY_FORM
-            ##   - <tt>CONNECT</tt> requests must have <tt>PATH_INFO</tt> set to an authority (authority-form).
+            ##   * Only <tt>CONNECT</tt> requests may have <tt>PATH_INFO</tt> set to an authority (authority-form).
             unless env[REQUEST_METHOD] == CONNECT
               raise LintError, "Only CONNECT requests may have PATH_INFO set to an authority (authority-form)"
             end
           when REQUEST_PATH_ABSOLUTE_FORM
-            ##   - <tt>CONNECT</tt> and <tt>OPTIONS</tt> requests must not have <tt>PATH_INFO</tt> set to a URI (absolute-form).
+            ##   * <tt>CONNECT</tt> and <tt>OPTIONS</tt> requests must not have <tt>PATH_INFO</tt> set to a URI (absolute-form).
             if env[REQUEST_METHOD] == CONNECT || env[REQUEST_METHOD] == OPTIONS
               raise LintError, "CONNECT and OPTIONS requests must not have PATH_INFO set to a URI (absolute-form)"
             end
           when REQUEST_PATH_ORIGIN_FORM
-            ##   - Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> (origin-form).
+            ##   * Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> (origin-form).
             unless env[PATH_INFO].start_with?("/")
               raise LintError, "PATH_INFO must start with a '/' (origin-form)"
             end

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'uri'
 
 require_relative 'constants'
 require_relative 'utils'
@@ -10,6 +11,11 @@ module Rack
   # responses according to the Rack spec.
 
   class Lint
+    REQUEST_PATH_ORIGIN_FORM = /\A\/[^?]*\??[^#]*\z/
+    REQUEST_PATH_ABSOLUTE_FORM = /\A#{URI::regexp}\z/
+    REQUEST_PATH_AUTHORITY_FORM = /\A(.*?)(:\d*)\z/
+    REQUEST_PATH_ASTERISK_FORM = /\A\*\z/
+
     def initialize(app)
       @app = app
     end
@@ -344,10 +350,34 @@ module Rack
           raise LintError, "SCRIPT_NAME must start with /"
         end
 
-        ## * The <tt>PATH_INFO</tt>, if non-empty (or the request is something other than <tt>OPTIONS *</tt>), must start with <tt>/</tt>
-        if env.include?(PATH_INFO) && !(env[REQUEST_METHOD] == OPTIONS && env[PATH_INFO] == ?*) && env[PATH_INFO] != "" && env[PATH_INFO] !~ /\A\//
-          raise LintError, "PATH_INFO must start with /"
+        ## * The <tt>PATH_INFO</tt>, if provided, must be a valid request target.
+        if env.include?(PATH_INFO)
+          case env[PATH_INFO]
+          when REQUEST_PATH_ASTERISK_FORM
+            ##   - Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to * (asterisk-form).
+            unless env[REQUEST_METHOD] == OPTIONS
+              raise LintError, "Only OPTIONS requests may have PATH_INFO set to * (asterisk-form)"
+            end
+          when REQUEST_PATH_AUTHORITY_FORM
+            ##   - <tt>CONNECT</tt> requests must have <tt>PATH_INFO</tt> set to an authority (authority-form).
+            unless env[REQUEST_METHOD] == CONNECT
+              raise LintError, "Only CONNECT requests may have PATH_INFO set to an authority (authority-form)"
+            end
+          when REQUEST_PATH_ABSOLUTE_FORM
+            ##   - <tt>CONNECT</tt> and <tt>OPTIONS</tt> requests must not have <tt>PATH_INFO</tt> set to a URI (absolute-form).
+            if env[REQUEST_METHOD] == CONNECT || env[REQUEST_METHOD] == OPTIONS
+              raise LintError, "CONNECT and OPTIONS requests must not have PATH_INFO set to a URI (absolute-form)"
+            end
+          when REQUEST_PATH_ORIGIN_FORM
+            ##   - Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> (origin-form).
+            unless env[PATH_INFO].start_with?("/")
+              raise LintError, "PATH_INFO must start with a '/' (origin-form)"
+            end
+          else
+            raise LintError, "PATH_INFO must be a valid request target"
+          end
         end
+
         ## * The <tt>CONTENT_LENGTH</tt>, if given, must consist of digits only.
         if env.include?("CONTENT_LENGTH") && env["CONTENT_LENGTH"] !~ /\A\d+\z/
           raise LintError, "Invalid CONTENT_LENGTH: #{env["CONTENT_LENGTH"]}"

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -11,7 +11,7 @@ module Rack
   # responses according to the Rack spec.
 
   class Lint
-    REQUEST_PATH_ORIGIN_FORM = /\A\/[^?]*\??[^#]*\z/
+    REQUEST_PATH_ORIGIN_FORM = /\A\/[^#]*\z/
     REQUEST_PATH_ABSOLUTE_FORM = /\A#{URI::regexp}\z/
     REQUEST_PATH_AUTHORITY_FORM = /\A(.*?)(:\d*)\z/
     REQUEST_PATH_ASTERISK_FORM = '*'
@@ -356,10 +356,10 @@ module Rack
           when REQUEST_PATH_ASTERISK_FORM
             ##   * Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to <tt>*</tt> (asterisk-form).
             unless env[REQUEST_METHOD] == OPTIONS
-              raise LintError, "Only OPTIONS requests may have PATH_INFO set to * (asterisk-form)"
+              raise LintError, "Only OPTIONS requests may have PATH_INFO set to '*' (asterisk-form)"
             end
           when REQUEST_PATH_AUTHORITY_FORM
-            ##   * Only <tt>CONNECT</tt> requests may have <tt>PATH_INFO</tt> set to an authority (authority-form).
+            ##   * Only <tt>CONNECT</tt> requests may have <tt>PATH_INFO</tt> set to an authority (authority-form). Note that in HTTP/2+, the authority-form is not a valid request target.
             unless env[REQUEST_METHOD] == CONNECT
               raise LintError, "Only CONNECT requests may have PATH_INFO set to an authority (authority-form)"
             end
@@ -369,12 +369,9 @@ module Rack
               raise LintError, "CONNECT and OPTIONS requests must not have PATH_INFO set to a URI (absolute-form)"
             end
           when REQUEST_PATH_ORIGIN_FORM
-            ##   * Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> (origin-form).
-            unless env[PATH_INFO].start_with?("/")
-              raise LintError, "PATH_INFO must start with a '/' (origin-form)"
-            end
+            ##   * Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> and must not include a fragment part starting with '#' (origin-form).
           else
-            raise LintError, "PATH_INFO must be a valid request target"
+            raise LintError, "PATH_INFO must start with a '/' and must not include a fragment part starting with '#' (origin-form)"
           end
         end
 

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -214,19 +214,6 @@ describe Rack::Lint do
       message.must_match(/must start with/)
 
     lambda {
-      Rack::Lint.new(nil).call(env("PATH_INFO" => "../foo"))
-    }.must_raise(Rack::Lint::LintError).
-      message.must_match(/must be a valid request target/)
-
-    # A non-empty PATH_INFO starting with something other than / has
-    # implications for Rack::Request#path and methods downstream from
-    # it. Note that RFC3875 does not actually anticipate dealing with
-    # `OPTIONS *`; that should be considered a bug in the spec.
-    Rack::Lint.new(
-      lambda { |_| [200, {}, []] }
-    ).call(env("REQUEST_METHOD" => "OPTIONS", "PATH_INFO" => ?*)).first.must_equal 200
-
-    lambda {
       Rack::Lint.new(nil).call(env("CONTENT_LENGTH" => "xcii"))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/Invalid CONTENT_LENGTH/)
@@ -321,6 +308,65 @@ describe Rack::Lint do
                      }).call(env({}))
     }.must_raise(Rack::Lint::LintError).
       message.must_include('response array has 4 elements instead of 3')
+  end
+
+  it "notices request-target asterisk form errors" do
+    # A non-empty PATH_INFO starting with something other than / has
+    # implications for Rack::Request#path and methods downstream from
+    # it. Note that RFC3875 does not actually anticipate dealing with
+    # `OPTIONS *`; that should be considered a bug in the spec.
+    Rack::Lint.new(valid_app).call(env("REQUEST_METHOD" => "OPTIONS", "PATH_INFO" => '*')).
+      first.must_equal 200
+
+    lambda do
+      Rack::Lint.new(nil).call(env("PATH_INFO" => "*"))
+    end.must_raise(Rack::Lint::LintError).
+      message.must_match(/Only OPTIONS requests may have PATH_INFO set to '\*'/)
+  end
+
+  it "notices request-target authority form errors" do
+    Rack::Lint.new(valid_app).call(env("REQUEST_METHOD" => "CONNECT", "PATH_INFO" => "example.com:80")).
+      first.must_equal 200
+
+    lambda do
+      Rack::Lint.new(nil).call(env("PATH_INFO" => "example.com:80"))
+    end.must_raise(Rack::Lint::LintError).
+      message.must_match(/Only CONNECT requests may have PATH_INFO set to an authority/)
+  end
+
+  it "notices request-target absolute-form errors" do
+    Rack::Lint.new(valid_app).call(env("REQUEST_METHOD" => "GET", "PATH_INFO" => "http://foo/bar")).
+      first.must_equal 200
+
+    lambda do
+      Rack::Lint.new(nil).call(env("REQUEST_METHOD" => "CONNECT", "PATH_INFO" => "http://foo/bar"))
+    end.must_raise(Rack::Lint::LintError).
+      message.must_match(/CONNECT and OPTIONS requests must not have PATH_INFO set to a URI/)
+
+    lambda do
+      Rack::Lint.new(nil).call(env("REQUEST_METHOD" => "OPTIONS", "PATH_INFO" => "http://foo/bar"))
+    end.must_raise(Rack::Lint::LintError).
+      message.must_match(/CONNECT and OPTIONS requests must not have PATH_INFO set to a URI/)
+  end
+
+  it "notices request-target origin-form errors" do
+    Rack::Lint.new(valid_app).call(env("REQUEST_METHOD" => "GET", "PATH_INFO" => "/foo/bar")).
+      first.must_equal 200
+
+    lambda do
+      Rack::Lint.new(nil).call(env("REQUEST_METHOD" => "GET", "PATH_INFO" => "../etc/passwd"))
+    end.must_raise(Rack::Lint::LintError).
+      message.must_match(/PATH_INFO must start with a '\/'/)
+
+    lambda do
+      Rack::Lint.new(nil).call(env("REQUEST_METHOD" => "GET", "PATH_INFO" => "/foo/bar#qux"))
+    end.must_raise(Rack::Lint::LintError).
+      message.must_match(/PATH_INFO.*must not include a fragment/)
+
+    lambda do
+      Rack::Lint.new(nil).call(env("REQUEST_METHOD" => "GET", "PATH_INFO" => "/foo/bar?baz#qux"))
+    end.must_raise(Rack::Lint::LintError).
+      message.must_match(/PATH_INFO.*must not include a fragment/)
   end
 
   it "notice status errors" do

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -216,7 +216,7 @@ describe Rack::Lint do
     lambda {
       Rack::Lint.new(nil).call(env("PATH_INFO" => "../foo"))
     }.must_raise(Rack::Lint::LintError).
-      message.must_match(/must start with/)
+      message.must_match(/must be a valid request target/)
 
     # A non-empty PATH_INFO starting with something other than / has
     # implications for Rack::Request#path and methods downstream from


### PR DESCRIPTION
This makes `Rack::Lint` more specific to the actual HTTP semantics, as described in <https://www.rfc-editor.org/rfc/rfc9112.html#name-request-target>.

Fixes #2117.