### PR TITLE
Reject line folding in multipart headers

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -31,12 +31,10 @@ module Rack
     Error = BoundaryTooLongError
 
     EOL = "\r\n"
-    FWS = /[ \t]+(?:\r\n[ \t]+)?/ # whitespace with optional folding
-    HEADER_VALUE = "(?:[^\r\n]|\r\n[ \t])*" # anything but a non-folding CRLF
     MULTIPART = %r|\Amultipart/.*boundary=\"?([^\";,]+)\"?|ni
-    MULTIPART_CONTENT_TYPE = /^Content-Type:#{FWS}?(#{HEADER_VALUE})/ni
-    MULTIPART_CONTENT_DISPOSITION = /^Content-Disposition:#{FWS}?(#{HEADER_VALUE})/ni
-    MULTIPART_CONTENT_ID = /^Content-ID:#{FWS}?(#{HEADER_VALUE})/ni
+    MULTIPART_CONTENT_TYPE = /Content-Type:[ \t]*(.*)#{EOL}/ni
+    MULTIPART_CONTENT_DISPOSITION = /Content-Disposition:(.*)(?=#{EOL}(\S|\z))/ni
+    MULTIPART_CONTENT_ID = /Content-ID:[ \t]*([^#{EOL}]*)/ni
 
     # Rack::Multipart::Parser handles parsing of multipart/form-data requests.
     #

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1167,7 +1167,7 @@ true\r
     data = <<-EOF
 --AaB03x\r
 content-type: text/plain\r
-content-disposition: attachment; name="quoted\\\\chars\\"in\tname"\r
+content-disposition: attachment; name="quoted\\\\chars\\"in\rname"\r
 \r
 true\r
 --AaB03x--\r
@@ -1180,7 +1180,7 @@ true\r
     }
     env = Rack::MockRequest.env_for("/", options)
     params = Rack::Multipart.parse_multipart(env)
-    params["quoted\\chars\"in\tname"].must_equal 'true'
+    params["quoted\\chars\"in\rname"].must_equal 'true'
   end
 
   it "supports mixed case metadata" do

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1288,10 +1288,9 @@ content-type: image/png\r
       :input => StringIO.new(data)
     }
     env = Rack::MockRequest.env_for("/", options)
-    params = Rack::Multipart.parse_multipart(env)
-    content_type = params["upload"][:type]
-    content_type.wont_include "\r\n"
-    content_type.wont_include "Content-Disposition"
+    lambda {
+      Rack::Multipart.parse_multipart(env)
+    }.must_raise Rack::BadRequest
   end
 
   it "prevents filename parameter injection via obs-fold" do
@@ -1310,9 +1309,9 @@ content-type: image/png\r
       :input => StringIO.new(data)
     }
     env = Rack::MockRequest.env_for("/", options)
-    params = Rack::Multipart.parse_multipart(env)
-    filename = params["upload"][:filename]
-    filename.wont_equal "passwd"
+    lambda {
+      Rack::Multipart.parse_multipart(env)
+    }.must_raise Rack::BadRequest
   end
 
   it "prevents CRLF injection in parameter values via obs-fold" do
@@ -1332,9 +1331,9 @@ content-type: image/png\r
       :input => StringIO.new(data)
     }
     env = Rack::MockRequest.env_for("/", options)
-    params = Rack::Multipart.parse_multipart(env)
-    content_type = params["upload"][:type]
-    content_type.wont_include "\r\n"
+    lambda {
+      Rack::Multipart.parse_multipart(env)
+    }.must_raise Rack::BadRequest
   end
 
   # Security tests for CVE-2025-49007: ReDoS vulnerability in regex patterns


### PR DESCRIPTION
Commit 4795831a0a310c2d31102749e551b38faab6401f enables obsolete line folding (obs-fold) contrary to [RFC 7230 §3.2.4](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.4).

So we revert 4795831a0a310c2d31102749e551b38faab6401f entirely, and provide a replacement fix with regression tests.

RFC 7230 §3.2.4 ¶5 states:
> A server that receives an obs-fold in a request message that is not within a message/http container MUST either reject the message by sending a 400 (Bad Request), preferably with a representation explaining that obsolete line folding is unacceptable, or replace each received obs-fold with one or more SP octets prior to interpreting the field value or forwarding the message downstream.

Rejecting is the correct choice, as there is no benefit to processing such requests.