### PR TITLE
Test against ruby-head

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - ruby-head
           - jruby-head
           - truffleruby-head
         include:


### PR DESCRIPTION
This should give more confidence that changes for unreleased ruby versions are correct.

I wonder if there is interest in this. I briefly looked into history and didn't find anything about this (but maybe I missed stuff). `ruby-head` are surprisingly stable from my experience but there may occasionally be legit failures that are entirely the fault of ruby.