### PR TITLE
Allow env to be `Hash or Hash-like instance`.

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -16,9 +16,7 @@ and the *body*.
 
 == The Environment
 
-The environment must be an unfrozen instance of Hash that includes
-CGI-like headers. The Rack application is free to modify the
-environment.
+The environment must be an unfrozen Hash or Hash-like instance which implements the following methods with equivalent behaviour to the methods of a Hash instance: #[], #[]=, #keys, #key?, #include?, #fetch, #delete, #clear, #to_hash, #each, #each_key, #each_value, #each_pair, #merge, #update, #frozen?, #inspect.
 
 The environment is required to include these variables
 (adopted from {PEP 333}[https://peps.python.org/pep-0333/]), except when they'd be empty, but see

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -46,6 +46,7 @@ module Rack
   autoload :Recursive, "rack/recursive"
   autoload :Reloader, "rack/reloader"
   autoload :Request, "rack/request"
+  autoload :RequestWrapper, "rack/request_wrapper"
   autoload :Response, "rack/response"
   autoload :RewindableInput, "rack/rewindable_input"
   autoload :Runtime, "rack/runtime"

--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -42,7 +42,7 @@ module Rack
       AUTHORIZATION_KEYS = ['HTTP_AUTHORIZATION', 'X-HTTP_AUTHORIZATION', 'X_HTTP_AUTHORIZATION']
 
       def authorization_key
-        @authorization_key ||= AUTHORIZATION_KEYS.detect { |key| @env.has_key?(key) }
+        @authorization_key ||= AUTHORIZATION_KEYS.detect { |key| @env.key?(key) }
       end
 
     end

--- a/lib/rack/request_wrapper.rb
+++ b/lib/rack/request_wrapper.rb
@@ -1,0 +1,13 @@
+require_relative 'request'
+
+module Rack
+  class RequestWrapper
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(Request[env])
+    end
+  end
+end

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -32,7 +32,7 @@ describe Rack::Lint do
 
   it "notice environment errors" do
     lambda { Rack::Lint.new(nil).call 5 }.must_raise(Rack::Lint::LintError).
-      message.must_match(/not a Hash/)
+      message.must_match(/env does not respond to/)
 
     lambda { Rack::Lint.new(nil).call({}.freeze) }.must_raise(Rack::Lint::LintError).
       message.must_match(/env should not be frozen, but is/)

--- a/test/spec_lock.rb
+++ b/test/spec_lock.rb
@@ -168,7 +168,8 @@ describe Rack::Lock do
 
   it "not replace the environment" do
     env  = Rack::MockRequest.env_for("/")
-    app  = lock_app(lambda { |inner_env| [200, { "content-type" => "text/plain" }, [inner_env.object_id.to_s]] })
+    # We call to_hash to get the underlying hash, not the environment wrapper of Rack::Lint.
+    app  = lock_app(lambda { |inner_env| [200, { "content-type" => "text/plain" }, [inner_env.to_hash.object_id.to_s]] })
 
     _, _, body = app.call(env)
 

--- a/test/spec_request_wrapper.rb
+++ b/test/spec_request_wrapper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+separate_testing do
+  require_relative '../lib/rack/request_wrapper'
+  require_relative '../lib/rack/lint'
+  require_relative '../lib/rack/mock_request'
+end
+
+describe Rack::RequestWrapper do
+  def request_wrapper(app)
+    Rack::RequestWrapper.new(app)
+  end
+
+  def request
+    Rack::MockRequest.env_for
+  end
+
+  it "converts the request env to a request object" do
+    app = lambda {|env| [200, {}, [env.class.to_s]]}
+
+    response = request_wrapper(app).call(request)
+    response[0].must_equal 200
+    response[1].must_equal({})
+    response[2].must_equal ["Rack::Request"]
+  end
+end


### PR DESCRIPTION
Implements the proposal described in <https://github.com/rack/rack/issues/1879>:

- Make a middleware that casts the env hash to a request object, then passes the request object to the next middleware
- Make the request object quack enough like a hash that existing legacy middleware can use the request object as if it was the env hash
