### PR TITLE
Undeprecate unprocessable entity.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -582,9 +582,11 @@ module Rack
           fallback_code = OBSOLETE_SYMBOLS_TO_STATUS_CODES.fetch(status) { raise ArgumentError, "Unrecognized status code #{status.inspect}" }
           message = "Status code #{status.inspect} is deprecated and will be removed in a future version of Rack."
           if canonical_symbol = OBSOLETE_SYMBOL_MAPPINGS[status]
-            message = "#{message} Please use #{canonical_symbol.inspect} instead."
+            # message = "#{message} Please use #{canonical_symbol.inspect} instead."
+            # For now, let's not emit any warning when there is a mapping.
+          else
+            warn message, uplevel: 3
           end
-          warn message, uplevel: 1
           fallback_code
         end
       else

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -538,12 +538,12 @@ describe Rack::Utils do
     capture_warnings(Rack::Utils) do |warnings|
       replaced_statuses.each do |symbol, value_hash|
         Rack::Utils.status_code(symbol).must_equal value_hash[:status_code]
-        warnings.pop.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack. Please use #{value_hash[:standard_symbol].inspect} instead.", { uplevel: 1 }]
+        warnings.must_be_empty
       end
 
       dropped_statuses.each do |symbol, code|
         Rack::Utils.status_code(symbol).must_equal code
-        warnings.pop.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack.", { uplevel: 1 }]
+        warnings.pop.must_equal ["Status code #{symbol.inspect} is deprecated and will be removed in a future version of Rack.", { uplevel: 3 }]
       end
     end
   end


### PR DESCRIPTION
This is creating downstream failures, e.g. https://github.com/rails/rails/pull/52097

I agree with <https://github.com/rack/rack/pull/2137#issuecomment-2066899861> for Rack 3.1 - so let's do that.