### PR TITLE
Avoid re-running logic to determine Request#ip once it's been calculated the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. For info on
 - Invalid cookie keys will now raise an error. ([#2193](https://github.com/rack/rack/pull/2193), [@ioquatix])
 - `Rack::MediaType#params` now handles empty strings. ([#2229](https://github.com/rack/rack/pull/2229), [@jeremyevans])
 - Avoid unnecessary calls to the `ip_filter` lambda to evaluate `Request#ip` ([#2287](https://github.com/rack/rack/pull/2287), [@willbryant])
+- Only calculate `Request#ip` once per request ([#2292](https://github.com/rack/rack/pull/2292), [@willbryant])
 
 ### Deprecated
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -61,7 +61,12 @@ module Rack
 
     def initialize(env)
       @env = env
+      @ip = nil
       @params = nil
+    end
+
+    def ip
+      @ip ||= super
     end
 
     def params


### PR DESCRIPTION
As mentioned in #2288, this reduces the amount of redundant re-calculation needed when gems like rack-attack call `Request#ip` more than once.

Feedback on the code factoring most welcome. This seemed like the least invasive way to do it; the usual simple `@ip ||= begin..end` pattern inside the method wouldn't work due to the `return` statements, but if we don't like the idea of the logic being in one place and the caching another, I can set the ivar in each return statement.

I did feel like doing it like this makes it very easy to add caching to other methods included from Helper without rewriting them, though, which could be desired over time?