### PR TITLE
feat: added a new options :exclude to Rack::Deflater

### DIFF
--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -311,7 +311,7 @@ describe Rack::Deflater do
   end
 
   it 'handle gzip response with last-modified header' do
-    last_modified = last_modified = Time.now.httpdate
+    last_modified = Time.now.httpdate
     options = {
       'response_headers' => {
         'content-type' => 'text/plain',

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -311,8 +311,7 @@ describe Rack::Deflater do
   end
 
   it 'handle gzip response with last-modified header' do
-    last_modified = 'Tue, 04 Feb 2025 19:23:29 GMT'
-
+    last_modified = last_modified = Time.now.httpdate
     options = {
       'response_headers' => {
         'content-type' => 'text/plain',


### PR DESCRIPTION
Currently we have a issue #1737 when last-modified is wrong, deflater is broken. 

So, I've just created a condition, something like that.

```rb
config.middleware.use(
  Rack::Deflater,
  if: ->(env, _, _, _) { !%r{/sidekiq}.match?(env['PATH_INFO']) }
)
```

But, It's not recognized in my eyes. I think that it's will be better if that was a exclude options, for example.

```rb
config.middleware.use(
  Rack::Deflater,
  exclude: ->(env, _, _, _) { %r{/sidekiq}.match?(env['PATH_INFO']) }
)
```

With truthy condition, right?
