### PR TITLE
Don't allow authority to match path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::Request#values_at` is removed. ([#2200](https://github.com/rack/rack/pull/2200), [@ioquatix])
 - `Rack::Logger` is removed with no replacement. ([#2196](https://github.com/rack/rack/pull/2196), [@ioquatix])
 
+## [3.1.4] - 2024-06-22
+
+### Fixed
+
+- Fix `Rack::Lint` matching some paths incorrectly as authority form. ([#2220](https://github.com/rack/rack/pull/2220), [@ioquatix])
+
 ## [3.1.3] - 2024-06-12
 
 ### Fixed

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -13,7 +13,7 @@ module Rack
   class Lint
     REQUEST_PATH_ORIGIN_FORM = /\A\/[^#]*\z/
     REQUEST_PATH_ABSOLUTE_FORM = /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
-    REQUEST_PATH_AUTHORITY_FORM = /\A(.*?)(:\d*)\z/
+    REQUEST_PATH_AUTHORITY_FORM = /\A[^\/:]+:\d+\z/
     REQUEST_PATH_ASTERISK_FORM = '*'
 
     def initialize(app)

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -336,6 +336,10 @@ describe Rack::Lint do
       Rack::Lint.new(nil).call(env("PATH_INFO" => "example.com:80"))
     end.must_raise(Rack::Lint::LintError).
       message.must_match(/Only CONNECT requests may have PATH_INFO set to an authority/)
+
+    lambda do
+      Rack::Lint.new(nil).call(env("PATH_INFO" => "/:80")).first.must_equal 200
+    end
   end
 
   it "notices request-target absolute-form errors" do


### PR DESCRIPTION
While investigating Sinatra failures, I noticed that some paths were incorrectly matching an authority.

```
  2) Error:
RoutingTest#test_it_handles_encoded_colons_correctly_0:
Rack::Lint::LintError: Only CONNECT requests may have PATH_INFO set to an authority (authority-form)
    /Users/samuel/Developer/ioquatix/rack/lib/rack/lint.rb:375:in `check_environment'
    /Users/samuel/Developer/ioquatix/rack/lib/rack/lint.rb:63:in `response'
    /Users/samuel/Developer/ioquatix/rack/lib/rack/lint.rb:41:in `call'
    /Users/samuel/.gem/ruby/3.3.3/gems/rack-test-2.1.0/lib/rack/test.rb:360:in `process_request'
    /Users/samuel/.gem/ruby/3.3.3/gems/rack-test-2.1.0/lib/rack/test.rb:163:in `custom_request'
    /Users/samuel/.gem/ruby/3.3.3/gems/rack-test-2.1.0/lib/rack/test.rb:112:in `get'
    /Users/samuel/.rubies/ruby-3.3.3/lib/ruby/3.3.0/forwardable.rb:240:in `get'
    test/routing_test.rb:113:in `block in <class:RoutingTest>'
```

I've confirmed after applying the patch, this test passes. We may need to backport this.