### PR TITLE
Rack logger compatibility

### DIFF
--- a/lib/rack/logger.rb
+++ b/lib/rack/logger.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative 'constants'
+
+warn "Rack::Logger is deprecated and will be removed in Rack 3.2.", uplevel: 1
+
+module Rack
+  class Logger
+    # A minimal implementation that satisfies the Rack specification.
+    class Output
+      def initialize(delegate = STDOUT)
+        @delegate = delegate
+      end
+      
+      def puts(*arguments, &block)
+        if block_given?
+          arguments << yield
+        end
+        
+        @delegate.puts(arguments.join(' '))
+      end
+      
+      def info(*arguments, &block)
+        puts(" INFO:", *arguments, &block)
+      end
+      
+      def debug(*arguments, &block)
+        puts("DEBUG:", *arguments, &block)
+      end
+      
+      def warn(*arguments, &block)
+        puts(" WARN:", *arguments, &block)
+      end
+      
+      def error(*arguments, &block)
+        puts("ERROR:", *arguments, &block)
+      end
+      
+      def fatal(*arguments, &block)
+        puts("FATAL:", *arguments, &block)
+      end
+    end
+    
+    def initialize(app, logger = nil)
+      @app = app
+      @logger = logger || Output.new
+    end
+    
+    def call(env)
+      env[RACK_LOGGER] ||= @logger
+      @app.call(env)
+    end
+  end
+end

--- a/test/spec_logger.rb
+++ b/test/spec_logger.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+separate_testing do
+  require_relative '../lib/rack/logger'
+  require_relative '../lib/rack/lint'
+  require_relative '../lib/rack/mock_request'
+end
+
+describe Rack::Logger do
+  app = lambda { |env|
+    log = env['rack.logger']
+    log.debug("Created logger")
+    log.info("Program started")
+    log.warn("Nothing to do!")
+
+    [200, { 'content-type' => 'text/plain' }, ["Hello, World!"]]
+  }
+
+  it "conform to Rack::Lint" do
+    errors = StringIO.new
+    a = Rack::Lint.new(Rack::Logger.new(app, Rack::Logger::Output.new(errors)))
+    Rack::MockRequest.new(a).get('/')
+    errors.string.must_match(/Program started/)
+    errors.string.must_match(/Nothing to do/)
+  end
+end


### PR DESCRIPTION
I'd like to consider restoring this, at least temporarily, until we fix Sinatra downstream.

Even if we don't merge, it's helpful to track external test failures.

I still think we should probably remove `Rack::Logger`, along with `rack.errors` and `rack.logger` from the SPEC. I don't think logging should be a concern of Rack.

Sinatra should introduce their own `Sinatra::Logger` and they can easily add a dependency on `logger` gem.