### PR TITLE
Add `Rack::Request#form_pairs`

### DIFF
--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -91,6 +91,25 @@ module Rack
       return params.to_h
     end
 
+    # Parses a query string by breaking it up at the '&', returning all key-value
+    # pairs as an array of [key, value] arrays. Unlike parse_query, this preserves
+    # all duplicate keys rather than collapsing them.
+    def parse_query_pairs(qs, separator = nil, &unescaper)
+      unescaper ||= method(:unescape)
+
+      pairs = []
+
+      check_query_string(qs, separator).split(separator ? (COMMON_SEP[separator] || /[#{separator}] */n) : DEFAULT_SEP).each do |p|
+        next if p.empty?
+        k, v = p.split('=', 2).map!(&unescaper)
+        pairs << [k, v]
+      end
+
+      return pairs
+    rescue ArgumentError => e
+      raise InvalidParameterError, e.message, e.backtrace
+    end
+
     # parse_nested_query expands a query string into structural types. Supported
     # types are Arrays, Hashes and basic value types. It is possible to supply
     # query strings with parameters of conflicting types, in this case a

--- a/test/spec_query_parser.rb
+++ b/test/spec_query_parser.rb
@@ -12,6 +12,9 @@ describe Rack::QueryParser do
     query_parser.parse_nested_query("a=a").must_equal({"a" => "a"})
     query_parser.parse_nested_query("a=").must_equal({"a" => ""})
     query_parser.parse_nested_query("a").must_equal({"a" => nil})
+    query_parser.parse_query_pairs("a=a").must_equal([["a", "a"]])
+    query_parser.parse_query_pairs("a=").must_equal([["a", ""]])
+    query_parser.parse_query_pairs("a").must_equal([["a", nil]])
   end
 
   it "accepts bytesize_limit to specify maximum size of query string to parse" do
@@ -19,9 +22,11 @@ describe Rack::QueryParser do
     query_parser.parse_query("a=a").must_equal({"a" => "a"})
     query_parser.parse_nested_query("a=a").must_equal({"a" => "a"})
     query_parser.parse_nested_query("a=a", '&').must_equal({"a" => "a"})
+    query_parser.parse_query_pairs("a=a").must_equal([["a", "a"]])
     proc { query_parser.parse_query("a=aa") }.must_raise Rack::QueryParser::QueryLimitError
     proc { query_parser.parse_nested_query("a=aa") }.must_raise Rack::QueryParser::QueryLimitError
     proc { query_parser.parse_nested_query("a=aa", '&') }.must_raise Rack::QueryParser::QueryLimitError
+    proc { query_parser.parse_query_pairs("a=aa") }.must_raise Rack::QueryParser::QueryLimitError
   end
 
   it "accepts params_limit to specify maximum number of query parameters to parse" do
@@ -29,8 +34,11 @@ describe Rack::QueryParser do
     query_parser.parse_query("a=a&b=b").must_equal({"a" => "a", "b" => "b"})
     query_parser.parse_nested_query("a=a&b=b").must_equal({"a" => "a", "b" => "b"})
     query_parser.parse_nested_query("a=a&b=b", '&').must_equal({"a" => "a", "b" => "b"})
+    query_parser.parse_query_pairs("a=a&b=b").must_equal([["a", "a"], ["b", "b"]])
+    query_parser.parse_query_pairs("a=1&a=2").must_equal([["a", "1"], ["a", "2"]])
     proc { query_parser.parse_query("a=a&b=b&c=c") }.must_raise Rack::QueryParser::QueryLimitError
     proc { query_parser.parse_nested_query("a=a&b=b&c=c", '&') }.must_raise Rack::QueryParser::QueryLimitError
     proc { query_parser.parse_query("b[]=a&b[]=b&b[]=c") }.must_raise Rack::QueryParser::QueryLimitError
+    proc { query_parser.parse_query_pairs("a=a&b=b&c=c") }.must_raise Rack::QueryParser::QueryLimitError
   end
 end


### PR DESCRIPTION
Instead of hiding the population of `RACK_REQUEST_FORM_PAIRS` inside `POST`, this extracts it as a separately accessible public method. To make it properly useful _as_ a public method, unlike the existing behaviour where a pairs-wanting caller must handle the non-multipart cases for themselves, here it's unified: if we have pairs available in any form, `form_pairs` will return them.

`POST` is thus reduced to the more specific job of converting the pair-stream to structured hash format only, slightly more similar to `GET`. (No behaviour change, of course -- just that the "where could form data be coming from" stuff is now delegated to this new method.)

This is the follow-up originally promised in https://github.com/rack/rack/pull/2088#issuecomment-1637445845, and more recently mentioned in https://github.com/rack/rack/issues/2341#issuecomment-3008205735