### PR TITLE
Avoid wrapping nil input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::Logger` is removed with no replacement. ([#2196](https://github.com/rack/rack/pull/2196), [@ioquatix])
 - Automatic cache invalidation in `Rack::Request#{GET,POST}` has been removed. ([#2230](https://github.com/rack/rack/pull/2230), [@jeremyevans])
 
+### Fixed
+
+- `Rack::RewindableInput::Middleware` no longer wraps a nil input. ([#2259](https://github.com/rack/rack/pull/2259), [@tt](https://github.com/tt))
+
 ## [3.1.8] - 2024-10-14
 
 ### Fixed

--- a/lib/rack/rewindable_input.rb
+++ b/lib/rack/rewindable_input.rb
@@ -21,7 +21,10 @@ module Rack
       end
 
       def call(env)
-        env[RACK_INPUT] = RewindableInput.new(env[RACK_INPUT])
+        if (input = env[RACK_INPUT])
+          env[RACK_INPUT] = RewindableInput.new(input)
+        end
+
         @app.call(env)
       end
     end

--- a/test/spec_rewindable_input.rb
+++ b/test/spec_rewindable_input.rb
@@ -172,4 +172,11 @@ describe Rack::RewindableInput::Middleware do
     app = Rack::RewindableInput::Middleware.new(app)
     app.call('rack.input'=>StringIO.new(''))[2].must_equal ['Rack::RewindableInput']
   end
+
+  it "preserves a nil rack.input" do
+    app = proc{|env| [200, {}, [env['rack.input'].class.to_s]]}
+    app.call('rack.input'=>nil)[2].must_equal ['NilClass']
+    app = Rack::RewindableInput::Middleware.new(app)
+    app.call('rack.input'=>nil)[2].must_equal ['NilClass']
+  end
 end


### PR DESCRIPTION
Rack ships with the `Rack::RewindableInput::Middleware` middleware for compatibility with older apps.

However, this middleware wraps `rack.input` unconditionally meaning that a nil input will also be wrapped potentially leading to exceptions.

Concretely, I have an older app with a middleware that's trying to `req.body&.read` and `req.body&.rewind` which for `GET` and `HEAD` requests now cause the following error:

```
NoMethodError: undefined method `read' for nil
   ~/.gem/ruby/3.3.6/gems/rack-3.1.8/lib/rack/rewindable_input.rb:96:in `make_rewindable'
   ~/.gem/ruby/3.3.6/gems/rack-3.1.8/lib/rack/rewindable_input.rb:41:in `read'
```

This middleware should probably interrogate `req.request_method`.

Even so, it seems that for backwards compatibility (and to avoid the possibility of runtime errors overall), it would be great to never wrap a nil value.