### PR TITLE
Add deprecation warning for `lib/rack/logger.rb`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. For info on
 - rack.early_hints is now officially supported as an optional feature (already implemented by Unicorn, Puma, and Falcon). ([#1831](https://github.com/rack/rack/pull/1831), [@casperisfine, @jeremyevans])
 - Deprecate automatic cache invalidation in `Request#{GET,POST}` ([#2073](https://github.com/rack/rack/pull/2073) ([@jeremyevans])
 - Only cookie keys that are not valid according to the HTTP specifications are escaped. We are planning to deprecate this behaviour, so now a deprecation message will be emitted in this case. In the future, invalid cookie keys may not be accepted. ([#2191](https://github.com/rack/rack/pull/2191), [@ioquatix])
+- `Rack::Logger` is deprecated. ([#2197](https://github.com/rack/rack/pull/2197), [@ioquatix])
 
 ## [3.0.11] - 2024-05-10
 

--- a/lib/rack/logger.rb
+++ b/lib/rack/logger.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require 'logger'
-
 require_relative 'constants'
+
+warn "Rack::Logger is deprecated and will be removed in Rack 3.2.", uplevel: 1
 
 module Rack
   # Sets up rack.logger to write to rack.errors stream


### PR DESCRIPTION
Fixes <https://github.com/rack/rack/issues/2190>.