### PR TITLE
`Rack::Builder` `#use`, `#run` and `#map` all return `nil`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::MediaType#params` now handles empty strings. ([#2229](https://github.com/rack/rack/pull/2229), [@jeremyevans])
 - Avoid unnecessary calls to the `ip_filter` lambda to evaluate `Request#ip` ([#2287](https://github.com/rack/rack/pull/2287), [@willbryant])
 - Only calculate `Request#ip` once per request ([#2292](https://github.com/rack/rack/pull/2292), [@willbryant])
+- `Rack::Builder` `#use`, `#map`, and `#run` methods now return `nil`. ([#2355](https://github.com/rack/rack/pull/2355), [@ioquatix])
 
 ### Deprecated
 

--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -162,6 +162,8 @@ module Rack
         @use << proc { |app| generate_map(app, mapping) }
       end
       @use << proc { |app| middleware.new(app, *args, &block) }
+
+      self
     end
     # :nocov:
     ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
@@ -194,6 +196,8 @@ module Rack
       raise ArgumentError, "Both app and block given!" if app && block_given?
 
       @run = app || block
+
+      self
     end
 
     # Takes a lambda or block that is used to warm-up the application. This block is called
@@ -252,6 +256,8 @@ module Rack
     def map(path, &block)
       @map ||= {}
       @map[path] = block
+
+      self
     end
 
     # Freeze the app (set using run) and all middleware instances when building the application

--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -163,7 +163,7 @@ module Rack
       end
       @use << proc { |app| middleware.new(app, *args, &block) }
 
-      self
+      nil
     end
     # :nocov:
     ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
@@ -197,7 +197,7 @@ module Rack
 
       @run = app || block
 
-      self
+      nil
     end
 
     # Takes a lambda or block that is used to warm-up the application. This block is called
@@ -257,7 +257,7 @@ module Rack
       @map ||= {}
       @map[path] = block
 
-      self
+      nil
     end
 
     # Freeze the app (set using run) and all middleware instances when building the application


### PR DESCRIPTION
See <https://github.com/rack/rack/pull/2346> for more context.

Alternatively, it could return `nil`, but I think returning `self` is slightly more useful. However, it does lock in the return value (`nil` might give us more flexibility in the future).

In principle with this change, one could write:

```
Rack::Builder.new.use(...).use(...).run(...).to_app
```

I'm open to either idea. WDYT.