### PR TITLE
Handle empty content-type parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Fixed
 
 - `Rack::RewindableInput::Middleware` no longer wraps a nil input. ([#2259](https://github.com/rack/rack/pull/2259), [@tt](https://github.com/tt))
+- `Rack::MediaType` no longer fails with invalid content-type. ([#2273](https://github.com/rack/rack/pull/2273), [@redox](https://github.com/redox))
 
 ## [3.1.8] - 2024-10-14
 

--- a/lib/rack/media_type.rb
+++ b/lib/rack/media_type.rb
@@ -36,6 +36,7 @@ module Rack
 
         content_type.split(SPLIT_PATTERN)[1..-1].each_with_object({}) do |s, hsh|
           s.strip!
+          next if s.empty?
           k, v = s.split('=', 2)
           k.downcase!
           hsh[k] = strip_doublequotes(v)

--- a/test/spec_media_type.rb
+++ b/test/spec_media_type.rb
@@ -80,4 +80,16 @@ describe Rack::MediaType do
       Rack::MediaType.params(@content_type)['charset'].must_equal ''
     end
   end
+
+  describe 'when content_type is valid yet contains an empty part' do
+    before { @content_type = 'txtlainio;;z' }
+
+    it '#type is application/text' do
+      Rack::MediaType.type(@content_type).must_equal 'application/text'
+    end
+
+    it '#params has key "charset" with value "utf-8"' do
+      Rack::MediaType.params(@content_type)['charset'].must_equal 'utf-8'
+    end
+  end
 end


### PR DESCRIPTION
Hi,

we stumbled upon an issue with our Puma/rack stack where a content-type that seems to be valid (from a Cloudflare point-of-view at least - looks like it's not while looking at the [RFC](https://www.w3.org/Protocols/rfc1341/4_Content-Type.html)) ends up doing a `nil.downcase!`: `application/text;;charset=utf-8` (note the double `;`).

I'm unclear whether it's on `Rack` to validate the content-type, but at least we should not crash.