### PR TITLE
[3-0-stable] Handle more Ruby 3.5 incompatibilies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,5 @@ group :test do
 end
 
 gem "base64"
+gem "logger"
+gem "ostruct"


### PR DESCRIPTION
Related to bundled gems:
* `logger` is gone, declare it as a dependency. It's handled on 3.1/main via deprecation/removal of `Rack::Logger`.
* `ostruct` is gone as well. Backport https://github.com/rack/rack/pull/2004 and also remove the missed require.

Not sure if you want this. I encountered this during the cgi stuff to get tests to run at all. Since this warns since Ruby 3.4 and no one complained, users are probably ok via dependencies of other gems (or nobody uses this functionality since it is autoloaded). If accepted, I would also backport to 2.0