### PR TITLE
Revert "Remove Sinatra as an external test until the issues are fixed (#2231)"

### DIFF
--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -20,10 +20,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby-pkgs@v1
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
+        apt-get: pandoc
+        brew: pandoc
 
     - name: Change permissions
       run: chmod -R o-w /opt/hostedtoolcache/Ruby

--- a/config/external.yaml
+++ b/config/external.yaml
@@ -11,3 +11,6 @@ roda:
 grape:
   url: https://github.com/ruby-grape/grape
   command: bundle exec rspec --exclude-pattern=spec/integration/**/*_spec.rb
+sinatra:
+  url: https://github.com/sinatra/sinatra
+  command: bundle exec rake test

--- a/config/external.yaml
+++ b/config/external.yaml
@@ -14,3 +14,6 @@ grape:
 sinatra:
   url: https://github.com/sinatra/sinatra
   command: bundle exec rake test
+  # This causes some integration tests taht would otherwise fail, to be skipped:
+  env:
+    rack: head


### PR DESCRIPTION
This reverts commit 4d11c61b9156188b4e37eef2fb2eebb20935478b.

Waiting on the following fixes:

- https://github.com/sinatra/sinatra/pull/2028
- https://github.com/sinatra/sinatra/pull/2029
- https://github.com/sinatra/sinatra/pull/2030
- https://github.com/sinatra/sinatra/pull/2031