### PR TITLE
[2.2-stable] Replace usage of CGI::Cookie

### DIFF
--- a/test/spec_mock.rb
+++ b/test/spec_mock.rb
@@ -292,6 +292,7 @@ describe Rack::MockResponse do
   it "provide access to session cookies" do
     res = Rack::MockRequest.new(app).get("")
     session_cookie = res.cookie("session_test")
+    session_cookie[0].must_equal "session_test"
     session_cookie.value[0].must_equal "session_test"
     session_cookie.domain.must_equal "test.com"
     session_cookie.path.must_equal "/"

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'helper'
-require 'cgi'
+require 'cgi/escape'
 require 'forwardable'
 require 'securerandom'
 


### PR DESCRIPTION
In Ruby 3.5, `cgi` will only contain functions related to escaping/unescaping.

https://bugs.ruby-lang.org/issues/21258

This is not an exact replicate of course, (`CGI::Cookie`) has some validations and coerces on setters but considering for that purpose this is, they don't seem necessary? During construction of the object rack already does conversions as necessary and setters don't make much sense, and aren't documented/tested for.

Although, for improved backwards compatibility, it wouldn't be much effort to make them `attr_accesor` instead.

cc @jeremyevans @Earlopain 