### PR TITLE
Add `logger` to the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ unless ENV['CI']
 end
 
 group :test do
+  gem "logger"
   gem "webrick"
 
   unless ENV['CI'] == 'spec'


### PR DESCRIPTION
While rack itself doesn't use it anymore, one test does. It checks that `CommonLogger` works with the std logger, so can't exactly change that test without outright removing it. Just add it to the gemfile.

https://github.com/rack/rack/blob/0ed580bbe3858ffe5d530adf1bdad9ef9c03407c/test/spec_common_logger.rb#L47-L53