### PR TITLE
Document that Rack::Files and Rack::Directory follow symlinks

### DIFF
--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -15,6 +15,11 @@ module Rack
   # be passed to the specified +app+.
   #
   # If +app+ is not specified, a Rack::Files of the same +root+ will be used.
+  #
+  # Be aware that just like the default behavior of most webservers, Rack::Directory
+  # will follow symbolic links encountered under the root. If a symlink points to
+  # a location outside of the root, that target will still be served as part of
+  # the response.
 
   class Directory
     DIR_FILE = "<tr><td class='name'><a href='%s'>%s</a></td><td class='size'>%s</td><td class='type'>%s</td><td class='mtime'>%s</td></tr>\n"

--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -16,6 +16,11 @@ module Rack
   #
   # Handlers can detect if bodies are a Rack::Files, and use mechanisms
   # like sendfile on the +path+.
+  #
+  # Be aware that just like the default behavior of most webservers, Rack::Files
+  # will follow symbolic links encountered under the root. If a symlink points to
+  # a location outside of the root, that target will still be served as part of
+  # the response.
 
   class Files
     ALLOWED_VERBS = %w[GET HEAD OPTIONS]


### PR DESCRIPTION
This is the default behavior for most webservers, so it should not be surprising. It's also not a security issue.  As explained by the Apache documentation:

```
Omitting this option [FollowSymLinks] should not be considered
a security restriction, since symlink testing is subject to
race conditions that make it circumventable.
```

However, we have had multiple security vulnerability reports about this behavior. To hopefully avoid future similar reports, it is useful to explicitly document that following symlinks is expected behavior.