### PR TITLE
Allow empty PATH_INFO.

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -130,7 +130,7 @@ There are the following restrictions:
 * There may be a valid early hints callback in <tt>rack.early_hints</tt>
 * The <tt>REQUEST_METHOD</tt> must be a valid token.
 * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
-* The <tt>PATH_INFO</tt>, if provided, must be a valid request target.
+* The <tt>PATH_INFO</tt>, if provided, must be a valid request target or an empty string.
   * Only <tt>OPTIONS</tt> requests may have <tt>PATH_INFO</tt> set to <tt>*</tt> (asterisk-form).
   * Only <tt>CONNECT</tt> requests may have <tt>PATH_INFO</tt> set to an authority (authority-form). Note that in HTTP/2+, the authority-form is not a valid request target.
   * <tt>CONNECT</tt> and <tt>OPTIONS</tt> requests must not have <tt>PATH_INFO</tt> set to a URI (absolute-form).

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -361,7 +361,7 @@ module Rack
           raise LintError, "SCRIPT_NAME must start with /"
         end
 
-        ## * The <tt>PATH_INFO</tt>, if provided, must be a valid request target.
+        ## * The <tt>PATH_INFO</tt>, if provided, must be a valid request target or an empty string.
         if env.include?(PATH_INFO)
           case env[PATH_INFO]
           when REQUEST_PATH_ASTERISK_FORM
@@ -381,6 +381,8 @@ module Rack
             end
           when REQUEST_PATH_ORIGIN_FORM
             ##   * Otherwise, <tt>PATH_INFO</tt> must start with a <tt>/</tt> and must not include a fragment part starting with '#' (origin-form).
+          when ""
+            # Empty string is okay.
           else
             raise LintError, "PATH_INFO must start with a '/' and must not include a fragment part starting with '#' (origin-form)"
           end

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -310,6 +310,10 @@ describe Rack::Lint do
       message.must_include('response array has 4 elements instead of 3')
   end
 
+  it "accepts empty PATH_INFO" do
+    Rack::Lint.new(valid_app).call(env("PATH_INFO" => "")).first.must_equal 200
+  end
+
   it "notices request-target asterisk form errors" do
     # A non-empty PATH_INFO starting with something other than / has
     # implications for Rack::Request#path and methods downstream from


### PR DESCRIPTION
From <https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.5>:

The PATH_INFO variable specifies a path to be interpreted by the CGI
   script.  It identifies the resource or sub-resource to be returned by
   the CGI script, and is derived from the portion of the URI path
   hierarchy following the part that identifies the script itself.
   Unlike a URI path, the PATH_INFO is not URL-encoded, and cannot
   contain path-segment parameters.  A PATH_INFO of "/" represents a
   single void path segment.

```
      PATH_INFO = "" | ( "/" path )
      path      = lsegment *( "/" lsegment )
      lsegment  = *lchar
      lchar     = <any TEXT or CTL except "/">
```

Our interpretation of `PATH_INFO` is more extensive than the CGI specification to allow for things like `OPTIONS *` and `CONNECT host:port` style requests.