### PR TITLE
Change SPEC to require request environment keys to be strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. For info on
 
 ## Unreleased
 
+### SPEC Changes
+
+- Request environment keys must now be strings. [#2310](https://github.com/rack/rack/issues/2310), [@jeremyevans])
+
 ### Added
 
 - Introduce `Rack::VERSION` constant. ([#2199](https://github.com/rack/rack/pull/2199), [@ioquatix])

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -8,7 +8,7 @@ A Rack application is a Ruby object that responds to +call+. It takes exactly on
 
 == The Request Environment
 
-Incoming HTTP requests are represented using an environment. The environment must be an unfrozen instance of +Hash+. The Rack application is free to modify the environment, but the modified environment should also comply with this specification.
+Incoming HTTP requests are represented using an environment. The environment must be an unfrozen instance of +Hash+. The Rack application is free to modify the environment, but the modified environment should also comply with this specification. All environment keys must be strings.
 
 === CGI Variables
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -134,9 +134,14 @@ module Rack
       ##
       ## Incoming HTTP requests are represented using an environment. \
       def check_environment(env)
-        ## The environment must be an unfrozen instance of +Hash+. The Rack application is free to modify the environment, but the modified environment should also comply with this specification.
+        ## The environment must be an unfrozen instance of +Hash+. The Rack application is free to modify the environment, but the modified environment should also comply with this specification. \
         raise LintError, "env #{env.inspect} is not a Hash, but #{env.class}" unless env.kind_of? Hash
         raise LintError, "env should not be frozen, but is" if env.frozen?
+
+        ## All environment keys must be strings.
+        unless env.keys.all?(String)
+          raise LintError, "env contains non-string keys"
+        end
 
         ##
         ## === CGI Variables

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -139,8 +139,10 @@ module Rack
         raise LintError, "env should not be frozen, but is" if env.frozen?
 
         ## All environment keys must be strings.
-        unless env.keys.all?(String)
-          raise LintError, "env contains non-string keys"
+        keys = env.keys
+        keys.reject!{|key| String === key}
+        unless keys.empty?
+          raise LintError, "env contains non-string keys: #{keys.inspect}"
         end
 
         ##

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -37,6 +37,9 @@ describe Rack::Lint do
     lambda { Rack::Lint.new(valid_app).call({}.freeze) }.must_raise(Rack::Lint::LintError).
       message.must_match(/env should not be frozen, but is/)
 
+    lambda { Rack::Lint.new(valid_app).call({a: 1}) }.must_raise(Rack::Lint::LintError).
+      message.must_equal("env contains non-string keys")
+
     lambda {
       e = env
       e.delete("REQUEST_METHOD")

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -38,7 +38,7 @@ describe Rack::Lint do
       message.must_match(/env should not be frozen, but is/)
 
     lambda { Rack::Lint.new(valid_app).call({a: 1}) }.must_raise(Rack::Lint::LintError).
-      message.must_equal("env contains non-string keys")
+      message.must_equal("env contains non-string keys: [:a]")
 
     lambda {
       e = env


### PR DESCRIPTION
Lint previously would raise for most non-String values, since it called:

```ruby
  key.include?(".")
```

on each environment key.  However, it's best to state this explicitly and add a specific Lint check for it.