### PR TITLE
Remove rack/handler reference

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,7 +6,6 @@ if ENV.delete('COVERAGE')
   SimpleCov.start do
     enable_coverage :branch
     add_filter "/test/"
-    add_filter "/lib/rack/handler"
     add_group('Missing'){|src| src.covered_percent < 100}
     add_group('Covered'){|src| src.covered_percent == 100}
   end


### PR DESCRIPTION
Remove the reference to `Rack::Handler` since it has been moved to the [rackup](https://github.com/rack/rackup) gem as part of #1937