### PR TITLE
Reduce unnecessary calls to Rack::Request.ip_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. For info on
 
 - Invalid cookie keys will now raise an error. ([#2193](https://github.com/rack/rack/pull/2193), [@ioquatix])
 - `Rack::MediaType#params` now handles empty strings. ([#2229](https://github.com/rack/rack/pull/2229), [@jeremyevans])
+- Avoid unnecessary calls to the `ip_filter` lambda to evaluate `Request#ip` ([#2287](https://github.com/rack/rack/pull/2287), [@willbryant])
 
 ### Deprecated
 


### PR DESCRIPTION
Previously this was typically invoked for every address found in REMOTE_ADDR/HTTP_FORWARDED/HTTP_X_FORWARDED_FOR. When ip_filter matches against several hundred IP ranges (eg. Cloudfront IP ranges), whole ms could be wasted.

Now it'll only be invoked until one acceptable address is found.