### PR TITLE
Various Fixes Based on Review of Coverage Testing

### DIFF
--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# XXX: Remove when removing AbstractRequest#request
 require_relative '../../request'
 
 module Rack
@@ -11,6 +12,7 @@ module Rack
       end
 
       def request
+        warn "Rack::Auth::AbstractRequest#request is deprecated and will be removed in a future version of rack.", uplevel: 1
         @request ||= Request.new(@env)
       end
 

--- a/lib/rack/media_type.rb
+++ b/lib/rack/media_type.rb
@@ -14,12 +14,11 @@ module Rack
       # For more information on the use of media types in HTTP, see:
       # http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7
       def type(content_type)
-        return nil unless content_type
-        if type = content_type.split(SPLIT_PATTERN, 2).first
-          type.rstrip!
-          type.downcase!
-          type
-        end
+        return nil unless content_type && !content_type.empty?
+        type = content_type.split(SPLIT_PATTERN, 2).first
+        type.rstrip!
+        type.downcase!
+        type
       end
 
       # The media type parameters provided in CONTENT_TYPE as a Hash, or
@@ -28,7 +27,7 @@ module Rack
       # this method responds with the following Hash:
       #   { 'charset' => 'utf-8' }
       def params(content_type)
-        return {} if content_type.nil?
+        return {} if content_type.nil? || content_type.empty?
 
         content_type.split(SPLIT_PATTERN)[1..-1].each_with_object({}) do |s, hsh|
           s.strip!

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -388,7 +388,6 @@ module Rack
             filename = normalize_filename(filename || '')
             filename.force_encoding(find_encoding(encoding))
           elsif filename
-            filename = $1 if filename =~ /^"(.*)"$/
             filename = normalize_filename(filename)
           end
 

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -249,12 +249,6 @@ module Rack
 
       private
 
-      def dequote(str) # From WEBrick::HTTPUtils
-        ret = (/\A"(.*)"\Z/ =~ str) ? $1 : str.dup
-        ret.gsub!(/\\(.)/, "\\1")
-        ret
-      end
-
       def read_data(io, outbuf)
         content = io.read(@bufsize, outbuf)
         handle_empty_content!(content)

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -646,6 +646,7 @@ module Rack
       end
 
       def parse_multipart
+        warn "Rack::Request#parse_multipart is deprecated and will be removed in a future version of Rack.", uplevel: 1
         Rack::Multipart.extract_multipart(self, query_parser)
       end
 

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -65,8 +65,12 @@ module Rack
     def dump_exception(exception)
       if exception.respond_to?(:detailed_message)
         message = exception.detailed_message(highlight: false)
+      # :nocov:
+      # Ruby 3.2 added Exception#detailed_message, so the else
+      # branch cannot be hit on the current Ruby version.
       else
         message = exception.message
+      # :nocov:
       end
       string = "#{exception.class}: #{message}\n".dup
       string << exception.backtrace.map { |l| "\t#{l}" }.join("\n")

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -180,12 +180,16 @@ module Rack
     # doesn't get monkey-patched by rails
     if defined?(ERB::Escape) && ERB::Escape.instance_method(:html_escape)
       define_method(:escape_html, ERB::Escape.instance_method(:html_escape))
+    # :nocov:
+    # Ruby 3.2/ERB 4.0 added ERB::Escape#html_escape, so the else
+    # branch cannot be hit on the current Ruby version.
     else
       require 'cgi/escape'
       # Escape ampersands, brackets and quotes to their HTML/XML entities.
       def escape_html(string)
         CGI.escapeHTML(string.to_s)
       end
+    # :nocov:
     end
 
     def select_best_encoding(available_encodings, accept_encoding)

--- a/test/spec_auth_basic.rb
+++ b/test/spec_auth_basic.rb
@@ -100,4 +100,8 @@ describe Rack::Auth::Basic do
     app = Rack::Auth::Basic.new(unprotected_app, realm) { true }
     realm.must_equal app.realm
   end
+
+  deprecated "supports #request for a Rack::Request object" do
+    Rack::Auth::Basic::Request.new({}).request.must_be_kind_of Rack::Request
+  end
 end

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -46,6 +46,14 @@ describe Rack::Builder do
     Rack::MockRequest.new(app).get("/").body.to_s.must_equal 'OK'
   end
 
+  it "raises if #run provided both app and block" do
+    proc {
+      app = builder_to_app do
+        run(Object.new) {|env| [200, { "content-type" => "text/plain" }, ["OK"]]}
+      end
+    }.must_raise(ArgumentError)
+  end
+
   it "supports mapping" do
     app = builder_to_app do
       map '/' do |outer_env|

--- a/test/spec_media_type.rb
+++ b/test/spec_media_type.rb
@@ -21,6 +21,18 @@ describe Rack::MediaType do
     end
   end
 
+  describe 'when content_type is empty string' do
+    before { @content_type = '' }
+
+    it '#type is nil' do
+      Rack::MediaType.type(@content_type).must_be_nil
+    end
+
+    it '#params is empty' do
+      Rack::MediaType.params(@content_type).must_equal @empty_hash
+    end
+  end
+
   describe 'when content_type contains only media_type' do
     before { @content_type = 'application/text' }
 

--- a/test/spec_mock_request.rb
+++ b/test/spec_mock_request.rb
@@ -66,6 +66,13 @@ describe Rack::MockRequest do
     end
   end
 
+  it "should handle :input object that does not respond to set_encoding" do
+    f = Object.new
+    f.define_singleton_method(:read) { File.binread(__FILE__) }
+    env = Rack::MockRequest.env_for("/", method: :post, input: f)
+    env['rack.input'].read.must_equal File.binread(__FILE__)
+  end
+
   it "return an environment with a path" do
     env = Rack::MockRequest.env_for("http://www.example.com/parse?location[]=1&location[]=2&age_group[]=2")
     env["QUERY_STRING"].must_equal "location[]=1&location[]=2&age_group[]=2"

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -871,11 +871,34 @@ EOF
     params['profile']['bio'].must_include 'hello'
   end
 
-  it "parses very long unquoted multipart file names" do
+  ['', '"'].each do |quote_char|
+    it "parses very long #{'un' if quote_char.empty?}quoted multipart file names" do
+      data = <<-EOF
+--AaB03x\r
+content-type: text/plain\r
+content-disposition: attachment; name=file; filename=#{quote_char}#{'long' * 100}#{quote_char}\r
+\r
+contents\r
+--AaB03x--\r
+      EOF
+
+      options = {
+        "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+        "CONTENT_LENGTH" => data.length.to_s,
+        :input => StringIO.new(data)
+      }
+      env = Rack::MockRequest.env_for("/", options)
+      params = Rack::Multipart.parse_multipart(env)
+
+      params["file"][:filename].must_equal 'long' * 100
+    end
+  end
+
+  it "does not remove escaped quotes in filenames" do
     data = <<-EOF
 --AaB03x\r
 content-type: text/plain\r
-content-disposition: attachment; name=file; filename=#{'long' * 100}\r
+content-disposition: attachment; name=file; filename="\\"#{'long' * 100}\\""\r
 \r
 contents\r
 --AaB03x--\r
@@ -889,7 +912,7 @@ contents\r
     env = Rack::MockRequest.env_for("/", options)
     params = Rack::Multipart.parse_multipart(env)
 
-    params["file"][:filename].must_equal 'long' * 100
+    params["file"][:filename].must_equal "\"#{'long' * 100}\""
   end
 
   it "limits very long file name extensions in multipart tempfiles" do

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -808,6 +808,21 @@ content-type: image/jpeg\r
     end
   end
 
+  it "treats a multipart limit of 0 as no limit" do
+    begin
+      previous_limit = Rack::Utils.multipart_total_part_limit
+      Rack::Utils.multipart_total_part_limit = 0
+
+      env = Rack::MockRequest.env_for '/', multipart_fixture(:three_files_three_fields)
+      params = Rack::Multipart.parse_multipart(env)
+      params['reply'].must_equal 'yes'
+      params['to'].must_equal 'people'
+      params['from'].must_equal 'others'
+    ensure
+      Rack::Utils.multipart_total_part_limit = previous_limit
+    end
+  end
+
   it "reaches a multipart file limit" do
     begin
       previous_limit = Rack::Utils.multipart_part_limit

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -54,6 +54,12 @@ describe Rack::Multipart do
     params["text/plain; charset=US-ASCII"].must_equal ["contents"]
   end
 
+  deprecated "parses multipart content when called using Rack::Request#parse_multipart" do
+    request = Rack::Request.new(Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_disposition)))
+    params = request.send(:parse_multipart)
+    params["text/plain; charset=US-ASCII"].must_equal ["contents"]
+  end
+
   it "parses multipart content when content type is present but disposition is not when using IO" do
     read, write = IO.pipe
     env = multipart_fixture(:content_type_and_no_disposition)

--- a/test/spec_response.rb
+++ b/test/spec_response.rb
@@ -18,6 +18,12 @@ describe Rack::Response do
     response.body.must_equal body
   end
 
+  it 'raises ArgumentError unless headers is a hash' do
+    lambda {
+      Rack::Response.new(nil, 200, Object.new)
+    }.must_raise(ArgumentError)
+  end
+
   it 'has cache-control methods' do
     response = Rack::Response.new
     cc = 'foo'


### PR DESCRIPTION
See individual commits for what is fixed by each. Briefly:

Bug Fixes:

* [Do not remove escaped opening/closing quotes for content-disposition](https://github.com/rack/rack/commit/a94639f0980932b4f9b5360fc9b1bd19e22aa409)
* [Make Rack::MediaType#params handle empty string](https://github.com/rack/rack/commit/11a9ed95ca6e49187b533d2995a714a3a1c7ddca)

Dead Code Removal or Deprecation:

* [Deprecate Rack::Auth::AbstractRequest#request](https://github.com/rack/rack/commit/6495572adda72688429f7a1ff01a28ee3adcbac0)
* [Deprecate Rack::Request#parse_multipart](https://github.com/rack/rack/commit/ed83c5f190e25ac1576257fe8b33b3b2fddac53d)
* [Remove Multipart::Parser#dequote private method](https://github.com/rack/rack/commit/b8ebea7e71b927dd86dad0145df714058e4df467)

Final two commits are adding nocov markings around code that cannot be hit with current Ruby versions, and just adding specs to get back to 100% coverage.