### PR TITLE
Revert "Skip Rack::Deflater tests on JRuby"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
-          - jruby
+          - jruby-head
           - truffleruby-head
         include:
           - os: macos-latest

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -11,10 +11,6 @@ separate_testing do
 end
 
 describe Rack::Deflater do
-  if RUBY_ENGINE == 'jruby'
-    warn "skipping Rack::Deflater tests on JRuby until JRuby is fixed"
-    next
-  end
 
   def build_response(status, body, accept_encoding, options = {})
     body = [body] if body.respond_to? :to_str


### PR DESCRIPTION
Reverts rack/rack#2182

This will be green once jruby/jruby#8281 has been merged into jruby-head builds.