### PR TITLE
[2.2-stable] Fix compatibility issues with Ruby 3.4.0dev

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4]
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2

--- a/lib/rack/auth/basic.rb
+++ b/lib/rack/auth/basic.rb
@@ -2,7 +2,6 @@
 
 require_relative 'abstract/handler'
 require_relative 'abstract/request'
-require 'base64'
 
 module Rack
   module Auth
@@ -48,7 +47,7 @@ module Rack
         end
 
         def credentials
-          @credentials ||= Base64.decode64(params).split(':', 2)
+          @credentials ||= params.unpack("m").first.split(':', 2)
         end
 
         def username

--- a/lib/rack/auth/digest/nonce.rb
+++ b/lib/rack/auth/digest/nonce.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'digest/md5'
-require 'base64'
 
 module Rack
   module Auth
@@ -21,7 +20,7 @@ module Rack
         end
 
         def self.parse(string)
-          new(*Base64.decode64(string).split(' ', 2))
+          new(*string.unpack("m").first.split(' ', 2))
         end
 
         def initialize(timestamp = Time.now, given_digest = nil)
@@ -29,7 +28,7 @@ module Rack
         end
 
         def to_s
-          Base64.encode64("#{@timestamp} #{digest}").strip
+          ["#{@timestamp} #{digest}"].pack("m").strip
         end
 
         def digest

--- a/lib/rack/session/cookie.rb
+++ b/lib/rack/session/cookie.rb
@@ -4,7 +4,6 @@ require 'openssl'
 require 'zlib'
 require_relative 'abstract/id'
 require 'json'
-require 'base64'
 require 'delegate'
 
 module Rack
@@ -51,11 +50,11 @@ module Rack
       # Encode session cookies as Base64
       class Base64
         def encode(str)
-          ::Base64.strict_encode64(str)
+          [str].pack("m0")
         end
 
         def decode(str)
-          ::Base64.decode64(str)
+          str.unpack("m").first
         end
 
         # Encode session cookies as Marshaled Base64 data

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -24,6 +24,7 @@ module Rack
 
     RFC2822_DAY_NAME = [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ]
     RFC2822_MONTH_NAME = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ]
+    RFC2396_PARSER = defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::RFC2396_Parser.new
 
     class << self
       attr_accessor :default_query_parser
@@ -42,13 +43,13 @@ module Rack
     # Like URI escaping, but with %20 instead of +. Strictly speaking this is
     # true URI escaping.
     def escape_path(s)
-      ::URI::DEFAULT_PARSER.escape s
+      RFC2396_PARSER.escape s
     end
 
     # Unescapes the **path** component of a URI.  See Rack::Utils.unescape for
     # unescaping query parameters or form components.
     def unescape_path(s)
-      ::URI::DEFAULT_PARSER.unescape s
+      RFC2396_PARSER.unescape s
     end
 
     # Unescapes a URI escaped string with +encoding+. +encoding+ will be the

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -382,7 +382,7 @@ module Rack
         ranges << (r0..r1)  if r0 <= r1
       end
 
-      return [] if ranges.map(&:size).sum > size
+      return [] if ranges.map(&:size).inject(0, :+) > size
 
       ranges
     end


### PR DESCRIPTION
I know `2.2` is marked a security patches only, but given `3.x` contains breaking changes, and a large part of the community still haven't been able to upgrade, I think it would be sensible to also consider simple compatibility patches, to make it work on Ruby 3.4.

The two issues I found where:

  - `base64` warnings, I went the same way as https://github.com/rack/rack/commit/696ed9e8f48053683a0a19fc68eb49f094c0efcb, using `pack/unpack`.
  - `uri` warnings, just applied a simple fix.

NB: Test suite is failing on ruby-head because webrick needs an update: https://github.com/ruby/webrick/pull/144

cc @tenderlove @jeremyevans 