### PR TITLE
Fix make_delete_cookie_header when domain and path values contain regex-unsafe characters

### DIFF
--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -292,8 +292,8 @@ module Rack
       end
 
       key = escape(key)
-      domain = value[:domain]
-      path = value[:path]
+      domain = Regexp.escape(value[:domain].to_s) if value[:domain]
+      path = Regexp.escape(value[:path].to_s) if value[:path]
       regexp = if domain
                  if path
                    /\A#{key}=.*(?:domain=#{domain}(?:;|$).*path=#{path}(?:;|$)|path=#{path}(?:;|$).*domain=#{domain}(?:;|$))/

--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -587,6 +587,19 @@ describe Rack::Utils, "cookies" do
     header['Set-Cookie'].must_equal "name=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT"
   end
 
+  it 'does not raise RegexpError with regex-unsafe characters in path and domain' do
+    value = { domain: 'example.com)' }
+    Rack::Utils.make_delete_cookie_header(nil, 'name', value).must_equal ''
+
+    value = { path: '/', domain: 'example.com)' }
+    Rack::Utils.make_delete_cookie_header(nil, 'name', value).must_equal ''
+
+    value = { path: '/)', domain: 'example.com' }
+    Rack::Utils.make_delete_cookie_header(nil, 'name', value).must_equal ''
+
+    value = { path: '/)' }
+    Rack::Utils.make_delete_cookie_header(nil, 'name', value).must_equal ''
+  end
 end
 
 describe Rack::Utils, "byte_range" do


### PR DESCRIPTION
When deleting cookies, the `domain` and `path` values are interpolated directly into regular expression without escaping, triggering a `RegexpError`. 
This pull request fixes that by escaping `domain` and `path` with `Regexp.escape`. 