### PR TITLE
`Rack::Response` should not generate invalid `content-length` header.

### DIFF
--- a/test/spec_mock_response.rb
+++ b/test/spec_mock_response.rb
@@ -296,4 +296,15 @@ describe Rack::MockResponse, 'headers' do
     @res.has_header?('Foo').must_equal false
     @res.delete_header('Foo').must_be_nil
   end
+
+  it 'does not add extra headers' do
+    # Force the body to be "enumerable" only:
+    enumerable_app = lambda { |env| [200, {}, [""].to_enum] }
+
+    response = Rack::MockRequest.new(enumerable_app).get('/')
+    response.status.must_equal 200
+    # This fails in Rack < 3.1 as it incorrectly adds a content-length header:
+    response.headers.must_equal({})
+    response.body.must_equal ""
+  end
 end

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -66,7 +66,7 @@ describe Rack::Response do
     }
   end
 
-  it "can be written to inside finish block, but does not update content-length" do
+  it "can be written to inside finish block and it does not generate a content-length header" do
     response = Rack::Response.new('foo')
     response.write "bar"
 
@@ -78,7 +78,7 @@ describe Rack::Response do
     body.each { |part| parts << part }
 
     parts.must_equal ["foo", "bar", "baz"]
-    h['content-length'].must_equal '6'
+    h['content-length'].must_be_nil
   end
 
   it "#write calls #<< on non-iterable body" do
@@ -594,13 +594,14 @@ describe Rack::Response do
     res.status = 200
     res.headers["content-length"] = "10"
     res.finish
+    # We don't overwrite the content-length if it's already set - e.g. HEAD response may not have a body...
     res.headers["content-length"].must_equal "10"
   end
 
   it "updates length when body appended to using #write" do
     res = Rack::Response.new
     res.status = 200
-    res.length.must_equal 0
+    res.length.must_be_nil
     res.write "Hi"
     res.length.must_equal 2
     res.write " there"


### PR DESCRIPTION
I'm experimenting with potential fixes for <https://github.com/rack/rack/issues/2218>.