### PR TITLE
[2.2] Update test suite for Ruby 3.5

### DIFF
--- a/test/spec_session_cookie.rb
+++ b/test/spec_session_cookie.rb
@@ -186,14 +186,14 @@ describe Rack::Session::Cookie do
     response = response_for(app: [incrementor, { coder: identity }])
 
     response["Set-Cookie"].must_include "rack.session="
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter" => 1 }.to_s)
     identity.calls.must_equal [:decode, :encode]
   end
 
   it "creates a new cookie" do
     response = response_for(app: incrementor)
     response["Set-Cookie"].must_include "rack.session="
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter" => 1 }.to_s)
   end
 
   it "passes through same_site option to session cookie" do
@@ -217,10 +217,10 @@ describe Rack::Session::Cookie do
     response = response_for(app: incrementor)
 
     response = response_for(app: incrementor, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.body.must_equal({ "counter" => 2 }.to_s)
 
     response = response_for(app: incrementor, cookie: response)
-    response.body.must_equal '{"counter"=>3}'
+    response.body.must_equal({ "counter"=> 3 }.to_s)
   end
 
   it "renew session id" do
@@ -259,13 +259,13 @@ describe Rack::Session::Cookie do
       app: incrementor,
       cookie: "rack.session=blarghfasel"
     )
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
 
     response = response_for(
       app: [incrementor, { secret: "test" }],
       cookie: "rack.session="
     )
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
   end
 
   it "barks on too big cookies" do
@@ -279,15 +279,15 @@ describe Rack::Session::Cookie do
 
     response = response_for(app: app)
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.body.must_equal({ "counter"=> 2 }.to_s)
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>3}'
+    response.body.must_equal({ "counter"=> 3 }.to_s)
 
     app = [incrementor, { secret: "other" }]
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
   end
 
   it "loads from a cookie with accept-only integrity hash for graceful key rotation" do
@@ -295,42 +295,42 @@ describe Rack::Session::Cookie do
 
     app = [incrementor, { secret: "test2", old_secret: "test" }]
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.body.must_equal({ "counter"=> 2 }.to_s)
 
     app = [incrementor, { secret: "test3", old_secret: "test2" }]
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>3}'
+    response.body.must_equal({ "counter"=> 3 }.to_s)
   end
 
   it "ignores tampered with session cookies" do
     app = [incrementor, { secret: "test" }]
     response = response_for(app: app)
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.body.must_equal({ "counter"=> 2 }.to_s)
 
     _, digest = response["Set-Cookie"].split("--")
     tampered_with_cookie = "hackerman-was-here" + "--" + digest
 
     response = response_for(app: app, cookie: tampered_with_cookie)
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
   end
 
   it "supports either of secret or old_secret" do
     app = [incrementor, { secret: "test" }]
     response = response_for(app: app)
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.body.must_equal({ "counter"=> 2 }.to_s)
 
     app = [incrementor, { old_secret: "test" }]
     response = response_for(app: app)
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.body.must_equal({ "counter"=> 2 }.to_s)
   end
 
   it "supports custom digest class" do
@@ -338,15 +338,15 @@ describe Rack::Session::Cookie do
 
     response = response_for(app: app)
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>2}'
+    response.body.must_equal({ "counter"=> 2 }.to_s)
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>3}'
+    response.body.must_equal({ "counter"=> 3 }.to_s)
 
     app = [incrementor, { secret: "other" }]
 
     response = response_for(app: app, cookie: response)
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
   end
 
   it "can handle Rack::Lint middleware" do
@@ -377,11 +377,11 @@ describe Rack::Session::Cookie do
 
   it "returns the session id in the session hash" do
     response = response_for(app: incrementor)
-    response.body.must_equal '{"counter"=>1}'
+    response.body.must_equal({ "counter"=> 1 }.to_s)
 
     response = response_for(app: session_id, cookie: response)
-    response.body.must_match(/"session_id"=>/)
-    response.body.must_match(/"counter"=>1/)
+    response.body.must_match(/"session_id"\s*=>/)
+    response.body.must_match(/"counter"\s*=>\s*1/)
   end
 
   it "does not return a cookie if set to secure but not using ssl" do
@@ -491,8 +491,8 @@ describe Rack::Session::Cookie do
       incrementor
     ], cookie: non_strict_response)
 
-    response.body.must_match %Q["value"=>"#{'A' * 256}"]
-    response.body.must_match '"counter"=>2'
+    response.body.must_match({ "value"=> 'A' * 256 }.to_s[1..-2])
+    response.body.must_match({ "counter" => 2 }.to_s[1..-2])
     response.body.must_match(/\A{[^}]+}\z/)
   end
 end

--- a/test/spec_session_pool.rb
+++ b/test/spec_session_pool.rb
@@ -41,7 +41,7 @@ describe Rack::Session::Pool do
     pool = Rack::Session::Pool.new(incrementor)
     res = Rack::MockRequest.new(pool).get("/")
     res["Set-Cookie"].must_match(session_match)
-    res.body.must_equal '{"counter"=>1}'
+    res.body.must_equal({ "counter" => 1 }.to_s)
   end
 
   it "determines session from a cookie" do
@@ -49,16 +49,16 @@ describe Rack::Session::Pool do
     req = Rack::MockRequest.new(pool)
     cookie = req.get("/")["Set-Cookie"]
     req.get("/", "HTTP_COOKIE" => cookie).
-      body.must_equal '{"counter"=>2}'
+      body.must_equal({ "counter" => 2 }.to_s)
     req.get("/", "HTTP_COOKIE" => cookie).
-      body.must_equal '{"counter"=>3}'
+      body.must_equal({ "counter" => 3 }.to_s)
   end
 
   it "survives nonexistent cookies" do
     pool = Rack::Session::Pool.new(incrementor)
     res = Rack::MockRequest.new(pool).
       get("/", "HTTP_COOKIE" => "#{session_key}=blarghfasel")
-    res.body.must_equal '{"counter"=>1}'
+    res.body.must_equal({ "counter" => 1 }.to_s)
   end
 
   it "does not send the same session id if it did not change" do
@@ -67,17 +67,17 @@ describe Rack::Session::Pool do
 
     res0 = req.get("/")
     cookie = res0["Set-Cookie"][session_match]
-    res0.body.must_equal '{"counter"=>1}'
+    res0.body.must_equal({ "counter" => 1 }.to_s)
     pool.pool.size.must_equal 1
 
     res1 = req.get("/", "HTTP_COOKIE" => cookie)
     res1["Set-Cookie"].must_be_nil
-    res1.body.must_equal '{"counter"=>2}'
+    res1.body.must_equal({ "counter" => 2 }.to_s)
     pool.pool.size.must_equal 1
 
     res2 = req.get("/", "HTTP_COOKIE" => cookie)
     res2["Set-Cookie"].must_be_nil
-    res2.body.must_equal '{"counter"=>3}'
+    res2.body.must_equal({ "counter" => 3 }.to_s)
     pool.pool.size.must_equal 1
   end
 
@@ -89,17 +89,17 @@ describe Rack::Session::Pool do
 
     res1 = req.get("/")
     session = (cookie = res1["Set-Cookie"])[session_match]
-    res1.body.must_equal '{"counter"=>1}'
+    res1.body.must_equal({ "counter" => 1 }.to_s)
     pool.pool.size.must_equal 1
 
     res2 = dreq.get("/", "HTTP_COOKIE" => cookie)
     res2["Set-Cookie"].must_be_nil
-    res2.body.must_equal '{"counter"=>2}'
+    res2.body.must_equal({ "counter" => 2 }.to_s)
     pool.pool.size.must_equal 0
 
     res3 = req.get("/", "HTTP_COOKIE" => cookie)
     res3["Set-Cookie"][session_match].wont_equal session
-    res3.body.must_equal '{"counter"=>1}'
+    res3.body.must_equal({ "counter" => 1 }.to_s)
     pool.pool.size.must_equal 1
   end
 
@@ -111,22 +111,22 @@ describe Rack::Session::Pool do
 
     res1 = req.get("/")
     session = (cookie = res1["Set-Cookie"])[session_match]
-    res1.body.must_equal '{"counter"=>1}'
+    res1.body.must_equal({ "counter" => 1 }.to_s)
     pool.pool.size.must_equal 1
 
     res2 = rreq.get("/", "HTTP_COOKIE" => cookie)
     new_cookie = res2["Set-Cookie"]
     new_session = new_cookie[session_match]
     new_session.wont_equal session
-    res2.body.must_equal '{"counter"=>2}'
+    res2.body.must_equal({ "counter" => 2 }.to_s)
     pool.pool.size.must_equal 1
 
     res3 = req.get("/", "HTTP_COOKIE" => new_cookie)
-    res3.body.must_equal '{"counter"=>3}'
+    res3.body.must_equal({ "counter" => 3 }.to_s)
     pool.pool.size.must_equal 1
 
     res4 = req.get("/", "HTTP_COOKIE" => cookie)
-    res4.body.must_equal '{"counter"=>1}'
+    res4.body.must_equal({ "counter" => 1 }.to_s)
     pool.pool.size.must_equal 2
   end
 
@@ -137,7 +137,7 @@ describe Rack::Session::Pool do
 
     res1 = dreq.get("/")
     res1["Set-Cookie"].must_be_nil
-    res1.body.must_equal '{"counter"=>1}'
+    res1.body.must_equal({ "counter" => 1 }.to_s)
     pool.pool.size.must_equal 1
   end
 
@@ -154,7 +154,7 @@ describe Rack::Session::Pool do
 
     res1 = req.get("/", "HTTP_COOKIE" => cookie)
     res1["Set-Cookie"].must_be_nil
-    res1.body.must_equal '{"counter"=>2}'
+    res1.body.must_equal({ "counter" => 2 }.to_s)
     pool.pool[session_id.private_id].wont_be_nil
   end
 
@@ -173,7 +173,7 @@ describe Rack::Session::Pool do
 
     res2 = dreq.get("/", "HTTP_COOKIE" => cookie)
     res2["Set-Cookie"].must_be_nil
-    res2.body.must_equal '{"counter"=>2}'
+    res2.body.must_equal({ "counter" => 2 }.to_s)
     pool.pool[session_id.private_id].must_be_nil
     pool.pool[session_id.public_id].must_be_nil
   end
@@ -209,7 +209,7 @@ describe Rack::Session::Pool do
     req = Rack::MockRequest.new(pool)
 
     res = req.get('/')
-    res.body.must_equal '{"counter"=>1}'
+    res.body.must_equal({ "counter" => 1 }.to_s)
     cookie = res["Set-Cookie"]
     sess_id = cookie[/#{pool.key}=([^,;]+)/, 1]
 


### PR DESCRIPTION
`Hash#inspect` changed a bit which is causing spec to fail, but it's quite trivial to make code compatible.