### PR TITLE
Don't use deprecated `URI.regexp`

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -12,7 +12,7 @@ module Rack
 
   class Lint
     REQUEST_PATH_ORIGIN_FORM = /\A\/[^#]*\z/
-    REQUEST_PATH_ABSOLUTE_FORM = /\A#{URI::regexp}\z/
+    REQUEST_PATH_ABSOLUTE_FORM = /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
     REQUEST_PATH_AUTHORITY_FORM = /\A(.*?)(:\d*)\z/
     REQUEST_PATH_ASTERISK_FORM = '*'
 


### PR DESCRIPTION
Followup to #2181

> rack/lib/rack/lint.rb:15: warning: URI.regexp is obsolete