### PR TITLE
Warn on invalid cookie keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add fallback lookup and deprecation warning for obsolete status symbols. ([#2137](https://github.com/rack/rack/pull/2137), [@wtn])
 - In `Rack::Files`, ignore the `Range` header if served file is 0 bytes. ([#2159](https://github.com/rack/rack/pull/2159), [@zarqman])
 - rack.early_hints is now officially supported as an optional feature (already implemented by Unicorn, Puma, and Falcon). ([#1831](https://github.com/rack/rack/pull/1831), [@casperisfine, @jeremyevans])
+- Only cookie keys that are not valid according to the HTTP specifications are escaped. We are planning to deprecate this behaviour, so now a deprecation message will be emitted in this case. In the future, invalid cookie keys may not be accepted. ([#2191](https://github.com/rack/rack/pull/2191), [@ioquatix])
 
 ## [3.0.11] - 2024-05-10
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -38,4 +38,19 @@ class Minitest::Spec
       end
     end
   end
+  
+  def capture_warnings(target)
+    verbose = $VERBOSE
+    warnings = Thread::Queue.new
+    target.define_singleton_method(:warn) do |*args|
+      warnings << args
+    end
+    begin
+      $VERBOSE = true
+      yield warnings
+    ensure
+      $VERBOSE = verbose
+      target.singleton_class.send(:remove_method, :warn)
+    end
+  end
 end

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -631,7 +631,10 @@ describe Rack::Utils, "cookies" do
   end
 
   it "encodes cookie key values by default" do
-    Rack::Utils.set_cookie_header('na e', 'value').must_equal 'na+e=value'
+    capture_warnings(Rack::Utils) do |warnings|
+      Rack::Utils.set_cookie_header('na e', 'value').must_equal 'na+e=value'
+      warnings.pop.first.must_match(/Cookie key "na e" is not valid/)
+    end
   end
 
   it "does not encode cookie key values if :escape_key is false" do


### PR DESCRIPTION
As discussed in <https://github.com/rack/rack/pull/2189>, we will warn on invalid cookie keys, and mark the escaping behaviour as deprecated.