### PR TITLE
Make Regexp.new and Regexp.union frozen.

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -53,7 +53,7 @@ module Rack
       /\A172\.(1[6-9]|2[0-9]|3[01])#{valid_ipv4_octet}{2}\z/,   # private IPv4 range 172.16.0.0 .. 172.31.255.255
       /\A192\.168#{valid_ipv4_octet}{2}\z/,                     # private IPv4 range 192.168.x.x
       /\Alocalhost\z|\Aunix(\z|:)/i,                            # localhost hostname, and unix domain sockets
-    )
+    ).freeze
 
     self.ip_filter = lambda { |ip| trusted_proxies.match?(ip) }
 
@@ -712,7 +712,7 @@ module Rack
            |
            :(?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?
          )?
-         :[0-9A-Fa-f]{1,4}%[-0-9A-Za-z._~]+/x)
+         :[0-9A-Fa-f]{1,4}%[-0-9A-Za-z._~]+/x).freeze
 
       AUTHORITY = /
         \A

--- a/lib/rack/urlmap.rb
+++ b/lib/rack/urlmap.rb
@@ -37,7 +37,7 @@ module Rack
         end
 
         location = location.chomp('/')
-        match = Regexp.new("^#{Regexp.quote(location).gsub('/', '/+')}(.*)", Regexp::NOENCODING)
+        match = Regexp.new("^#{Regexp.quote(location).gsub('/', '/+')}(.*)", Regexp::NOENCODING).freeze
 
         [host, location, match, app]
       }.sort_by do |(host, location, _, _)|

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -595,7 +595,7 @@ module Rack
       end
     end
 
-    PATH_SEPS = Regexp.union(*[::File::SEPARATOR, ::File::ALT_SEPARATOR].compact)
+    PATH_SEPS = Regexp.union(*[::File::SEPARATOR, ::File::ALT_SEPARATOR].compact).freeze
 
     def clean_path_info(path_info)
       parts = path_info.split PATH_SEPS


### PR DESCRIPTION
Regexp objects created from literals are already frozen, which is ideal for Ractor. However, objects created with Regexp.new and Regexp.union are not. This change makes them frozen to ensure consistency and improve Ractor-friendliness.

```irb
irb(main):001> RUBY_VERSION
=> "3.4.4"
irb(main):002> /a/.frozen?
=> true
irb(main):003> Regexp.new('a').frozen?
=> false
irb(main):004> Regexp.union(/a/, /b/).frozen?
=> false
```