### PR TITLE
Add documentation for Multipart::Parser file parameter contents

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -50,17 +50,6 @@ module Rack
 # * +:name+ - The parameter name from the form
 # * +:tempfile+ - A Tempfile object containing the uploaded data
 # * +:head+ - The raw header content for this part
-#
-# Example Usage
-#
-#   uploaded_file = params[:file]
-#   filename = uploaded_file[:filename]  # Already URL decoded
-#   content_type = uploaded_file[:type]
-#   file_data = uploaded_file[:tempfile]
-#
-# The filename value has already undergone URL decoding during parsing,
-# so applications can use it directly without additional processing
-
     class Parser
       BUFSIZE = 1_048_576
       TEXT_PLAIN = "text/plain"

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -38,18 +38,18 @@ module Rack
     MULTIPART_CONTENT_DISPOSITION = /^Content-Disposition:#{FWS}?(#{HEADER_VALUE})/ni
     MULTIPART_CONTENT_ID = /^Content-ID:#{FWS}?(#{HEADER_VALUE})/ni
 
-# Rack::Multipart::Parser handles parsing of multipart/form-data requests.
-#
-# File Parameter Contents
-#
-# When processing file uploads, the parser returns a hash containing
-# information about uploaded files. For +file+ parameters, the hash includes:
-#
-# * +:filename+ - The original filename, already URL decoded by the parser
-# * +:type+ - The content type of the uploaded file  
-# * +:name+ - The parameter name from the form
-# * +:tempfile+ - A Tempfile object containing the uploaded data
-# * +:head+ - The raw header content for this part
+    # Rack::Multipart::Parser handles parsing of multipart/form-data requests.
+    #
+    # File Parameter Contents
+    #
+    # When processing file uploads, the parser returns a hash containing
+    # information about uploaded files. For +file+ parameters, the hash includes:
+    #
+    # * +:filename+ - The original filename, already URL decoded by the parser
+    # * +:type+ - The content type of the uploaded file  
+    # * +:name+ - The parameter name from the form
+    # * +:tempfile+ - A Tempfile object containing the uploaded data
+    # * +:head+ - The raw header content for this part
     class Parser
       BUFSIZE = 1_048_576
       TEXT_PLAIN = "text/plain"

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -38,6 +38,29 @@ module Rack
     MULTIPART_CONTENT_DISPOSITION = /^Content-Disposition:#{FWS}?(#{HEADER_VALUE})/ni
     MULTIPART_CONTENT_ID = /^Content-ID:#{FWS}?(#{HEADER_VALUE})/ni
 
+# Rack::Multipart::Parser handles parsing of multipart/form-data requests.
+#
+# File Parameter Contents
+#
+# When processing file uploads, the parser returns a hash containing
+# information about uploaded files. For +:file+ parameters, the hash includes:
+#
+# * +:filename+ - The original filename, already URL decoded by the parser
+# * +:type+ - The content type of the uploaded file  
+# * +:name+ - The parameter name from the form
+# * +:tempfile+ - A Tempfile object containing the uploaded data
+# * +:head+ - The raw header content for this part
+#
+# Example Usage
+#
+#   uploaded_file = params[:file]
+#   filename = uploaded_file[:filename]  # Already URL decoded
+#   content_type = uploaded_file[:type]
+#   file_data = uploaded_file[:tempfile]
+#
+# The filename value has already undergone URL decoding during parsing,
+# so applications can use it directly without additional processing
+
     class Parser
       BUFSIZE = 1_048_576
       TEXT_PLAIN = "text/plain"

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -43,7 +43,7 @@ module Rack
 # File Parameter Contents
 #
 # When processing file uploads, the parser returns a hash containing
-# information about uploaded files. For +:file+ parameters, the hash includes:
+# information about uploaded files. For +file+ parameters, the hash includes:
 #
 # * +:filename+ - The original filename, already URL decoded by the parser
 # * +:type+ - The content type of the uploaded file  


### PR DESCRIPTION
This PR adds class-level documentation to `Rack::Multipart::Parser` explaining the contents of the hash returned for file parameters.

Following discussion in the security advisory, this clarifies:
- Structure of the file parameter hash
- That filenames are already URL decoded by the parser  
- Example usage patterns

This should help developers better understand what data is available when processing file uploads.

Addresses the documentation gap mentioned by @jeremyevans for general information about file parameter contents.