### PR TITLE
Opt-in for MFA requirement explicitly

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |s|
     "bug_tracker_uri" => "https://github.com/rack/rack/issues",
     "changelog_uri" => "https://github.com/rack/rack/blob/main/CHANGELOG.md",
     "documentation_uri" => "https://rubydoc.info/github/rack/rack",
-    "source_code_uri"   => "https://github.com/rack/rack"
+    "source_code_uri"   => "https://github.com/rack/rack",
+    "rubygems_mfa_required" => "true"
   }
 
   s.add_development_dependency 'minitest', "~> 5.0"


### PR DESCRIPTION
As a pupular gem, `rack` implicitly requires that all privileged operations by any of the owners require OTP.

However, by explicitly setting `rubygems_mfa_required` metadata, the gem will show "NEW VERSIONS REQUIRE MFA" and
"VERSION PUBLISHED WITH MFA" in the sidebar at
https://rubygems.org/gems/rack

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/
