### PR TITLE
fix: malformed charset param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. For info on
 
 - Invalid cookie keys will now raise an error. ([#2193](https://github.com/rack/rack/pull/2193), [@ioquatix])
 - `Rack::MediaType#params` now handles empty strings. ([#2229](https://github.com/rack/rack/pull/2229), [@jeremyevans])
+- `Rack::MediaType#params` now handles parameters without values. ([#2263](https://github.com/rack/rack/pull/2263), [@AllyMarthaJ](https://github.com/AllyMarthaJ))
 
 ### Deprecated
 

--- a/lib/rack/media_type.rb
+++ b/lib/rack/media_type.rb
@@ -26,6 +26,11 @@ module Rack
       # provided.  e.g., when the CONTENT_TYPE is "text/plain;charset=utf-8",
       # this method responds with the following Hash:
       #   { 'charset' => 'utf-8' }
+      #
+      # This will pass back parameters with empty strings in the hash if they
+      # lack a value (e.g., "text/plain;charset=" will return { 'charset' => '' },
+      # and "text/plain;charset" will return { 'charset' => '' }, similarly to 
+      # the query params parser (barring the latter case, which returns nil instead)).
       def params(content_type)
         return {} if content_type.nil? || content_type.empty?
 
@@ -39,9 +44,9 @@ module Rack
 
       private
 
-        def strip_doublequotes(str)
-          (str.start_with?('"') && str.end_with?('"')) ? str[1..-2] : str
-        end
+      def strip_doublequotes(str)
+        (str && str.start_with?('"') && str.end_with?('"')) ? str[1..-2] : str || ''
+      end
     end
   end
 end

--- a/test/spec_media_type.rb
+++ b/test/spec_media_type.rb
@@ -56,4 +56,28 @@ describe Rack::MediaType do
       Rack::MediaType.params(@content_type)['charset'].must_equal 'utf-8'
     end
   end
+
+  describe 'when content_type contains media_type and incomplete params' do 
+    before { @content_type = 'application/text;CHARSET' }
+
+    it '#type is application/text' do
+      Rack::MediaType.type(@content_type).must_equal 'application/text'
+    end
+
+    it '#params has key "charset" with value ""' do
+      Rack::MediaType.params(@content_type)['charset'].must_equal ''
+    end
+  end
+
+  describe 'when content_type contains media_type and empty params' do 
+    before { @content_type = 'application/text;CHARSET=' }
+
+    it '#type is application/text' do
+      Rack::MediaType.type(@content_type).must_equal 'application/text'
+    end
+
+    it '#params has key "charset" with value of empty string' do
+      Rack::MediaType.params(@content_type)['charset'].must_equal ''
+    end
+  end
 end


### PR DESCRIPTION
If a content type header is provided with a malformed part, there's no nice way of interpreting it since instead of being a key/value pair it's just a key.

I think the sensible option here is to assume, like in the case where a param is provided with an empty value, that the value is an empty string. I'm not super tied to this, though (for example, it could just as easily be omitted from the params entirely, or the value could simply be nil; each option are equally as valid).

issue: https://github.com/rack/rack/issues/2250