### PR TITLE
Correct IP address order

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -403,7 +403,7 @@ module Rack
               return forwarded.last
             end
           when :x_forwarded
-            if (value = get_header(HTTP_X_FORWARDED_HOST)) && (x_forwarded_host = split_header(value).last)
+            if (value = get_header(HTTP_X_FORWARDED_HOST)) && (x_forwarded_host = split_header(value).first)
               return wrap_ipv6(x_forwarded_host)
             end
           end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -411,7 +411,7 @@ class RackRequestTest < Minitest::Spec
 
       req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
         "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
-        forwarded_authority.must_equal '4.5.6.7'
+        forwarded_authority.must_equal '2.3.4.5'
 
       req("HTTP_FORWARDED"=>"proto=https",
         "HTTP_X_FORWARDED_PROTO" => "ws",


### PR DESCRIPTION
What Stéphane pointed out in #2395 sounds right to me. [Mozilla Doc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#directives) says

> If a request goes through multiple proxies, the IP addresses of each successive proxy are listed. This means that the rightmost IP address is the IP address of the most recent proxy and the leftmost IP address is the address of the originating client (assuming well-behaved client and proxies).