### PR TITLE
Add `nil` as a valid return from a Response `body.to_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. For info on
 ### SPEC Changes
 
 - Request environment keys must now be strings. [#2310](https://github.com/rack/rack/issues/2310), [@jeremyevans])
+- Add `nil` as a valid return from a Response `body.to_path` ([#2318](https://github.com/rack/rack/pull/2318), [@MSP-Greg])
 
 ### Added
 

--- a/SPEC.rdoc
+++ b/SPEC.rdoc
@@ -235,7 +235,7 @@ The Body must either be consumed or returned. The Body is consumed by optionally
 
 After calling +close+, the Body is considered closed and should not be consumed again. If the original Body is replaced by a new Body, the new Body must also consume the original Body by calling +close+ if possible.
 
-If the Body responds to +to_path+, it must return a +String+ path for the local file system whose contents are identical to that produced by calling +each+; this may be used by the server as an alternative, possibly more efficient way to transport the response. The +to_path+ method does not consume the body.
+If the Body responds to +to_path+, it must return either +nil+ or a +String+. If a +String+ is returned, it must be a path for the local file system whose contents are identical to that produced by calling +each+; this may be used by the server as an alternative, possibly more efficient way to transport the response. The +to_path+ method does not consume the body.
 
 ==== Enumerable Body
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -837,8 +837,12 @@ module Rack
         ##
         ## If the Body responds to +to_path+, it must return a +String+ path for the local file system whose contents are identical to that produced by calling +each+; this may be used by the server as an alternative, possibly more efficient way to transport the response. The +to_path+ method does not consume the body.
         if @body.respond_to?(:to_path)
-          unless ::File.exist? @body.to_path
-            raise LintError, "The file identified by body.to_path does not exist"
+          optional_path = @body.to_path
+
+          if optional_path != nil
+            unless optional_path.is_a?(String) && ::File.exist?(optional_path)
+              raise LintError, "The file identified by body.to_path does not exist"
+            end
           end
         end
       end

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -841,7 +841,7 @@ module Rack
 
           if optional_path != nil
             unless optional_path.is_a?(String) && ::File.exist?(optional_path)
-              raise LintError, "The file identified by body.to_path does not exist"
+              raise LintError, "body.to_path must be nil or a path to an existing file"
             end
           end
         end

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -835,7 +835,7 @@ module Rack
 
       def verify_to_path
         ##
-        ## If the Body responds to +to_path+, it must return a +String+ path for the local file system whose contents are identical to that produced by calling +each+; this may be used by the server as an alternative, possibly more efficient way to transport the response. The +to_path+ method does not consume the body.
+        ## If the Body responds to +to_path+, it must return either +nil+ or a +String+. If a +String+ is returned, it must be a path for the local file system whose contents are identical to that produced by calling +each+; this may be used by the server as an alternative, possibly more efficient way to transport the response. The +to_path+ method does not consume the body.
         if @body.respond_to?(:to_path)
           optional_path = @body.to_path
 

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -607,6 +607,17 @@ describe Rack::Lint do
     body.to_path.must_equal __FILE__
   end
 
+  it "handles body.to_path returning nil" do
+    body = Object.new
+    def body.each; end
+    def body.to_path; nil end
+    app = lambda { |env| [200, {}, body] }
+
+    body = Rack::Lint.new(app).call(env({}))[2]
+    body.must_respond_to(:to_path)
+    body.to_path.must_be_nil
+  end
+
   it "notice body errors" do
     lambda {
       body = Rack::Lint.new(lambda { |env|
@@ -734,6 +745,17 @@ describe Rack::Lint do
                                to_path = Object.new
                                def to_path.each; end
                                def to_path.to_path; 'non-existent' end
+                               [200, { "content-type" => "text/plain", "content-length" => "0" }, to_path]
+                             }).call(env({}))[2]
+      body.each { |part| }
+    }.must_raise(Rack::Lint::LintError).
+      message.must_equal 'The file identified by body.to_path does not exist'
+
+    lambda {
+      body = Rack::Lint.new(lambda { |env|
+                               to_path = Object.new
+                               def to_path.each; end
+                               def to_path.to_path; false end
                                [200, { "content-type" => "text/plain", "content-length" => "0" }, to_path]
                              }).call(env({}))[2]
       body.each { |part| }

--- a/test/spec_lint.rb
+++ b/test/spec_lint.rb
@@ -749,7 +749,7 @@ describe Rack::Lint do
                              }).call(env({}))[2]
       body.each { |part| }
     }.must_raise(Rack::Lint::LintError).
-      message.must_equal 'The file identified by body.to_path does not exist'
+      message.must_equal 'body.to_path must be nil or a path to an existing file'
 
     lambda {
       body = Rack::Lint.new(lambda { |env|
@@ -760,7 +760,7 @@ describe Rack::Lint do
                              }).call(env({}))[2]
       body.each { |part| }
     }.must_raise(Rack::Lint::LintError).
-      message.must_equal 'The file identified by body.to_path does not exist'
+      message.must_equal 'body.to_path must be nil or a path to an existing file'
 
     lambda {
       body = Rack::Lint.new(lambda { |env|


### PR DESCRIPTION
Currently, a Response's `body.to_path` is only allowed to return a `String`.  Ruby's `IO.to_path` can be `nil` or a `String`.

Allow `nil` to be returned, add tests, update SPEC.

Closes #2317