### PR TITLE
Relax `check_header_value`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. For info on
 
 - Request environment keys must now be strings. ([#2310](https://github.com/rack/rack/issues/2310), [@jeremyevans])
 - Add `nil` as a valid return from a Response `body.to_path` ([#2318](https://github.com/rack/rack/pull/2318), [@MSP-Greg])
+- `#check_header_value` is relaxed, only disallowing CR/LF/NUL characters. ([#2354](https://github.com/rack/rack/pull/2354), [@ioquatix])
 
 ### Added
 

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -743,7 +743,7 @@ module Rack
 
       def check_header_value(key, value)
         ## such that each +String+ value must not contain <tt>NUL</tt> (<tt>\0</tt>), <tt>CR</tt> (<tt>\r</tt>), or <tt>LF</tt> (<tt>\n</tt>).
-        if value =~ /[\x00\x0A\x0D]/
+        if value.match?(/[\x00\x0A\x0D]/)
           raise LintError, "invalid header value #{key}: #{value.inspect}"
         end
       end

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -742,8 +742,8 @@ module Rack
       end
 
       def check_header_value(key, value)
-        ## such that each +String+ value must not contain characters with an ASCII ordinal below 040 (32).
-        if value =~ /[\000-\037]/
+        ## such that each +String+ value must not contain <tt>NUL</tt> (<tt>\0</tt>), <tt>CR</tt> (<tt>\r</tt>), or <tt>LF</tt> (<tt>\n</tt>).
+        if value =~ /[\x00\x0A\x0D]/
           raise LintError, "invalid header value #{key}: #{value.inspect}"
         end
       end


### PR DESCRIPTION
As has been previously discussed, `Rack::Lint` is not for validating user data or the correctness of data, just that the `env` has the right shape and that the interfaces are used correctly.

Fixes #2308.