### PR TITLE
Allow dynamic headers for Rack::Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Added
 
+- Add support for dynamic headers with procs to `Rack::Files`. ([#2377](https://github.com/rack/rack/pull/2377), [@codergeek121](https://github.com/codergeek121))
 - Add support for `rack.response_finished` to `Rack::TempfileReaper`. ([#2363](https://github.com/rack/rack/pull/2363), [@skipkayhil](https://github.com/skipkayhil))
 - Add support for streaming bodies when using `Rack::Events`. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Added
 
-- Add support for dynamic headers with procs to `Rack::Files`. ([#2377](https://github.com/rack/rack/pull/2377), [@codergeek121](https://github.com/codergeek121))
+- Add `Rack::Files#set_headers` to allow overriding how the configured file headers are set. ([#2377](https://github.com/rack/rack/pull/2377), [@codergeek121](https://github.com/codergeek121))
 - Add support for `rack.response_finished` to `Rack::TempfileReaper`. ([#2363](https://github.com/rack/rack/pull/2363), [@skipkayhil](https://github.com/skipkayhil))
 - Add support for streaming bodies when using `Rack::Events`. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Added
 
-- Add `Rack::Files#set_headers` to allow overriding how the configured file headers are set. ([#2377](https://github.com/rack/rack/pull/2377), [@codergeek121](https://github.com/codergeek121))
+- Add `Rack::Files#assign_headers` to allow overriding how the configured file headers are set. ([#2377](https://github.com/rack/rack/pull/2377), [@codergeek121](https://github.com/codergeek121))
 - Add support for `rack.response_finished` to `Rack::TempfileReaper`. ([#2363](https://github.com/rack/rack/pull/2363), [@skipkayhil](https://github.com/skipkayhil))
 - Add support for streaming bodies when using `Rack::Events`. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
 

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -76,7 +76,7 @@ module Rack
       mime_type = mime_type path, @default_mime
       headers[CONTENT_TYPE] = mime_type if mime_type
 
-      set_headers(headers, request)
+      assign_headers(headers, request)
 
       status = 200
       size = filesize path
@@ -117,7 +117,7 @@ module Rack
       [status, headers, body]
     end
 
-    def set_headers(headers, request)
+    def assign_headers(headers, request)
       headers.merge!(@headers) if @headers
     end
 

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -76,8 +76,7 @@ module Rack
       mime_type = mime_type path, @default_mime
       headers[CONTENT_TYPE] = mime_type if mime_type
 
-      # Set custom headers
-      headers.merge!(compute_headers(@headers, request)) if @headers
+      set_headers(headers, request)
 
       status = 200
       size = filesize path
@@ -116,6 +115,10 @@ module Rack
       end
 
       [status, headers, body]
+    end
+
+    def set_headers(headers, request)
+      headers.merge!(@headers) if @headers
     end
 
     class BaseIterator
@@ -186,12 +189,6 @@ EOF
     end
 
     private
-
-    def compute_headers(headers, request)
-      headers.transform_values do |value|
-        value.respond_to?(:call) ? value.call(request) : value
-      end
-    end
 
     def fail(status, body, headers = {})
       body += "\n"

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -77,7 +77,7 @@ module Rack
       headers[CONTENT_TYPE] = mime_type if mime_type
 
       # Set custom headers
-      headers.merge!(@headers) if @headers
+      headers.merge!(compute_headers(@headers, request)) if @headers
 
       status = 200
       size = filesize path
@@ -186,6 +186,12 @@ EOF
     end
 
     private
+
+    def compute_headers(headers, request)
+      headers.transform_values do |value|
+        value.respond_to?(:call) ? value.call(request) : value
+      end
+    end
 
     def fail(status, body, headers = {})
       body += "\n"

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -262,12 +262,19 @@ content-range: bytes 60-80/209\r
     heads['access-control-allow-origin'].must_equal '*'
   end
 
-  it "supports dynamic http headers with procs" do
+  it "allows customizing the way http header's are set" do
     env = Rack::MockRequest.env_for("/cgi/test")
-    status, heads, _ = files(DOCROOT, 'x-custom-proc' => ->(request) { request.path }).call(env)
+    custom_files = Class.new(Rack::Files) do
+      def set_headers(headers, request)
+        request.must_be_instance_of Rack::Request
+        headers.merge!(@headers.invert)
+      end
+    end
+
+    status, heads, _ = Rack::Lint.new(custom_files.new(DOCROOT, 'left' => 'right')).call(env)
 
     status.must_equal 200
-    heads['x-custom-proc'].must_equal '/cgi/test'
+    heads['right'].must_equal 'left'
   end
 
   it "does not add custom HTTP headers when none are supplied" do

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -262,6 +262,14 @@ content-range: bytes 60-80/209\r
     heads['access-control-allow-origin'].must_equal '*'
   end
 
+  it "supports dynamic http headers with procs" do
+    env = Rack::MockRequest.env_for("/cgi/test")
+    status, heads, _ = files(DOCROOT, 'x-custom-proc' => ->(request) { request.path }).call(env)
+
+    status.must_equal 200
+    heads['x-custom-proc'].must_equal '/cgi/test'
+  end
+
   it "does not add custom HTTP headers when none are supplied" do
     env = Rack::MockRequest.env_for("/cgi/test")
     status, heads, _ = files(DOCROOT).call(env)

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -265,7 +265,7 @@ content-range: bytes 60-80/209\r
   it "allows customizing the way http header's are set" do
     env = Rack::MockRequest.env_for("/cgi/test")
     custom_files = Class.new(Rack::Files) do
-      def set_headers(headers, request)
+      def assign_headers(headers, request)
         request.must_be_instance_of Rack::Request
         headers.merge!(@headers.invert)
       end


### PR DESCRIPTION
This PR adds support for dynamic headers in Rack::Files via the headers configuration.

For example the following configuration add the header "x-dynamic" with a random integer between 1 and 10 for each request handled by Rack::Files:

```
Rack::Files.new(".", {
  "x-dynamic" => ->(request) { rand(1..10).to_s }
})
```

This feature could be used to provide different cache durations for different files. E.g. a longer duration for files with a contenthash and shorter duration for files without a contenthash. This would allow solving issues like
https://github.com/rails/rails/pull/55249 within Rack::Files directly.