### PR TITLE
Failing test with Rack::MockResponse

### DIFF
--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -22,6 +22,7 @@ module Rack
   ETAG              = 'etag'
   EXPIRES           = 'expires'
   SET_COOKIE        = 'set-cookie'
+  TRANSFER_ENCODING = 'transfer-encoding'
 
   # HTTP method verbs
   GET     = 'GET'

--- a/lib/rack/content_length.rb
+++ b/lib/rack/content_length.rb
@@ -21,6 +21,7 @@ module Rack
 
       if !STATUS_WITH_NO_ENTITY_BODY.key?(status.to_i) &&
          !headers[CONTENT_LENGTH] &&
+         !headers[TRANSFER_ENCODING] &&
          body.respond_to?(:to_ary)
 
         response[2] = body = body.to_ary

--- a/lib/rack/response.rb
+++ b/lib/rack/response.rb
@@ -25,6 +25,7 @@ module Rack
       self.new(body, status, headers)
     end
 
+    CHUNKED = 'chunked'
     STATUS_WITH_NO_ENTITY_BODY = Utils::STATUS_WITH_NO_ENTITY_BODY
 
     attr_accessor :length, :status, :body
@@ -89,7 +90,11 @@ module Rack
       self.status = status
       self.location = target
     end
- 
+
+    def chunked?
+      CHUNKED == get_header(TRANSFER_ENCODING)
+    end
+
     def no_entity_body?
       # The response body is an enumerable body and it is not allowed to have an entity body.
       @body.respond_to?(:each) && STATUS_WITH_NO_ENTITY_BODY[@status]
@@ -105,7 +110,7 @@ module Rack
         close
         return [@status, @headers, []]
       else
-        if @length && @length > 0
+        if @length && @length > 0 && !chunked?
           set_header CONTENT_LENGTH, @length.to_s
         end
 

--- a/test/spec_content_length.rb
+++ b/test/spec_content_length.rb
@@ -44,6 +44,21 @@ describe Rack::ContentLength do
     response[1]['content-length'].must_be_nil
   end
 
+  it "not set content-length when transfer-encoding is chunked" do
+    app = lambda { |env| [200, { 'content-type' => 'text/plain', 'transfer-encoding' => 'chunked' }, []] }
+    response = content_length(app).call(request)
+    response[1]['content-length'].must_be_nil
+  end
+
+  # Using "Connection: close" for this is fairly contended. It might be useful
+  # to have some other way to signal this.
+  #
+  # should "not force a content-length when Connection:close" do
+  #   app = lambda { |env| [200, {'Connection' => 'close'}, []] }
+  #   response = content_length(app).call({})
+  #   response[1]['content-length'].must_be_nil
+  # end
+
   it "close bodies that need to be closed" do
     body = Struct.new(:body) do
       attr_reader :closed


### PR DESCRIPTION
[This PR](https://github.com/rack/rack/pull/2195) removed checking for `transfer-encoding` from the `Rack::Response` object when [deciding whether or not to set the content-length header](https://github.com/rack/rack/pull/2195/files#diff-cfcc6d2645b6f77c5ec05acd448f280ce3004d3dba85b8aef3b3c81faf6d1373L113-L115).  This had an impact on the `Rack::MockResponse` subclass as the mock response subclass will try to buffer the response immediately [inside the initialize method](https://github.com/rack/rack/blob/0700a9ca85f748c1d21eb4544d23ffa4df2348c9/lib/rack/mock_response.rb#L36).  When the response is buffered, the `@length` instance variable is set, and this causes the superclass to set the content-length header even though it's a streaming response.

I'm unsure how to fix this situation, so this PR is just a failing test that demonstrates the problematic behavior.  Even though the chunked body object _doesn't_ respond to `to_ary`, the mock response object decides to buffer it anyway, causing the "content length" header to be set.  I tried returning early from `buffered_body!`, but this causes other issues surrounding when the body should be "closed" (it turns tests will try to read the response body twice, but the second time it is closed).

Ref: https://github.com/rails/rails/issues/52066
Ref: https://github.com/rails/rails/pull/52092