### PR TITLE
Add support for ISO-2022-JP encoding in multipart form data handling(#2245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Added
 
 - Introduce `Rack::VERSION` constant. ([#2199](https://github.com/rack/rack/pull/2199), [@ioquatix])
+- Add support for ISO-2022-JP in Multipart Requests. ([#2245](https://github.com/rack/rack/pull/2245), [@nappa])
 
 ### Changed
 

--- a/test/multipart/multiple_encodings
+++ b/test/multipart/multiple_encodings
@@ -1,0 +1,10 @@
+--AaB03x
+content-disposition: form-data; name="us-ascii"
+
+Alice
+--AaB03x
+content-disposition: form-data; name="iso-2022-jp"
+content-type: text/plain; charset=iso-2022-jp
+
+アリス
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1050,4 +1050,16 @@ content-type: image/png\r
     f.write(params["image/png"][0])
     f.length.must_equal 26473
   end
+
+  it "supports ISO-2022-JP-encoded part" do
+    unless defined?(NKF)
+      env = Rack::MockRequest.env_for("/", multipart_fixture(:multiple_encodings))
+      params = Rack::Multipart.parse_multipart(env)
+      params["us-ascii"].must_equal("Alice")
+      params["iso-2022-jp"].must_equal("アリス")
+    else
+      # rod
+      pass
+    end
+  end
 end


### PR DESCRIPTION
Hi, I added support for ISO-2022-JP encoding in multipart form data handling, which solves #2245 .

- Starting with Ruby 3.4, nkf will be separated into a gem, so this code does not assume its presence. If nkf is not available, the code will behave as it did before.
- This code is written to behave like other encodings if Encoding::ISO_2022_JP is no longer treated as a dummy encoding in the future.
- Introduced `handle_dummy_encoding` method to properly convert ISO-2022-JP encoded parameters and bodies to UTF-8 using the `nkf` library, if available.
- Wrapped `nkf` library loading in a `begin-rescue` block to gracefully handle environments where the library is not available.
- Updated multipart parser to use the new method for handling legacy encodings, ensuring proper parameter normalization.
- Added test case to verify correct handling of multipart data with ISO-2022-JP encoding.

I hope it helps.