### PR TITLE
Don't use file separator for splitting path info.

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -595,10 +595,10 @@ module Rack
       end
     end
 
-    PATH_SEPS = Regexp.union(*[::File::SEPARATOR, ::File::ALT_SEPARATOR].compact)
+    PATH_SEPS = /\//.freeze
 
     def clean_path_info(path_info)
-      parts = path_info.split PATH_SEPS
+      parts = path_info.split("/")
 
       clean = []
 
@@ -607,7 +607,7 @@ module Rack
         part == '..' ? clean.pop : clean << part
       end
 
-      clean_path = clean.join(::File::SEPARATOR)
+      clean_path = clean.join("/")
       clean_path.prepend("/") if parts.empty? || parts.first.empty?
       clean_path
     end


### PR DESCRIPTION
It is only by coincidence that the `::File::SEPARATOR` is the same as the URI path separator, but semantically, they are unrelated. Ensure that only `"/"` is used to separate path segments, as per the RFC: https://datatracker.ietf.org/doc/html/rfc3986#section-3.3