### PR TITLE
Document supported versions, matrix, and Rack 2/3 specific callouts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,15 @@ contributors](https://github.com/rack/rack/graphs/contributors). You're
 encouraged to submit [pull requests](https://github.com/rack/rack/pulls) and
 [propose features and discuss issues](https://github.com/rack/rack/issues).
 
+## Backports
+
+Only security patches are ideal for backporting to non-main release versions. If
+you're not sure if your bug fix is backportable, you should open a discussion to
+discuss it first.
+
+The [Security Policy] documents which release versions will receive security
+backports.
+
 ## Fork the Project
 
 Fork the [project on GitHub](https://github.com/rack/rack) and check out your
@@ -131,3 +140,5 @@ there!
 
 Please do know that we really appreciate and value your time and work. We love
 you, really.
+
+[Security Policy]: SECURITY.md

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # ![Rack](contrib/logo.webp)
 
-> **_NOTE:_** Rack v3.0.0 was recently released. Please check the [Upgrade
-> Guide](UPGRADE-GUIDE.md) for more details about migrating your existing
-> servers, middlewares and applications. For detailed information on specific
-> changes, check the [Change Log](CHANGELOG.md).
-
 Rack provides a minimal, modular, and adaptable interface for developing web
 applications in Ruby. By wrapping HTTP requests and responses in the simplest
 way possible, it unifies and distills the bridge between web servers, web
@@ -22,6 +17,22 @@ Rack applications should conform to.
 | <= 2.1.x | End of support.                    |
 
 Please see the [Security Policy] for more information.
+
+## Rack 3.0
+
+This is the latest version of Rack. It contains API improvements but also some
+breaking changes. Please check the [Upgrade Guide](UPGRADE-GUIDE.md) for more
+details about migrating servers, middlewares and applications designed for Rack 2
+to Rack 3. For detailed information on specific changes, check the [Change Log](CHANGELOG.md).
+
+## Rack 2.2
+
+This version of Rack is receiving security patches only, and effort should be
+made to move to Rack 3.
+
+Starting in Ruby 3.4 the `base64` dependency will no longer be a default gem,
+and may cause a warning or error about `base64` being missing. To correct this,
+add `base64` as a dependency to your project.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ frameworks, and web application into a single method call.
 The exact details of this are described in the [Rack Specification], which all
 Rack applications should conform to.
 
+## Version support
+
+| Version  | Support                            |
+|----------|------------------------------------|
+|    3.0.x | Bug fixes and security patches.    |
+|    2.2.x | Security patches only.             |
+| <= 2.1.x | End of support.                    |
+
+Please see the [Security Policy] for more information.
+
 ## Installation
 
 Add the rack gem to your application bundle, or follow the instructions provided
@@ -306,3 +316,4 @@ would like to thank:
 Rack is released under the [MIT License](MIT-LICENSE).
 
 [Rack Specification]: SPEC.rdoc
+[Security Policy]: SECURITY.md

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ by a [supported web framework](#supported-web-frameworks):
 $ gem install rack
 
 # or, add it to your current application gemfile:
-$ bundle add rack --version 3.0.0
+$ bundle add rack
 ```
 
 If you need features from `Rack::Session` or `bin/rackup` please add those gems separately.


### PR DESCRIPTION
Highlight supported versions near the top of the README. This is cross-linked to the public security policy.

Remove the Rack 3 admonition in favour of two small sub-sections, one for Rack 3 linking to the upgrade guide, and one for Rack 2 highlighting its security-only release cadence and that newer versions of Ruby will require a `base64` dependency added to the application to satisfy a `Base64` dependency inside Rack 2.

Removed explicit version from `bundle add` example as Bundler will add a nicer SemVer constraint on its own.