### PR TITLE
Improved handling of invalid `accept` headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::Request#values_at` is removed. ([#2200](https://github.com/rack/rack/pull/2200), [@ioquatix])
 - `Rack::Logger` is removed with no replacement. ([#2196](https://github.com/rack/rack/pull/2196), [@ioquatix])
 
+## [3.1.6] - 2024-07-03
+
+- Fix several edge cases in `Rack::Request#parse_http_accept_header`'s implementation. ([#2226](https://github.com/rack/rack/pull/2226), [@ioquatix])
+
 ## [3.1.5] - 2024-07-02
 
 ### Security

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -635,7 +635,8 @@ module Rack
       end
 
       def parse_http_accept_header(header)
-        header.to_s.split(',').filter_map do |part|
+        # It would be nice to use filter_map here, but it's Ruby 2.7+
+        header.to_s.split(',').map do |part|
           part.strip!
           next if part.empty?
 
@@ -647,7 +648,7 @@ module Rack
             quality = $1.to_f
           end
           [attribute, quality]
-        end
+        end.compact
       end
 
       # Get an array of values set in the RFC 7239 `Forwarded` request header.

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -635,7 +635,10 @@ module Rack
       end
 
       def parse_http_accept_header(header)
-        header.to_s.split(',').map do |part|
+        header.to_s.split(',').filter_map do |part|
+          part.strip!
+          next if part.empty?
+
           attribute, parameters = part.split(';', 2)
           attribute.strip!
           parameters&.strip!

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -636,7 +636,9 @@ module Rack
 
       def parse_http_accept_header(header)
         # It would be nice to use filter_map here, but it's Ruby 2.7+
-        header.to_s.split(',').map do |part|
+        parts = header.to_s.split(',')
+
+        parts.map! do |part|
           part.strip!
           next if part.empty?
 
@@ -648,7 +650,11 @@ module Rack
             quality = $1.to_f
           end
           [attribute, quality]
-        end.compact
+        end
+
+        parts.compact!
+
+        parts
       end
 
       # Get an array of values set in the RFC 7239 `Forwarded` request header.

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1560,6 +1560,8 @@ EOF
 
     parser.call("gzip ; q=0.9").must_equal [["gzip", 0.9]]
     parser.call("gzip ; deflate").must_equal [["gzip", 1.0]]
+
+    parser.call(", ").must_equal []
   end
 
   it "parse Accept-Language correctly" do
@@ -1577,6 +1579,8 @@ EOF
 
     parser.call("fr ; q=0.9").must_equal [["fr", 0.9]]
     parser.call("fr").must_equal [["fr", 1.0]]
+
+    parser.call(", ").must_equal []
   end
 
   def ip_app

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1562,6 +1562,8 @@ EOF
     parser.call("gzip ; deflate").must_equal [["gzip", 1.0]]
 
     parser.call(", ").must_equal []
+    parser.call(", gzip").must_equal [["gzip", 1.0]]
+    parser.call("gzip, ").must_equal [["gzip", 1.0]]
   end
 
   it "parse Accept-Language correctly" do
@@ -1581,6 +1583,8 @@ EOF
     parser.call("fr").must_equal [["fr", 1.0]]
 
     parser.call(", ").must_equal []
+    parser.call(", en").must_equal [["en", 1.0]]
+    parser.call("en, ").must_equal [["en", 1.0]]
   end
 
   def ip_app


### PR DESCRIPTION
Possible fix for <https://github.com/rack/rack/issues/2225>.

A few thoughts:

- How bad is `split(/\s*,\s*/)` on recent versions of Ruby? Could we return to using it in the future if the performance isn't bad?
- `filter_map` is only available in Ruby 2.7+ - I know we decided to support old Rubies for as long as possible and I don't think we should change that right now, but I just wanted to call out that there is (probably) a slight loss of performance due to backwards compatibility.