### PR TITLE
Make Rack::Lint disallow PATH_INFO="" SCRIPT_NAME=""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file. For info on
 - Fix `NoMethodError` in `Rack::Request#wrap_ipv6` when `x-forwarded-host` is empty. ([#2270](https://github.com/rack/rack/pull/2270), [@oieioi](https://github.com/oieioi))
 - Fix the specification for `SERVER_PORT` which was incorrectly documented as required to be an `Integer` if present - it must be a `String` containing digits only. ([#2296](https://github.com/rack/rack/pull/2296), [@ioquatix])
 - `SERVER_NAME` and `HTTP_HOST` are now more strictly validated according to the relevant specifications. ([#2298](https://github.com/rack/rack/pull/2298), [@ioquatix])
+- `Rack::Lint` now disallows `PATH_INFO="" SCRIPT_NAME=""`. ([#2298](https://github.com/rack/rack/issues/2307), [@jeremyevans])
 
 ## [3.1.16] - 2025-06-04
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -195,7 +195,7 @@ module Rack
         end
 
         ## and one of <tt>SCRIPT_NAME</tt> or <tt>PATH_INFO</tt> must be set, e.g. <tt>PATH_INFO</tt> can be <tt>/</tt> if <tt>SCRIPT_NAME</tt> is empty.
-        unless env[SCRIPT_NAME] || env[PATH_INFO]
+        if env[SCRIPT_NAME].to_s.empty? && env[PATH_INFO].to_s.empty?
           raise LintError, "One of SCRIPT_NAME or PATH_INFO must be set (make PATH_INFO '/' if SCRIPT_NAME is empty)"
         end
 

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -244,6 +244,25 @@ describe Rack::Lint do
       message.must_match(/One of .* must be set/)
 
     lambda {
+      Rack::Lint.new(valid_app).call(env("PATH_INFO" => "", "SCRIPT_NAME" => ""))
+    }.must_raise(Rack::Lint::LintError).
+      message.must_match(/One of .* must be set/)
+
+    lambda {
+      e = env("PATH_INFO" => "")
+      e.delete("SCRIPT_NAME")
+      Rack::Lint.new(valid_app).call(e)
+    }.must_raise(Rack::Lint::LintError).
+      message.must_match(/One of .* must be set/)
+
+    lambda {
+      e = env("SCRIPT_NAME" => "")
+      e.delete("PATH_INFO")
+      Rack::Lint.new(valid_app).call(e)
+    }.must_raise(Rack::Lint::LintError).
+      message.must_match(/One of .* must be set/)
+
+    lambda {
       Rack::Lint.new(valid_app).call(env("SCRIPT_NAME" => "/"))
     }.must_raise(Rack::Lint::LintError).
       message.must_match(/cannot be .* make it ''/)
@@ -321,7 +340,7 @@ describe Rack::Lint do
   end
 
   it "accepts empty PATH_INFO" do
-    Rack::Lint.new(valid_app).call(env("PATH_INFO" => "")).first.must_equal 200
+    Rack::Lint.new(valid_app).call(env("PATH_INFO" => "", "SCRIPT_NAME" => "/foo")).first.must_equal 200
   end
 
   it "notices request-target asterisk form errors" do


### PR DESCRIPTION
This was previously allowed, even though the text implies it shouldn't be valid.  As such, I consider this a bug fix and not a SPEC change.

Fixes #2307.