### PR TITLE
Deflator option to enable custom ones like `zstd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add `Rack::Files#assign_headers` to allow overriding how the configured file headers are set. ([#2377](https://github.com/rack/rack/pull/2377), [@codergeek121](https://github.com/codergeek121))
 - Add support for `rack.response_finished` to `Rack::TempfileReaper`. ([#2363](https://github.com/rack/rack/pull/2363), [@skipkayhil](https://github.com/skipkayhil))
 - Add support for streaming bodies when using `Rack::Events`. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
+- Add `deflaters` option to `Rack::Deflater` to enable custom compression algorithms like zstd. ([#2168](https://github.com/rack/rack/issues/2168), [@alexanderadam](https://github.com/alexanderadam))
 
 ### Changed
 


### PR DESCRIPTION
I deleted my fork by accident and therefore I closed #2393 :face_with_peeking_eye: 
Here it is again:

___

Hi folks,

I hope that it is okay that I gave it a try? :face_with_peeking_eye: 
Basically this is how I understood Jeremy's comment in the [issue 2168](https://github.com/rack/rack/issues/2168#issuecomment-2140429059).

The basic usage [with Zstd](https://github.com/SpringMT/zstd-ruby) would be

```ruby
use Rack::Deflater, deflaters: {
  "zstd" => lambda { |headers, body| ZstdStream.new(body) }
}
```

Thank you so much for maintaining Rack! :pray: 


**PS:** I'm looking for a new adventure in case anybody is looking to hire someone or in case someone would like to work with a Ruby/Rails/Crystal dev