### PR TITLE
Rake events streaming bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file. For info on
 
 - Raise before exceeding a part limit, not after. ([#2362](https://github.com/rack/rack/pull/2362), [@matthew-puku](https://github.com/matthew-puku))
 
+### Fixed
+
+- Fix an issue where a `NoMethodError` would be raised when using `Rack::Events` with streaming bodies. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
+
 ## [3.2.0] - 2025-07-31
 
 This release continues Rack's evolution toward a cleaner, more efficient foundation while maintaining backward compatibility for most applications. The breaking changes primarily affect deprecated functionality, so most users should experience a smooth upgrade with improved performance and standards compliance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. For info on
 ### Added
 
 - Add support for `rack.response_finished` to `Rack::TempfileReaper`. ([#2363](https://github.com/rack/rack/pull/2363), [@skipkayhil](https://github.com/skipkayhil))
+- Add support for streaming bodies when using `Rack::Events`. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
 
 ### Changed
 

--- a/lib/rack/events.rb
+++ b/lib/rack/events.rb
@@ -90,6 +90,15 @@ module Rack
         @handlers.reverse_each { |handler| handler.on_send request, response }
         super
       end
+
+      def respond_to?(method_name, include_all = false)
+        case method_name
+        when :each
+          @body.respond_to?(method_name, include_all)
+        else
+          super
+        end
+      end
     end
 
     class BufferedResponse < Rack::Response::Raw # :nodoc:

--- a/test/spec_events.rb
+++ b/test/spec_events.rb
@@ -133,5 +133,12 @@ module Rack
                     [se, :on_finish],
       ], events
     end
+
+    def test_evented_body_proxy_respond_to_each_matches_body
+      app = lambda { |env| [200, {}, lambda { |stream| stream.close }] }
+      e = Events.new app, []
+      triple = e.call({})
+      refute triple[2].respond_to?(:each)
+    end
   end
 end

--- a/test/spec_events.rb
+++ b/test/spec_events.rb
@@ -84,6 +84,21 @@ module Rack
       ], events
     end
 
+    def test_send_is_called_on_call
+      events = []
+      ret = [200, {}, lambda { |stream| stream.close }]
+      app = lambda { |env| events << [app, :call]; ret }
+      se = EventMiddleware.new events
+      e = Events.new app, [se]
+      triple = e.call({})
+      triple[2].call(StringIO.new)
+      assert_equal [[se, :on_start],
+                    [app, :call],
+                    [se, :on_commit],
+                    [se, :on_send],
+      ], events
+    end
+
     def test_finish_is_called_on_close
       events = []
       ret = [200, {}, []]


### PR DESCRIPTION
Fixes rack/rack#2373.

---

## [Fix streaming bodies when using Rack::Events](https://github.com/rack/rack/commit/65317d91a3a443828e76b5a9c7ff8aec59a38e4d)

When `Rack::Events` is used, it would use `EventedBodyProxy` to wrap
the body. Unlike `BodyProxy`, `EventedBodyProxy` always implements
`#each`.

As per the spec, streaming bodies must both implement `#call` and not
implement `#each`, and if both are present, the server must call
`#each`, not `#call`.

When a streaming body was wrapped by an `EventedBodyProxy`, the proxy
will nonetheless `.respond_to?(:each)`. This would cause the server to
call `#each` on the proxy. The proxy would then forward the call to
`#each` to the body that it proxies, which does not implement `#each`,
raising a `NoMethodError`.

To fix this, `EventedBodyProxy` will only `.respond_to?(:each)` if
the body it proxies responds to `#each`.

Note that, while this fixes the `NoMethodError`, this means that the
`on_send` handler will never be invoked for streaming bodies.

## [Call on_send handler for streaming bodies](https://github.com/rack/rack/commit/fcc4c679bcccdc1e186148991b3710f5cd6461a7)

When using the `Rack::Events` middleware, call `on_send` on the
middleware's handlers when `#call` is invoked, in the same way it
is done when `#each` is invoked.