### PR TITLE
consistent clean_path_info separator

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -607,9 +607,7 @@ module Rack
         part == '..' ? clean.pop : clean << part
       end
 
-      clean_path = clean.join(::File::SEPARATOR)
-      clean_path.prepend("/") if parts.empty? || parts.first.empty?
-      clean_path
+      "#{::File::SEPARATOR}#{clean.join(::File::SEPARATOR)}"
     end
 
     NULL_BYTE = "\0"


### PR DESCRIPTION
It is inconsistent to prepend `/` while earlier `clean.join(::File::SEPARATOR)`.

Additionally request `PATH_INFO` should always start with a slash so we
can remove the conditional prepending and just always prepend.

This can also prevent path traversal attacks in case some code checks
the request path beginning using string comparison or regular expression
but the underlying server implementation allowed a request path without
a leading slash through.

I can say that at least puma fails fast on request paths without a
leading slash but I see no harm in being extra sure.

P.S. actually I'd be even happier to make it `join("/")` instead of `clean.join(::File::SEPARATOR)`. Is there any arch that would need a different separator than `/`?