### PR TITLE
Add rails smoke tests to external tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,6 @@ group :test do
   gem "webrick"
 
   unless ENV['CI'] == 'spec'
-    gem 'bake-test-external', '~> 0.1.3'
+    gem 'bake-test-external'
   end
 end

--- a/config/external.yaml
+++ b/config/external.yaml
@@ -1,3 +1,6 @@
 protocol-rack:
   url: https://github.com/socketry/protocol-rack
   command: bundle exec bake test
+rails:
+  url: https://github.com/rails/rails
+  command: bash -c "cd actionpack && bundle exec rake test"


### PR DESCRIPTION
We've had a couple of challenges relating to what essentially amount to compatibility issues between Rails and Rack, e.g. <https://github.com/rails/rails/issues/52066>. Let's ensure that Rails' smoke tests all pass as part of Rack's CI. This should give earlier indications about potential issues.