### PR TITLE
Runtime in Server-Timing header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add `Rack::Request#prefetch?` for identifying requests with `Sec-Purpose: prefetch` header set. ([#2405](https://github.com/rack/rack/pull/2405), [@glaszig](https://github.com/glaszig))
 - Add `rack.request.trusted_proxy` environment key to indicate whether the request is coming from a trusted proxy.
 - Add `Rack::Request#headers` for simpler access to request headers by header name. ([#1881](https://github.com/rack/rack/pull/1881), [@jeremyevans](https://github.com/jeremyevans))
+- Introduce `Rack::ServerTiming` middleware for instrumenting runtime in part or all of an application, and reporting via the [Server-Timing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing) header. ([#2375](github.com/rack/rack/pull/2389), [@lewispb](https://github.com/lewispb))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ middleware:
   the request.
 * `Rack::Sendfile` for working with web servers that can use optimized file
   serving for file system paths.
+* `Rack::ServerTiming` for including a Server-Timing response header with the
+  time taken to process the request.
 * `Rack::ShowException` for catching unhandled exceptions and presenting them in
   a nice and helpful way with clickable backtrace.
 * `Rack::ShowStatus` for using nice error pages for empty client error

--- a/lib/rack.rb
+++ b/lib/rack.rb
@@ -49,6 +49,7 @@ module Rack
   autoload :RewindableInput, "rack/rewindable_input"
   autoload :Runtime, "rack/runtime"
   autoload :Sendfile, "rack/sendfile"
+  autoload :ServerTiming, "rack/server_timing"
   autoload :ShowExceptions, "rack/show_exceptions"
   autoload :ShowStatus, "rack/show_status"
   autoload :Static, "rack/static"

--- a/lib/rack/headers.rb
+++ b/lib/rack/headers.rb
@@ -54,6 +54,7 @@ module Rack
       Report-To
       Retry-After
       Server
+      Server-Timing
       Set-Cookie
       Status
       Strict-Transport-Security

--- a/lib/rack/server_timing.rb
+++ b/lib/rack/server_timing.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative 'utils'
+
+module Rack
+  # Sets or appends to a "server-timing" response header, indicating the
+  # response time of the request, in milliseconds. The header follows the
+  # Server-Timing specification (https://www.w3.org/TR/server-timing/).
+  #
+  # You can put it right before the application to see the processing
+  # time, or before all the other middlewares to include time for them,
+  # too.
+  class ServerTiming
+    DURATION_FORMAT_STRING = "%0.3f" # :nodoc:
+    HEADER_NAME = "server-timing" # :nodoc:
+    METRIC_NAME = "rack-runtime" # :nodoc:
+
+    def initialize(app, metric_name = METRIC_NAME)
+      @app = app
+      @metric_name = metric_name
+    end
+
+    def call(env)
+      start_time = Utils.clock_time
+      _, headers, _ = response = @app.call(env)
+
+      duration_ms = (Utils.clock_time - start_time) * 1000
+
+      set_server_timing_header(headers, duration_ms)
+
+      response
+    end
+
+    private
+
+    def set_server_timing_header(headers, duration_ms)
+      metric = "#{@metric_name};dur=#{DURATION_FORMAT_STRING % duration_ms}"
+
+      headers[HEADER_NAME] = [headers[HEADER_NAME], metric].compact.join(", ")
+    end
+  end
+end

--- a/lib/rack/server_timing.rb
+++ b/lib/rack/server_timing.rb
@@ -15,7 +15,7 @@ module Rack
     HEADER_NAME = "server-timing" # :nodoc:
     METRIC_NAME = "rack-runtime" # :nodoc:
 
-    def initialize(app, metric_name = METRIC_NAME)
+    def initialize(app, metric_name: METRIC_NAME)
       @app = app
       @metric_name = metric_name
     end

--- a/test/spec_server_timing.rb
+++ b/test/spec_server_timing.rb
@@ -34,28 +34,4 @@ describe Rack::ServerTiming do
     response = server_timing_app(app, "db").call(request)
     response[1]['server-timing'].must_match(/^db;dur=[\d\.]+$/)
   end
-
-  it "allows multiple timers to be set" do
-    app = lambda { |env| sleep 0.1; [200, { 'content-type' => 'text/plain' }, "Hello, World!"] }
-    server_timing = server_timing_app(app, "db")
-
-    # wrap many times to guarantee a measurable difference
-    100.times do |i|
-      server_timing = Rack::ServerTiming.new(server_timing, "t#{i}")
-    end
-    server_timing = Rack::ServerTiming.new(server_timing, "total")
-
-    response = server_timing.call(request)
-    server_timing_header = response[1]['server-timing']
-
-    # Verify total value is greater than db value
-    db_duration = server_timing_header.match(/db;dur=([\d\.]+)/)[1]
-    total_duration = server_timing_header.match(/total;dur=([\d\.]+)/)[1]
-    Float(total_duration).must_be :>, Float(db_duration)
-
-    # Verify all other timers are present
-    100.times do |i|
-      server_timing_header.must_match(/t#{i};dur=[\d\.]+/)
-    end
-  end
 end

--- a/test/spec_server_timing.rb
+++ b/test/spec_server_timing.rb
@@ -20,18 +20,18 @@ describe Rack::ServerTiming do
   it "sets server-timing header with rack-runtime metric" do
     app = lambda { |env| [200, { 'content-type' => 'text/plain' }, "Hello, World!"] }
     response = server_timing_app(app).call(request)
-    response[1]['server-timing'].must_match(/^rack-runtime;dur=[\d\.]+$/)
+    response[1]['server-timing'].must_match(/\Arack-runtime;dur=[\d\.]+\z/)
   end
 
   it "appends to existing server-timing header" do
     app = lambda { |env| [200, { 'content-type' => 'text/plain', 'server-timing' => 'view;dur=50.0' }, "Hello, World!"] }
     response = server_timing_app(app).call(request)
-    response[1]['server-timing'].must_match(/^view;dur=50\.0, rack-runtime;dur=[\d\.]+$/)
+    response[1]['server-timing'].must_match(/\Aview;dur=50\.0, rack-runtime;dur=[\d\.]+\z/)
   end
 
   it "sets server-timing metric with custom name" do
     app = lambda { |env| [200, { 'content-type' => 'text/plain' }, "Hello, World!"] }
     response = server_timing_app(app, "db").call(request)
-    response[1]['server-timing'].must_match(/^db;dur=[\d\.]+$/)
+    response[1]['server-timing'].must_match(/\Adb;dur=[\d\.]+\z/)
   end
 end

--- a/test/spec_server_timing.rb
+++ b/test/spec_server_timing.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+separate_testing do
+  require_relative '../lib/rack/server_timing'
+  require_relative '../lib/rack/lint'
+  require_relative '../lib/rack/mock_request'
+end
+
+describe Rack::ServerTiming do
+  def server_timing_app(app, *args)
+    Rack::Lint.new Rack::ServerTiming.new(app, *args)
+  end
+
+  def request
+    Rack::MockRequest.env_for
+  end
+
+  it "sets server-timing header with rack-runtime metric" do
+    app = lambda { |env| [200, { 'content-type' => 'text/plain' }, "Hello, World!"] }
+    response = server_timing_app(app).call(request)
+    response[1]['server-timing'].must_match(/^rack-runtime;dur=[\d\.]+$/)
+  end
+
+  it "appends to existing server-timing header" do
+    app = lambda { |env| [200, { 'content-type' => 'text/plain', 'server-timing' => 'view;dur=50.0' }, "Hello, World!"] }
+    response = server_timing_app(app).call(request)
+    response[1]['server-timing'].must_match(/^view;dur=50\.0, rack-runtime;dur=[\d\.]+$/)
+  end
+
+  it "sets server-timing metric with custom name" do
+    app = lambda { |env| [200, { 'content-type' => 'text/plain' }, "Hello, World!"] }
+    response = server_timing_app(app, "db").call(request)
+    response[1]['server-timing'].must_match(/^db;dur=[\d\.]+$/)
+  end
+
+  it "allows multiple timers to be set" do
+    app = lambda { |env| sleep 0.1; [200, { 'content-type' => 'text/plain' }, "Hello, World!"] }
+    server_timing = server_timing_app(app, "db")
+
+    # wrap many times to guarantee a measurable difference
+    100.times do |i|
+      server_timing = Rack::ServerTiming.new(server_timing, "t#{i}")
+    end
+    server_timing = Rack::ServerTiming.new(server_timing, "total")
+
+    response = server_timing.call(request)
+    server_timing_header = response[1]['server-timing']
+
+    # Verify total value is greater than db value
+    db_duration = server_timing_header.match(/db;dur=([\d\.]+)/)[1]
+    total_duration = server_timing_header.match(/total;dur=([\d\.]+)/)[1]
+    Float(total_duration).must_be :>, Float(db_duration)
+
+    # Verify all other timers are present
+    100.times do |i|
+      server_timing_header.must_match(/t#{i};dur=[\d\.]+/)
+    end
+  end
+end

--- a/test/spec_server_timing.rb
+++ b/test/spec_server_timing.rb
@@ -9,8 +9,8 @@ separate_testing do
 end
 
 describe Rack::ServerTiming do
-  def server_timing_app(app, *args)
-    Rack::Lint.new Rack::ServerTiming.new(app, *args)
+  def server_timing_app(app, **kwargs)
+    Rack::Lint.new Rack::ServerTiming.new(app, **kwargs)
   end
 
   def request
@@ -31,7 +31,7 @@ describe Rack::ServerTiming do
 
   it "sets server-timing metric with custom name" do
     app = lambda { |env| [200, { 'content-type' => 'text/plain' }, "Hello, World!"] }
-    response = server_timing_app(app, "db").call(request)
+    response = server_timing_app(app, metric_name: "db").call(request)
     response[1]['server-timing'].must_match(/\Adb;dur=[\d\.]+\z/)
   end
 end


### PR DESCRIPTION
[Server-Timing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing) is the standard way to report server performance to the user agent nowadays. I like that it's standardized around reporting milliseconds, and this is presented meaningfully in web browsers dev tools. 

This PR introduces `Rack::ServerTiming` to set (or append to) the Server-Timing response header, with a duration measurement value, similar to the existing `Rack::Runtime` middleware.