### PR TITLE
Use a fixed `Zlib::GzipWriter#mtime` value in deflater gzip payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Changed
 
 - Raise before exceeding a part limit, not after. ([#2362](https://github.com/rack/rack/pull/2362), [@matthew-puku](https://github.com/matthew-puku))
+- Rack::Deflater now uses a fixed GZip mtime value. ([#2372](https://github.com/rack/rack/pull/2372), [@bensheldon](https://github.com/bensheldon))
 
 ### Fixed
 

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -26,6 +26,9 @@ module Rack
   # Note that despite the name, Deflater does not support the +deflate+
   # encoding.
   class Deflater
+
+    GZIP_MTIME = RUBY_VERSION >= "2.7" ? 0 : 1
+
     # Creates Rack::Deflater middleware. Options:
     #
     # :if :: a lambda enabling / disabling deflation based on returned boolean value
@@ -65,9 +68,7 @@ module Rack
       when "gzip"
         headers['content-encoding'] = "gzip"
         headers.delete(CONTENT_LENGTH)
-        mtime = headers["last-modified"]
-        mtime = Time.httpdate(mtime).to_i if mtime
-        response[2] = GzipStream.new(body, mtime, @sync)
+        response[2] = GzipStream.new(body, GZIP_MTIME, @sync)
         response
       when "identity"
         response

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -73,13 +73,7 @@ describe Rack::Deflater do
       when 'gzip'
         io = StringIO.new(body_text)
         gz = Zlib::GzipReader.new(io)
-        mtime = gz.mtime.to_i
-        if last_mod = headers['last-modified']
-          Time.httpdate(last_mod).to_i.must_equal mtime
-        else
-          mtime.must_be(:<=, Time.now.to_i)
-          mtime.must_be(:>=, start.to_i - 1)
-        end
+        gz.mtime.to_i.must_equal(Rack::Deflater::GZIP_MTIME)
         tmp = gz.read
         gz.close
         tmp


### PR DESCRIPTION
This PR removes the variable `mtime` property from gzipped assets produced by `Rack::Deflater`. The [`Zlib::GzipWriter#mtime` property](https://docs.ruby-lang.org/en/3.4/Zlib/GzipWriter.html#method-i-mtime-3D):

> Specify the modification time (mtime) in the gzip header. Using an Integer.
> 
> Setting the mtime in the gzip header does not effect the mtime of the file generated. Different utilities that expand the gzipped files may use the mtime header. For example the gunzip utility can use the ‘-N` flag which will set the resultant file’s mtime to the value in the header. By default many tools will set the mtime of the expanded file to the mtime of the gzipped file, not the mtime in the header.
> 
> If you do not set an mtime, the default value will be the time when compression started. Setting a value of 0 indicates no time stamp is available.

Assigning `Zlib::GzipWriter#mtime` of the gzipped content based on the `Last-Modified` value means that a new, unequal gzipped resource will be generated when `Last-Modified` changes even if the content being gzipped remains unchanged. Setting `Zlib::GzipWriter#mtime` to a fixed value/`0` causes the compressed resource's content to be deterministically tied solely to the content of its uncompressed counterpart.

I couldn't find a rationale for why `Zlib::GzipWriter#mtime` was initially added in d2d51ff05966b36c40dc9439437e82d0a23f2b88.

I don't believe that `Zlib::GzipWriter#mtime` serves any purpose in the context of http payloads. The `Last-Modified` header is transmitted for both original and compressed resources and I haven't found evidence that any browser/client resolves `gzip#mtime`. Some clients do [mishandle conditional requests when the last-modified header changes but the contents do not](https://rachelbythebay.com/fs/help.html):

> More than a couple of feed readers use a library which hashes the contents of the body and then skips updating their cached values for Last-Modified and ETag. This makes them send the old values over and over, turning them into a generator of unconditional requests. This is bad.

...but I think it would be weird to justify only handling that with gzip compression.

