### PR TITLE
Make "use" return a middleware creation proc

### DIFF
--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -156,12 +156,17 @@ module Rack
     # All requests through to this application will first be processed by the middleware class.
     # The +call+ method in this example sets an additional environment key which then can be
     # referenced in the application if required.
+    #
+    # Returns a proc that returns a new instance of this middleware using the supplied args. The proc
+    # can be called with either a Rack application parameter or nil/no-argument for use outside Rack.
     def use(middleware, *args, &block)
       if @map
         mapping, @map = @map, nil
         @use << proc { |app| generate_map(app, mapping) }
       end
-      @use << proc { |app| middleware.new(app, *args, &block) }
+      creator = proc { |app| middleware.new(app, *args, &block) }
+      @use << creator
+      creator
     end
     # :nocov:
     ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)


### PR DESCRIPTION
[OmniAuth](/omniauth/omniauth) uses Rack to add a middleware for each of its configured authentication strategies. At the moment, when one wants to use a strategy to create a properly-configured OAuth2 client for that strategy to refresh an access token and/or make endpoint calls, one must initialize one's own instance of that strategy, duplicating the Omniauth config with its `id` and `secret` client keys  (these can be nil if no token refreshing is needed).

This duplication could be avoided if either Omniauth's `provider` declarations returned a strategy creation proc (that is a closure for its arguments) or Omniauth provided an `Omniauth::Strategy.get(name)` method.

The best way to do either is for Rack's `use` method to [return](/rack/rack/blob/df2f3f2804373acafc429ed9f0770847a9c6b226/lib/rack/builder.rb#L164) the middleware initialisation proc instead of the current array of middleware. This directly supplies what Omniauth's `provider` method returns, plus OmniAuth (or Rack) can store these procs in a Hash for lookup by name.

Yes, a solution without any change is for Omniauth to return `use(...).last`, but this makes it dependent on Rack's internals.

So this PR changes `use` to return the proc rather than the current array of procs. I don't see this as breaking any reasonable code.

