### PR TITLE
Add `assert_required` to clarify spec assertions.

### DIFF
--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -54,6 +54,7 @@ module Rack
   RACK_MULTIPART_BUFFER_SIZE          = 'rack.multipart.buffer_size'
   RACK_MULTIPART_TEMPFILE_FACTORY     = 'rack.multipart.tempfile_factory'
   RACK_RESPONSE_FINISHED              = 'rack.response_finished'
+  RACK_PROTOCOL                       = 'rack.protocol'
   RACK_REQUEST_FORM_INPUT             = 'rack.request.form_input'
   RACK_REQUEST_FORM_HASH              = 'rack.request.form_hash'
   RACK_REQUEST_FORM_PAIRS             = 'rack.request.form_pairs'


### PR DESCRIPTION
These are the code changes sans documentation changes from <https://github.com/rack/rack/pull/2256>.

The addition of two assertion helpers, is designed to clearly communicate the expectation of whether something is required or optional.

1. All the existing checks are semantically the same.
2. There are a few new checks as described by the documentation but not explicitly validated by the lint.
3. There are some minor cosmetic changes to the code for consistency.