### PR TITLE
Allow to configure the selected value for `x-forwarded-host`

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -412,7 +412,7 @@ module Rack
               return forwarded.last
             end
           when :x_forwarded
-            if (value = get_header(HTTP_X_FORWARDED_HOST)) && (x_forwarded_host = split_header(value).last)
+            if (value = get_header(HTTP_X_FORWARDED_HOST)) && (x_forwarded_host = split_header(value).first)
               return wrap_ipv6(x_forwarded_host)
             end
           end

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -38,10 +38,21 @@ module Rack
       # similar to <tt>[:scheme, :proto]</tt>.  You can remove either or
       # both of the entries in array to ignore that respective header.
       attr_accessor :x_forwarded_proto_priority
+
+      # Whether to use the first (leftmost) value from the
+      # <tt>X-Forwarded-Host</tt> header. The default is +false+,
+      # which returns the last (rightmost) value from the most
+      # recent (and typically trusted) proxy. Set to +true+ to
+      # use the first value, which is the original client-supplied
+      # host, useful for generating URLs and redirects. Note that
+      # earlier values can be spoofed by clients, so only set to
+      # +true+ if you trust your proxy chain to sanitize headers.
+      attr_accessor :x_forwarded_host_first
     end
 
     @forwarded_priority = [:forwarded, :x_forwarded]
     @x_forwarded_proto_priority = [:proto, :scheme]
+    @x_forwarded_host_first = false
 
     valid_ipv4_octet = /\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])/
 
@@ -412,7 +423,8 @@ module Rack
               return forwarded.last
             end
           when :x_forwarded
-            if (value = get_header(HTTP_X_FORWARDED_HOST)) && (x_forwarded_host = split_header(value).first)
+            if (value = get_header(HTTP_X_FORWARDED_HOST)) && (hosts = split_header(value)) && !hosts.empty?
+              x_forwarded_host = x_forwarded_host_first ? hosts.first : hosts.last
               return wrap_ipv6(x_forwarded_host)
             end
           end
@@ -786,6 +798,10 @@ module Rack
 
       def x_forwarded_proto_priority
         Request.x_forwarded_proto_priority
+      end
+
+      def x_forwarded_host_first
+        Request.x_forwarded_host_first
       end
     end
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -410,8 +410,8 @@ class RackRequestTest < Minitest::Spec
         forwarded_port.must_equal [2345]
 
       req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
-        "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
-        forwarded_authority.must_equal '4.5.6.7'
+        "HTTP_X_FORWARDED_HOST" => "example.com,cdn.vade.io,proxy.internal").
+        forwarded_authority.must_equal 'example.com'
 
       req("HTTP_FORWARDED"=>"proto=https",
         "HTTP_X_FORWARDED_PROTO" => "ws",


### PR DESCRIPTION
This is basically PR #2397. I just deleted the fork because I though that it is not needed any more :laughing: 


/CC @wtn @ioquatix @jeremyevans 
___

What Stéphane pointed out in #2395 sounds right to me. [Mozilla Doc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#directives) says

> If a request goes through multiple proxies, the IP addresses of each successive proxy are listed. This means that the rightmost IP address is the IP address of the most recent proxy and the leftmost IP address is the address of the originating client (assuming well-behaved client and proxies).

I couldn't find a spec that defines the rules for `x-forwarded-host` but I'd _assume_ that they apply there as well.
Also [the GitLab folks say](https://gitlab.com/gitlab-org/gitlab-pages/-/merge_requests/386):

> When multiple reverse-proxies are stacked, the X-Forwarded-Host header
contains all hops, separated by ", ".
> We take the first one, i.e. probably the fqdn set by the browser.

Howeveeeeer, [another comment](https://gitlab.com/gitlab-org/gitlab-pages/-/merge_requests/386#note_535448323) in that very issue states that Apache might _prepend_ hosts. I don't read it that way [in Apache's documentation](https://httpd.apache.org/docs/current/mod/mod_proxy.html#x-headers) though.
Is Apache still using SVN? :scream: 
If so, then [this might still be the current code](https://svn.apache.org/repos/asf/httpd/httpd/tags/2.4.9/modules/proxy/proxy_util.c):

```c
    if (dconf->add_forwarded_headers) {
        if (PROXYREQ_REVERSE == r->proxyreq) {
            const char *buf;

            /* Add X-Forwarded-For: so that the upstream has a chance to
             * determine, where the original request came from.
             */
            apr_table_mergen(r->headers_in, "X-Forwarded-For",
                             r->useragent_ip);

            /* Add X-Forwarded-Host: so that upstream knows what the
             * original request hostname was.
             */
            if ((buf = apr_table_get(r->headers_in, "Host"))) {
                apr_table_mergen(r->headers_in, "X-Forwarded-Host", buf);
            }

            /* Add X-Forwarded-Server: so that upstream knows what the
             * name of this proxy server is (if there are more than one)
             * XXX: This duplicates Via: - do we strictly need it?
             */
            apr_table_mergen(r->headers_in, "X-Forwarded-Server",
                             r->server->server_hostname);
        }
    }
```

But it's too late at my place to make any sense of that right now.
I will go to :bed: bed now. :wink: 


**PS:** I'm looking for a new adventure in case anybody is looking to hire someone or in case someone would like to work with a PO/PM or Ruby/Rails/Crystal dev