### PR TITLE
Remove Sinatra as an external test until the issues are fixed

### DIFF
--- a/config/external.yaml
+++ b/config/external.yaml
@@ -11,6 +11,3 @@ roda:
 grape:
   url: https://github.com/ruby-grape/grape
   command: bundle exec rspec --exclude-pattern=spec/integration/**/*_spec.rb
-sinatra:
-  url: https://github.com/sinatra/sinatra
-  command: bundle exec rake test


### PR DESCRIPTION
There is no point in having CI complain about every commit when there is nothing Rack can do to fix things.

Sinatra was only added because it was thought to be already passing, due to a bug in bake-test-external that has since been fixed.  As soon as Sinatra is fixed and works with Rack main, this commit can be reverted.