### PR TITLE
Resolve deprecation warnings about uri `DEFAULT_PARSER`

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -12,7 +12,7 @@ module Rack
 
   class Lint
     REQUEST_PATH_ORIGIN_FORM = /\A\/[^#]*\z/
-    REQUEST_PATH_ABSOLUTE_FORM = /\A#{URI::DEFAULT_PARSER.make_regexp}\z/
+    REQUEST_PATH_ABSOLUTE_FORM = /\A#{Utils::URI_PARSER.make_regexp}\z/
     REQUEST_PATH_AUTHORITY_FORM = /\A[^\/:]+:\d+\z/
     REQUEST_PATH_ASTERISK_FORM = '*'
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -24,6 +24,7 @@ module Rack
     DEFAULT_SEP = QueryParser::DEFAULT_SEP
     COMMON_SEP = QueryParser::COMMON_SEP
     KeySpaceConstrainedParams = QueryParser::Params
+    URI_PARSER = defined?(::URI::RFC2396_PARSER) ? ::URI::RFC2396_PARSER : ::URI::DEFAULT_PARSER
 
     class << self
       attr_accessor :default_query_parser
@@ -43,13 +44,13 @@ module Rack
     # Like URI escaping, but with %20 instead of +. Strictly speaking this is
     # true URI escaping.
     def escape_path(s)
-      ::URI::DEFAULT_PARSER.escape s
+      URI_PARSER.escape s
     end
 
     # Unescapes the **path** component of a URI.  See Rack::Utils.unescape for
     # unescaping query parameters or form components.
     def unescape_path(s)
-      ::URI::DEFAULT_PARSER.unescape s
+      URI_PARSER.unescape s
     end
 
     # Unescapes a URI escaped string with +encoding+. +encoding+ will be the


### PR DESCRIPTION
Ruby switches the default parser from RFC2396 to RFC3986. This parser contains all methods from the old parser but delegates to RFC2396 for a few and warns. Namely `extract`, `make_regexp`, `escape`,and `unescape`.

Since the RFC2396 alias is not available for old rubies, do a defined check and select the appropriate one. This will work for all versions without warnings.

Additional info:
* https://github.com/ruby/uri/pull/107
* https://bugs.ruby-lang.org/issues/19266

While this removes the warning and passes tests, I can't describe the possible impact for continuing to use the older parser like this. I'll leave that up to someone with more domain knowledge, consider this a notice about the warning if that turns out to be important.