### PR TITLE
Add support for ISO-2022-JP encoding in multipart form data handling(#2245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Added
 
 - Introduce `Rack::VERSION` constant. ([#2199](https://github.com/rack/rack/pull/2199), [@ioquatix])
+- Add support for ISO-2022-JP in Multipart Requests. ([#2245](https://github.com/rack/rack/pull/2245), [@nappa])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Added
 
 - Introduce `Rack::VERSION` constant. ([#2199](https://github.com/rack/rack/pull/2199), [@ioquatix])
-- Add support for ISO-2022-JP in Multipart Requests. ([#2245](https://github.com/rack/rack/pull/2245), [@nappa])
+- ISO-2022-JP encoded parts within MIME Multipart sections of an HTTP request body will now be converted to UTF-8. ([#2245](https://github.com/rack/rack/pull/2245), [@nappa])
 
 ### Changed
 

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -487,15 +487,21 @@ module Rack
         Encoding::BINARY
       end
 
+      REENCODE_DUMMY_ENCODINGS = {
+        # ISO-2022-JP is a legacy but still widely used encoding in Japan
+        # Here we convert ISO-2022-JP to UTF-8 so that it can be handled.
+        Encoding::ISO_2022_JP => true
+
+        # Other dummy encodings are rarely used and have not been supported yet.
+        # Adding support for them will require careful considerations.
+      }
+
       def handle_dummy_encoding(name, body)
-        # 'dummy' encodings are not properly implemented in Ruby MRI
-        if name.encoding.dummy?
-          # ISO-2022-JP is a legacy but still widely used encoding in Japan
-          # Here we properly convert ISO-2022-JP to UTF-8
-          if name.encoding == Encoding::ISO_2022_JP
-            name = name.encode(Encoding::UTF_8)
-            body = body.encode(Encoding::UTF_8)
-          end
+        # A string object with a 'dummy' encoding does not have full functionality and can cause errors.
+        # So here we covert it to UTF-8 so that it can be handled properly.
+        if name.encoding.dummy? && REENCODE_DUMMY_ENCODINGS[name.encoding]
+          name = name.encode(Encoding::UTF_8)
+          body = body.encode(Encoding::UTF_8)
         end
         return name, body
       end

--- a/test/multipart/multiple_encodings
+++ b/test/multipart/multiple_encodings
@@ -1,0 +1,10 @@
+--AaB03x
+content-disposition: form-data; name="us-ascii"
+
+Alice
+--AaB03x
+content-disposition: form-data; name="iso-2022-jp"
+content-type: text/plain; charset=iso-2022-jp
+
+アリス
+--AaB03x--

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1050,4 +1050,11 @@ content-type: image/png\r
     f.write(params["image/png"][0])
     f.length.must_equal 26473
   end
+
+  it "supports ISO-2022-JP-encoded part" do
+    env = Rack::MockRequest.env_for("/", multipart_fixture(:multiple_encodings))
+    params = Rack::Multipart.parse_multipart(env)
+    params["us-ascii"].must_equal("Alice")
+    params["iso-2022-jp"].must_equal("アリス")
+  end
 end


### PR DESCRIPTION
Hi, I introduced simple workaround for ISO-2022-JP encoding in multipart form data handling, which solves #2245 .
Also, I added test case to verify correct handling of multipart data with ISO-2022-JP encoding.

I hope it helps.