### PR TITLE
[3-1-stable] Test on Ruby v3.4.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
           - jruby-head
           - truffleruby-head
         include:

--- a/test/spec_headers.rb
+++ b/test/spec_headers.rb
@@ -220,8 +220,8 @@ class RackHeadersTest < Minitest::Spec
 
   def test_inspect
     %i'inspect to_s'.each do |meth|
-      assert_equal '{}', @h.send(meth)
-      assert_equal '{"ab"=>"1", "cd"=>"2", "3"=>"4"}', @fh.send(meth)
+      assert_equal({}.inspect, @h.send(meth))
+      assert_equal({"ab"=>"1", "cd"=>"2", "3"=>"4"}.inspect, @fh.send(meth))
     end
   end
 


### PR DESCRIPTION
jruby-head (or rather jruby-10) is now targeting ruby 3.4, which means that test changes from https://github.com/rack/rack/pull/2272 are required for CI to be green.