### PR TITLE
Fix encoding setting for non-binary IO-like objects in MockRequest#env_for

### DIFF
--- a/lib/rack/mock_request.rb
+++ b/lib/rack/mock_request.rb
@@ -139,23 +139,13 @@ module Rack
         end
       end
 
-      input = opts[:input]
-      if String === input
-        rack_input = StringIO.new(input)
-        rack_input.set_encoding(Encoding::BINARY)
-      else
-        if input.respond_to?(:encoding) && input.encoding != Encoding::BINARY
-          warn "input encoding not binary", uplevel: 1
-          if input.respond_to?(:set_encoding)
-            input.set_encoding(Encoding::BINARY)
-          else
-            raise ArgumentError, "could not coerce input to binary encoding"
-          end
-        end
-        rack_input = input
+      rack_input = opts[:input]
+      if String === rack_input
+        rack_input = StringIO.new(rack_input)
       end
 
       if rack_input
+        rack_input.set_encoding(Encoding::BINARY) if rack_input.respond_to?(:set_encoding)
         env[RACK_INPUT] = rack_input
 
         env["CONTENT_LENGTH"] ||= env[RACK_INPUT].size.to_s if env[RACK_INPUT].respond_to?(:size)

--- a/test/spec_mock_request.rb
+++ b/test/spec_mock_request.rb
@@ -48,11 +48,20 @@ describe Rack::MockRequest do
     env.must_be_kind_of Hash
   end
 
-  it "should handle a non-GET request with both :input and :params" do
+  it "should handle a non-GET request with :input String and :params" do
     env = Rack::MockRequest.env_for("/", method: :post, input: "", params: {})
     env["PATH_INFO"].must_equal "/"
     env.must_be_kind_of Hash
     env['rack.input'].read.must_equal ''
+  end
+
+  it "should convert :input IO object to binary encoding" do
+    f = File.open(__FILE__, :encoding=>'UTF-8')
+    env = Rack::MockRequest.env_for("/", method: :post, input: f)
+    f.external_encoding.must_equal Encoding::BINARY
+    env['rack.input'].read.must_equal File.binread(__FILE__)
+  ensure
+    f&.close
   end
 
   it "return an environment with a path" do


### PR DESCRIPTION
No core class implements both encoding and set_encoding.

Classes implementing encoding:

* Regexp
* Symbol
* String

Classes implementing set_encoding:

* File
* ARGF.class
* IO

This code was added in 64610db2d2e7e910c4d3e17874dc316ed3eb227a. Previously, set_encoding was always called.
64610db2d2e7e910c4d3e17874dc316ed3eb227a actually broke encoding setting to binary for IO objects, but because there were no tests for the case, it wasn't caught.

I don't see a point of warning of Regexp and Symbol use, and raising for objects that support encoding but not set_encoding doesn't make sense.  I'm guessing the intention was to handle IO-like objects, and then internal_encoding could be checked, but it's simpler to just call set_encoding in that case, as that was the previous behavior.

An alternative to this code would be reverting
64610db2d2e7e910c4d3e17874dc316ed3eb227a, but that is no longer backwards compatible with 3.1.0, which allows objects that do not respond to set_encoding.

Found by coverage testing.