### PR TITLE
Add Grape as an external test

### DIFF
--- a/config/external.yaml
+++ b/config/external.yaml
@@ -8,3 +8,6 @@ roda:
   url: https://github.com/jeremyevans/roda
   command: bundle exec rake spec spec_lint
   gemfile: .ci.gemfile
+grape:
+  url: https://github.com/ruby-grape/grape
+  command: bundle exec rspec --exclude-pattern=spec/integration/**/*_spec.rb


### PR DESCRIPTION
Once this and  #2210 are merged, Rack's external tests will test about 99% of usage by web frameworks in terms of download popularity. Rails, Sinatra, Roda, and Grape combine for about 627k daily downloads, next is gruf with about 5.4k, nothing else has more than 1k.