### PR TITLE
Improve deprecation for `status_code` with removed/changed stati

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -573,7 +573,7 @@ module Rack
           if canonical_symbol = OBSOLETE_SYMBOL_MAPPINGS[status]
             message = "#{message} Please use #{canonical_symbol.inspect} instead."
           end
-          warn message, uplevel: 1
+          warn message, uplevel: 3
           fallback_code
         end
       else

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -538,12 +538,12 @@ describe Rack::Utils do
     capture_warnings(Rack::Utils) do |warnings|
       replaced_statuses.each do |symbol, value_hash|
         Rack::Utils.status_code(symbol).must_equal value_hash[:status_code]
-        warnings.pop.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack. Please use #{value_hash[:standard_symbol].inspect} instead.", { uplevel: 1 }]
+        warnings.pop.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack. Please use #{value_hash[:standard_symbol].inspect} instead.", { uplevel: 3 }]
       end
 
       dropped_statuses.each do |symbol, code|
         Rack::Utils.status_code(symbol).must_equal code
-        warnings.pop.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack.", { uplevel: 1 }]
+        warnings.pop.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack.", { uplevel: 3 }]
       end
     end
   end


### PR DESCRIPTION
The caller before `warn` looks like this:
```
/home/earlopain/Documents/rack/lib/rack/utils.rb:590:in `fetch'
/home/earlopain/Documents/rack/lib/rack/utils.rb:590:in `status_code'
/my/own/code.rb:3:in `<main>'
```

Intuitively (and from docs at https://ruby-doc.org/3.3.2/Kernel.html#method-i-warn) I would say `uplevel` needs to be 2 but that doesn't work so 3 it is.