### PR TITLE
option for custom deflaters

### DIFF
--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -39,11 +39,19 @@ module Rack
     # :sync :: determines if the stream is going to be flushed after every chunk.  Flushing after every chunk reduces
     #          latency for time-sensitive streaming applications, but hurts compression and throughput.
     #          Defaults to +true+.
+    # :deflaters :: a hash of custom deflaters, where keys are encoding names and values are callables
+    #              that take (headers, body) and return a deflated body object. When provided, these
+    #              custom deflaters will be used if the client's accept-encoding header matches.
     def initialize(app, options = {})
       @app = app
       @condition = options[:if]
       @compressible_types = options[:include]
       @sync = options.fetch(:sync, true)
+      @deflaters = options[:deflaters]
+      @available_encodings = %w(gzip)
+      @deflaters.each_key { |key| @available_encodings << key } if @deflaters
+      @available_encodings << 'identity'
+      @available_encodings.freeze
     end
 
     def call(env)
@@ -54,8 +62,7 @@ module Rack
       end
 
       request = Request.new(env)
-
-      encoding = Utils.select_best_encoding(%w(gzip identity),
+      encoding = Utils.select_best_encoding(@available_encodings,
                                             request.accept_encoding)
 
       # Set the Vary HTTP header.
@@ -72,11 +79,18 @@ module Rack
         response
       when "identity"
         response
-      else # when nil
-        # Only possible encoding values here are 'gzip', 'identity', and nil
-        message = "An acceptable encoding for the requested resource #{request.fullpath} could not be found."
-        bp = Rack::BodyProxy.new([message]) { body.close if body.respond_to?(:close) }
-        [406, { CONTENT_TYPE => "text/plain", CONTENT_LENGTH => message.length.to_s }, bp]
+      else
+        if deflater = @deflaters&.[](encoding)
+          headers['content-encoding'] = encoding
+          headers.delete(CONTENT_LENGTH)
+          response[2] = deflater.call(headers, body)
+          response
+        else
+          # Only possible encoding values here are 'gzip', 'identity', and nil
+          message = "An acceptable encoding for the requested resource #{request.fullpath} could not be found."
+          bp = Rack::BodyProxy.new([message]) { body.close if body.respond_to?(:close) }
+          [406, { CONTENT_TYPE => "text/plain", CONTENT_LENGTH => message.length.to_s }, bp]
+        end
       end
     end
 


### PR DESCRIPTION
**EDIT:** I deleted my fork again and this action closed this PR here. I created PR #2399. Sorry for the inconvenience.

Hi folks,

I hope that it is open that I gave it a try? :face_with_peeking_eye: 
Basically this is how I understood Jeremy's comment in the [issue 2168](https://github.com/rack/rack/issues/2168#issuecomment-2140429059).

The basic usage [with Zstd](https://github.com/SpringMT/zstd-ruby) would be

```ruby
use Rack::Deflater, deflaters: {
  "zstd" => lambda { |headers, body| ZstdStream.new(body) }
}
```

Thank you so much for maintaining Rack! :pray: 