### PR TITLE
Install pandoc for sinatra external tests.

### DIFF
--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -27,4 +27,7 @@ jobs:
         apt-get: _update_ libfcgi-dev libmemcached-dev
         brew: fcgi libmemcached
 
+    # Install pandoc:
+    - run: sudo apt-get install -y pandoc
+
     - run: bundle exec bake test:external


### PR DESCRIPTION
e.g.

```
  1) Error:
PandocTest#test_can_be_used_in_a_nested_fashion_for_partials_and_whatnot_0:
Errno::ENOENT: No such file or directory - pandoc
```