### PR TITLE
[3-1-stable] Replace usage of `CGI::Cookie`

### DIFF
--- a/test/spec_mock_response.rb
+++ b/test/spec_mock_response.rb
@@ -84,6 +84,7 @@ describe Rack::MockResponse do
   it "provides access to session cookies" do
     res = Rack::MockRequest.new(app).get("")
     session_cookie = res.cookie("session_test")
+    session_cookie[0].must_equal "session_test"
     session_cookie.value[0].must_equal "session_test"
     session_cookie.domain.must_equal "test.com"
     session_cookie.path.must_equal "/"

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'helper'
-require 'cgi'
+require 'cgi/escape'
 require 'forwardable'
 require 'securerandom'
 


### PR DESCRIPTION
It's https://github.com/rack/rack/pull/2327, but for the latest stable version (:

cc @byroot 