### PR TITLE
Fix `NoMethodError` in `Request#wrap_ipv6` when `x-forwarded-host` is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Fixed
 
 - `Rack::RewindableInput::Middleware` no longer wraps a nil input. ([#2259](https://github.com/rack/rack/pull/2259), [@tt](https://github.com/tt))
+- Fix `NoMethodError` in `Rack::Request#wrap_ipv6` when `x-forwarded-host` is empty. ([#2270](https://github.com/rack/rack/pull/2270), [@oieioi](https://github.com/oieioi))
 
 ## [3.1.10] - 2025-02-12
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -398,7 +398,7 @@ module Rack
               return forwarded.last
             end
           when :x_forwarded
-            if x_forwarded_host = split_header(get_header(HTTP_X_FORWARDED_HOST)).last
+            if (value = get_header(HTTP_X_FORWARDED_HOST)) && (x_forwarded_host = split_header(value).last)
               return wrap_ipv6(x_forwarded_host)
             end
           end

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -398,8 +398,8 @@ module Rack
               return forwarded.last
             end
           when :x_forwarded
-            if value = get_header(HTTP_X_FORWARDED_HOST)
-              return wrap_ipv6(split_header(value).last)
+            if x_forwarded_host = split_header(get_header(HTTP_X_FORWARDED_HOST)).last
+              return wrap_ipv6(x_forwarded_host)
             end
           end
         end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -578,6 +578,10 @@ class RackRequestTest < Minitest::Spec
     req = make_request \
       Rack::MockRequest.env_for("/", "HTTP_HOST" => "localhost:81", "HTTP_X_FORWARDED_HOST" => "example.org", "HTTP_FORWARDED" => "host=example.com:9292", "SERVER_PORT" => "9393")
     req.host_with_port.must_equal "example.com:9292"
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "http://example.org", "HTTP_X_FORWARDED_HOST" => "")
+    req.host_with_port.must_equal "http://example.org"
   end
 
   it "parse the query string" do

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -580,8 +580,8 @@ class RackRequestTest < Minitest::Spec
     req.host_with_port.must_equal "example.com:9292"
 
     req = make_request \
-      Rack::MockRequest.env_for("/", "HTTP_HOST" => "http://example.org", "HTTP_X_FORWARDED_HOST" => "")
-    req.host_with_port.must_equal "http://example.org"
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "example.org", "HTTP_X_FORWARDED_HOST" => "")
+    req.host_with_port.must_equal "example.org"
   end
 
   it "parse the query string" do


### PR DESCRIPTION
Currently, sending a request with an empty `x-forwarded-host` causes a `NoMethodError` due to nil access in `wrap_ipv6`. Since `forwarded_authority` is the only method that could pass nil to `wrap_ipv6`, I added a nil check in `forwarded_authority` to prevent this issue.

For example, when making a request to a Rack server using JavaScript, an error occurred on the server.

```javascript
// client.js
let headers = new Headers
headers.set('x-forwarded-host', '')
let res = await fetch('http://rack-server.test', { method: 'GET', headers: headers})
```

```rb
# server.rb
# ...
logger.info("host_with_port: #{request.host_with_port}")
# ...
```

```
#<NoMethodError: undefined method `start_with?' for nil:NilClass
if !host.start_with?('[') && host.count(':') > 1
        ^^^^^^^^^^^^>
```