### PR TITLE
Add Ractor support

### DIFF
--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -908,6 +908,7 @@ module Rack
       end
 
       BODY_METHODS = {to_ary: true, each: true, call: true, to_path: true}
+      Ractor.make_shareable(BODY_METHODS) if defined?(Ractor)
 
       def to_path
         @body.to_path

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -560,6 +560,7 @@ module Rack
 
     # Responses with HTTP status codes that should not have an entity body
     STATUS_WITH_NO_ENTITY_BODY = Hash[((100..199).to_a << 204 << 304).product([true])]
+    Ractor.make_shareable(STATUS_WITH_NO_ENTITY_BODY) if defined?(Ractor)
 
     SYMBOL_TO_STATUS_CODE = Hash[*HTTP_STATUS_CODES.map { |code, message|
       [message.downcase.gsub(/\s|-/, '_').to_sym, code]


### PR DESCRIPTION
Hello,

I added some changes to rack to support Ractor.

- Make some constants ractor-shareable
  - `Rack::Utils::STATUS_WITH_NO_ENTITY_BODY`
  - `Rack::Lint::Wrapper::BODY_METHODS`

And I confirmed that:

- Without `Ractor`
  - It doesn't affect to the behavior with all ruby versions, except ruby-3.0.0-preview1
    - It's a preview version issue so I believe it's not a real problem

```
$ docker run -it -v .:/rack --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.4.0 ./all-ruby -I/rack/lib -W0 /rack/test.rb
ruby-2.4.0          [200, {"content-length"=>"0"}, [""]]
...
ruby-2.7.8          [200, {"content-length"=>"0"}, [""]]
ruby-3.0.0-preview1 [#<NoMethodError: undefined method `make_shareable' for Ractor:Class>, "/rack/lib/rack/utils.rb:563:in `<module:Utils>'"]
ruby-3.0.0-preview2 [200, {"content-length"=>"0"}, [""]]
...
ruby-3.4.0-preview1 [200, {"content-length"=>"0"}, [""]]
ruby-3.4.0-preview2 [200, {"content-length" => "0"}, [""]]
...
ruby-3.4.1          [200, {"content-length" => "0"}, [""]]
```

- With `Ractor`
  - It allows us to call `Rack::ContentLength#call` and `Rack::Lint#call` in Ractor with ruby >= 3.1.0
  - It can't allow us call `Rack::ContentLength#call` with ruby-3.0.x unfortunately
    - Because of the specification of Ractor on ruby-3.0.x

```
$ docker run -it -v .:/rack --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-3.0.0 ./all-ruby -I/rack/lib -W0 /rack/test.rb ractor
ruby-3.0.0          [:ractor, [#<Rack::Lint::LintError: example.com must be a valid authority>, "/rack/lib/rack/lint.rb:298:in `check_environment'"]]
...
ruby-3.0.7          [:ractor, [#<Rack::Lint::LintError: example.com must be a valid authority>, "/rack/lib/rack/lint.rb:298:in `check_environment'"]]
ruby-3.1.0-preview1 [:ractor, [200, {"content-length"=>"0"}, [""]]]
...
ruby-3.4.0-preview1 [:ractor, [200, {"content-length"=>"0"}, [""]]]
ruby-3.4.0-preview2 [:ractor, [200, {"content-length" => "0"}, [""]]]
...
ruby-3.4.1          [:ractor, [200, {"content-length" => "0"}, [""]]]
```

Here is my `test.rb`.
```test.rb
require "rack"

def test
  begin
    env = {"REQUEST_METHOD"=>"GET", "SERVER_NAME"=>"example.com", "QUERY_STRING"=>"GET", "SERVER_PROTOCOL"=>"HTTP/1.1", "rack.errors"=>$stderr, "rack.url_scheme"=>"http", "PATH_INFO"=>"/"}
    Rack::ContentLength.new(Rack::Lint.new(proc { |env| [200, {}, [""]] })).call(env)
  rescue
    [$!, $@[0]]
  end
end

if ARGV[0]
  test # for autoload
  p Ractor.new { [:ractor, test] }.take
else
  p test
end
```