### PR TITLE
Remove any dependency on `transfer-encoding: chunked`.

### DIFF
--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -22,7 +22,6 @@ module Rack
   ETAG              = 'etag'
   EXPIRES           = 'expires'
   SET_COOKIE        = 'set-cookie'
-  TRANSFER_ENCODING = 'transfer-encoding'
 
   # HTTP method verbs
   GET     = 'GET'

--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -21,7 +21,6 @@ module Rack
 
       if !STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) &&
          !headers[CONTENT_LENGTH] &&
-         !headers[TRANSFER_ENCODING] &&
          body.respond_to?(:to_ary)
 
         response[2] = body = body.to_ary

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -25,7 +25,6 @@ module Rack
       self.new(body, status, headers)
     end
 
-    CHUNKED = 'chunked'
     STATUS_WITH_NO_ENTITY_BODY = Utils::STATUS_WITH_NO_ENTITY_BODY
 
     attr_accessor :length, :status, :body
@@ -90,11 +89,7 @@ module Rack
       self.status = status
       self.location = target
     end
-
-    def chunked?
-      CHUNKED == get_header(TRANSFER_ENCODING)
-    end
-
+ 
     def no_entity_body?
       # The response body is an enumerable body and it is not allowed to have an entity body.
       @body.respond_to?(:each) && STATUS_WITH_NO_ENTITY_BODY[@status]
@@ -110,7 +105,7 @@ module Rack
         close
         return [@status, @headers, []]
       else
-        if @length && @length > 0 && !chunked?
+        if @length && @length > 0
           set_header CONTENT_LENGTH, @length.to_s
         end
 

--- a/test/spec_content_length.rb
+++ b/test/spec_content_length.rb
@@ -44,21 +44,6 @@ describe Rack::ContentLength do
     response[1]['content-length'].must_be_nil
   end
 
-  it "not set content-length when transfer-encoding is chunked" do
-    app = lambda { |env| [200, { 'content-type' => 'text/plain', 'transfer-encoding' => 'chunked' }, []] }
-    response = content_length(app).call(request)
-    response[1]['content-length'].must_be_nil
-  end
-
-  # Using "Connection: close" for this is fairly contended. It might be useful
-  # to have some other way to signal this.
-  #
-  # should "not force a content-length when Connection:close" do
-  #   app = lambda { |env| [200, {'Connection' => 'close'}, []] }
-  #   response = content_length(app).call({})
-  #   response[1]['content-length'].must_be_nil
-  # end
-
   it "close bodies that need to be closed" do
     body = Struct.new(:body) do
       attr_reader :closed


### PR DESCRIPTION
`transfer-encoding` should not be manipulated by application code. We decided that already by dropping `Rack::Chunked`. It's also extremely confusing based on the prior implementation of whether `transfer-encoding: chunked` meant to chunk the output OR the output is already chunked (what `Rack::Chunked` did). Both are incompatible with HTTP/2 and I advise we drop this concept from Rack entirely as it's no longer relevant. The server itself can decide how to best send the response body.

This PR drops checking `transfer-encoding: chunked` from `Rack::ContentLength` and `Rack::Response`. In both instances the only test that failed was the test that directly checked the behaviour.