### PR TITLE
Skip Rack::Deflater tests on JRuby

### DIFF
--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -11,6 +11,10 @@ separate_testing do
 end
 
 describe Rack::Deflater do
+  if RUBY_ENGINE == 'jruby'
+    warn "skipping Rack::Deflater tests on JRuby until JRuby is fixed"
+    next
+  end
 
   def build_response(status, body, accept_encoding, options = {})
     body = [body] if body.respond_to? :to_str


### PR DESCRIPTION
This starting breaking in JRuby 9.4.3.0.  It's been almost a year since then and the problem is not fixed.  Let's skip the tests on JRuby until JRuby fixes them.