### PR TITLE
Mime type should use semi-colon rather than comma.

### DIFF
--- a/test/multipart/mixed_files
+++ b/test/multipart/mixed_files
@@ -4,7 +4,7 @@ content-disposition: form-data; name="foo"
 bar
 --AaB03x
 content-disposition: form-data; name="files"
-content-type: multipart/mixed, boundary=BbC04y
+content-type: multipart/mixed; boundary=BbC04y
 
 --BbC04y
 content-disposition: attachment; filename="file.txt"

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -82,7 +82,7 @@ describe Rack::MethodOverride do
 content-disposition: form-data; name="huge"; filename="huge"\r
 EOF
     env = Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size.to_s,
                       :method => "POST", :input => input)
     app.call env
@@ -96,7 +96,7 @@ EOF
 content-disposition: form-data; name="huge"; filename="huge"\r
 EOF
     env = Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size.to_s,
                       Rack::RACK_ERRORS => StringIO.new,
                       :method => "POST", :input => input)

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -744,7 +744,7 @@ content-type: image/jpeg\r
     input = File.read(multipart_file("bad_robots"))
 
     req = Rack::Request.new Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=1yy3laWhgX31qpiHinh67wJXqKalukEUTvqTzmon",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=1yy3laWhgX31qpiHinh67wJXqKalukEUTvqTzmon",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -778,7 +778,7 @@ class RackRequestTest < Minitest::Spec
   it "safely accepts POST requests with empty body" do
     mr = Rack::MockRequest.env_for("/",
       "REQUEST_METHOD" => "POST",
-      "CONTENT_TYPE"   => "multipart/form-data, boundary=AaB03x",
+      "CONTENT_TYPE"   => "multipart/form-data; boundary=AaB03x",
       "CONTENT_LENGTH" => '0',
       :input => nil)
 
@@ -1180,7 +1180,7 @@ content-transfer-encoding: base64\r
 --AaB03x--\r
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1219,7 +1219,7 @@ content-transfer-encoding: base64
 --AaB03x--
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1243,7 +1243,7 @@ content-transfer-encoding: base64\r
 --AaB03x--\r
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1274,7 +1274,7 @@ EOF
 EOF
     mr = Rack::MockRequest.env_for(
       "/",
-      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
       "CONTENT_LENGTH" => input.size,
       :input => input
     )
@@ -1357,7 +1357,7 @@ content-disposition: form-data; name="mean"; filename="mean"\r
 --AaB03x--\r
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1383,7 +1383,7 @@ content-transfer-encoding: base64\r
 --AaB03x--\r
 EOF
     env = Rack::MockRequest.env_for("/",
-                          "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                          "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                           "CONTENT_LENGTH" => input.size,
                           :input => input)
     req = make_request(env)
@@ -1397,7 +1397,7 @@ EOF
 content-disposition: form-data; name="huge"; filename="huge"\r
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1410,7 +1410,7 @@ content-disposition: form-data; name="huge"; filename="huge"\r
 foo\r
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1423,7 +1423,7 @@ content-disposition: form-data; name="huge"; filename="huge"\r
 foo\r
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1436,7 +1436,7 @@ EOF
 content-disposition: form-data; name="huge"; filename="huge"\r
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1455,7 +1455,7 @@ foo\r
 --AaB03x--\r
 EOF
     req = make_request Rack::MockRequest.env_for("/",
-                      "CONTENT_TYPE" => "multipart/related, boundary=AaB03x",
+                      "CONTENT_TYPE" => "multipart/related; boundary=AaB03x",
                       "CONTENT_LENGTH" => input.size,
                       :input => input)
 
@@ -1473,7 +1473,7 @@ content-type: application/octet-stream\r
 EOF
 
         req = make_request Rack::MockRequest.env_for("/",
-                          "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+                          "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
                           "CONTENT_LENGTH" => input.size,
                           :input => input)
 
@@ -1521,7 +1521,7 @@ content-transfer-encoding: base64\r
 EOF
     input.force_encoding(Encoding::ASCII_8BIT)
     res = Rack::MockRequest.new(Rack::Lint.new(app)).get "/",
-      "CONTENT_TYPE" => "multipart/form-data, boundary=AaB03x",
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
       "CONTENT_LENGTH" => input.size.to_s, "rack.input" => StringIO.new(input)
 
     res.must_be :ok?


### PR DESCRIPTION
See <https://datatracker.ietf.org/doc/html/rfc1341> for the formal specification, e.g.

```
Content-Type := type "/" subtype *[";" parameter]
```

We don't validate this in the Lint, but when I experimented with adding validations, I picked this up.