### PR TITLE
Only treat space and \t as allowed whitespace in headers

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -32,9 +32,9 @@ module Rack
 
     EOL = "\r\n"
     MULTIPART = %r|\Amultipart/.*boundary=\"?([^\";,]+)\"?|ni
-    MULTIPART_CONTENT_TYPE = /Content-Type: (.*)#{EOL}/ni
+    MULTIPART_CONTENT_TYPE = /Content-Type:[ \t]*(.*)#{EOL}/ni
     MULTIPART_CONTENT_DISPOSITION = /Content-Disposition:(.*)(?=#{EOL}(\S|\z))/ni
-    MULTIPART_CONTENT_ID = /Content-ID:\s*([^#{EOL}]*)/ni
+    MULTIPART_CONTENT_ID = /Content-ID:[ \t]*([^#{EOL}]*)/ni
 
     class Parser
       BUFSIZE = 1_048_576

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -685,7 +685,7 @@ module Rack
       end
 
       def split_header(value)
-        value ? value.strip.split(/[,\s]+/) : []
+        value ? value.strip.split(/[, \t]+/) : []
       end
 
       # ipv6 extracted from resolv stdlib, simplified

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -404,7 +404,7 @@ module Rack
       return nil if size.zero?
       return nil unless http_range && http_range =~ /bytes=([^;]+)/
       ranges = []
-      $1.split(/,\s*/).each do |range_spec|
+      $1.split(/,[ \t]*/).each do |range_spec|
         return nil unless range_spec.include?('-')
         range = range_spec.split('-')
         r0, r1 = range[0], range[1]

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -334,7 +334,7 @@ describe Rack::Multipart do
 
   it "ignores content-disposition values over to 1536 bytes" do
     x = content_disposition_parse.call("a=#{'a'*1510}; filename=\"bar\"; name=\"file\"")
-    x.must_equal "text/plain"=>[""]
+    x.must_equal "application/pdf"=>[""]
   end
 
   it 'raises an EOF error on content-length mismatch' do


### PR DESCRIPTION
RFC 7230 (HTTP RFC) Section 3.2.3 is clear that those are the only two allowed characters for required/optional whitespace in headers.

RFC 2046 (MIME/Multipart RFC) refers to RFC 822, and RFC 822 Section 3.3 also specifies that linear white space is made up of only space and tab characters.

While here, I noticed the content-type parser in the multipart code was requiring a space, when whitespace is optional. Make the whitespace optional, and adjust a test where a content-type was ignored because it didn't use whitespace.

The request and utils changes here are operating on header values, and generally other whitespace is allowed there, but I'm not sure we should split on whitespace other than space and \t, so I made the change there as well.

There are a lot of places in Rack where we are using strip/strip! were we should potentially change to be more strict and only strip space and \t, but this commit does not attempt to address strip/strip! usage.