### PR TITLE
Make `env[QUERY_STRING]` optional.

### DIFF
--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -44,8 +44,8 @@ below.
                      percent-encoded when originating from
                      a URL.
 <tt>QUERY_STRING</tt>:: The portion of the request URL that
-                        follows the <tt>?</tt>, if any. May be
-                        empty, but is always required!
+                        follows the <tt>?</tt>, if any. If no <tt>?</tt>
+                        is present, this value is <tt>nil</tt>.
 <tt>SERVER_NAME</tt>:: When combined with <tt>SCRIPT_NAME</tt> and
                        <tt>PATH_INFO</tt>, these variables can be
                        used to complete the URL. Note, however,

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -134,8 +134,8 @@ module Rack
         ##                      a URL.
 
         ## <tt>QUERY_STRING</tt>:: The portion of the request URL that
-        ##                         follows the <tt>?</tt>, if any. May be
-        ##                         empty, but is always required!
+        ##                         follows the <tt>?</tt>, if any. If no <tt>?</tt>
+        ##                         is present, this value is <tt>nil</tt>.
 
         ## <tt>SERVER_NAME</tt>:: When combined with <tt>SCRIPT_NAME</tt> and
         ##                        <tt>PATH_INFO</tt>, these variables can be
@@ -279,7 +279,7 @@ module Rack
         ## is reserved for use with the Rack core distribution and other
         ## accepted specifications and must not be used otherwise.
         ##
-        %w[REQUEST_METHOD SERVER_NAME QUERY_STRING SERVER_PROTOCOL rack.errors].each do |header|
+        %w[REQUEST_METHOD SERVER_NAME SERVER_PROTOCOL rack.errors].each do |header|
           raise LintError, "env missing required key #{header}" unless env.include? header
         end
 
@@ -386,6 +386,12 @@ module Rack
           else
             raise LintError, "PATH_INFO must start with a '/' and must not include a fragment part starting with '#' (origin-form)"
           end
+        end
+
+        # * The <tt>QUERY_STRING</tt>, if provided, must be a valid query string or <tt>nil</tt>. The query string is the part of the request target that follows the first <tt>?</tt> character, and may be an empty string. If the request target does not include a query string, <tt>env[QUERY_STRING]</tt> must be <tt>nil</tt>.
+        query_string = env['QUERY_STRING']
+        unless query_string.kind_of?(String) || query_string.nil?
+          raise LintError, "QUERY_STRING must be a String or nil"
         end
 
         ## * The <tt>CONTENT_LENGTH</tt>, if given, must consist of digits only.

--- a/lib/rack/mock_request.rb
+++ b/lib/rack/mock_request.rb
@@ -105,7 +105,9 @@ module Rack
       env[SERVER_NAME]     = (uri.host || "example.org").b
       env[SERVER_PORT]     = (uri.port ? uri.port.to_s : "80").b
       env[SERVER_PROTOCOL] = opts[:http_version] || 'HTTP/1.1'
-      env[QUERY_STRING]    = (uri.query.to_s).b
+      if query = uri.query
+        env[QUERY_STRING]    = query.b
+      end
       env[PATH_INFO]       = (uri.path).b
       env[RACK_URL_SCHEME] = (uri.scheme || "http").b
       env[HTTPS]           = (env[RACK_URL_SCHEME] == "https" ? "on" : "off").b

--- a/test/spec_mock_request.rb
+++ b/test/spec_mock_request.rb
@@ -88,7 +88,7 @@ describe Rack::MockRequest do
     env["SERVER_NAME"].must_equal "example.org"
     env["SERVER_PORT"].must_equal "80"
     env["SERVER_PROTOCOL"].must_equal "HTTP/1.1"
-    env["QUERY_STRING"].must_equal ""
+    env["QUERY_STRING"].must_be_nil
     env["PATH_INFO"].must_equal "/"
     env["SCRIPT_NAME"].must_equal ""
     env["rack.url_scheme"].must_equal "http"
@@ -170,7 +170,7 @@ describe Rack::MockRequest do
     env["REQUEST_METHOD"].must_equal "GET"
     env["SERVER_NAME"].must_equal "example.org"
     env["SERVER_PORT"].must_equal "443"
-    env["QUERY_STRING"].must_equal ""
+    env["QUERY_STRING"].must_be_nil
     env["PATH_INFO"].must_equal "/foo"
     env["rack.url_scheme"].must_equal "https"
     env["HTTPS"].must_equal "on"
@@ -185,7 +185,7 @@ describe Rack::MockRequest do
     env["REQUEST_METHOD"].must_equal "GET"
     env["SERVER_NAME"].must_equal "example.org"
     env["SERVER_PORT"].must_equal "80"
-    env["QUERY_STRING"].must_equal ""
+    env["QUERY_STRING"].must_be_nil
     env["PATH_INFO"].must_equal "/foo"
     env["rack.url_scheme"].must_equal "http"
   end
@@ -232,7 +232,7 @@ describe Rack::MockRequest do
     res = Rack::MockRequest.new(app).post("/foo", params: { foo: { bar: "1" } })
     env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
-    env["QUERY_STRING"].must_equal ""
+    env["QUERY_STRING"].must_be_nil
     env["PATH_INFO"].must_equal "/foo"
     env["CONTENT_TYPE"].must_equal "application/x-www-form-urlencoded"
     env["mock.postdata"].must_equal "foo%5Bbar%5D=1"
@@ -242,7 +242,7 @@ describe Rack::MockRequest do
     res = Rack::MockRequest.new(app).post("/foo", params: "foo%5Bbar%5D=1")
     env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
-    env["QUERY_STRING"].must_equal ""
+    env["QUERY_STRING"].must_be_nil
     env["PATH_INFO"].must_equal "/foo"
     env["CONTENT_TYPE"].must_equal "application/x-www-form-urlencoded"
     env["mock.postdata"].must_equal "foo%5Bbar%5D=1"
@@ -253,7 +253,7 @@ describe Rack::MockRequest do
     res = Rack::MockRequest.new(app).post("/foo", params: { "submit-name" => "Larry", "files" => files })
     env = YAML.unsafe_load(res.body)
     env["REQUEST_METHOD"].must_equal "POST"
-    env["QUERY_STRING"].must_equal ""
+    env["QUERY_STRING"].must_be_nil
     env["PATH_INFO"].must_equal "/foo"
     env["CONTENT_TYPE"].must_equal "multipart/form-data; boundary=AaB03x"
     # The gsub accounts for differences in YAMLs affect on the data.
@@ -276,7 +276,7 @@ describe Rack::MockRequest do
   end
 
   it "defaults encoding to ASCII 8BIT" do
-    req = Rack::MockRequest.env_for("/foo")
+    req = Rack::MockRequest.env_for("/foo?x=10")
 
     keys = [
       Rack::REQUEST_METHOD,

--- a/test/spec_recursive.rb
+++ b/test/spec_recursive.rb
@@ -14,7 +14,7 @@ describe Rack::Recursive do
   @app1 = lambda { |env|
     res = Rack::Response.new
     res["x-path-info"] = env["PATH_INFO"]
-    res["x-query-string"] = env["QUERY_STRING"]
+    res["x-query-string"] = env["QUERY_STRING"].to_s
     res.finish do |inner_res|
       inner_res.write "App1"
     end


### PR DESCRIPTION
At present, there is no way to differentiate between these two URLs:

1. `http://example.com/foo/bar`
2. `http://example.com/foo/bar?`

Ruby's `uri` implementation does differentiate between these, using `nil` for the former and empty string for the latter:

```
irb(main):002> URI.parse("http://foo.com/bar").query
=> nil
irb(main):003> URI.parse("http://foo.com/bar?").query
=> ""
irb(main):004> URI.parse("http://foo.com/bar?x=y").query
=> "x=y"
```