### PR TITLE
add Rack::Request#prefetch? helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add support for `rack.response_finished` to `Rack::TempfileReaper`. ([#2363](https://github.com/rack/rack/pull/2363), [@skipkayhil](https://github.com/skipkayhil))
 - Add support for streaming bodies when using `Rack::Events`. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
 - Add `deflaters` option to `Rack::Deflater` to enable custom compression algorithms like zstd. ([#2168](https://github.com/rack/rack/issues/2168), [@alexanderadam](https://github.com/alexanderadam))
+- Add `Rack::Request#prefetch?` for identifying requests with `Sec-Purpose: prefetch` header set. ([#2405](https://github.com/rack/rack/pull/2405), [@glaszig](https://github.com/glaszig))
 
 ### Changed
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -319,6 +319,15 @@ module Rack
         get_header("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest"
       end
 
+      # Checks whether the `Sec-Purpose` header is set to indicate a `prefetch`
+      # request through, e.g., <a href="..." rel="prefetch">...</a>.
+      #
+      # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Purpose
+      # https://wicg.github.io/nav-speculation/prefetch.html#sec-purpose-header
+      def prefetch?
+        get_header("HTTP_SEC_PURPOSE") == "prefetch"
+      end
+
       # The `HTTP_HOST` header.
       def host_authority
         get_header(HTTP_HOST)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -1049,6 +1049,15 @@ EOF
     req.must_be :xhr?
   end
 
+  it "figure out if prefetch request" do
+    req = make_request(Rack::MockRequest.env_for(""))
+    req.wont_be :prefetch?
+
+    req = make_request \
+      Rack::MockRequest.env_for("", "HTTP_SEC_PURPOSE" => "prefetch")
+    req.must_be :prefetch?
+  end
+
   it "ssl detection" do
     request = make_request(Rack::MockRequest.env_for("/"))
     request.scheme.must_equal "http"


### PR DESCRIPTION
allows to effortlessly identify prefetch request as defined by WICG. inspects the `Sec-Purpose` header as defined in specification [0].

the usefulness is probably best explained by the following quote from the original fetch draft [1]:

"The server can use this to adjust the caching expiry for prefetches, to disallow the prefetch, or to treat it differently when counting page visits."

[0]: https://wicg.github.io/nav-speculation/prefetch.html#sec-purpose-header
[1]: https://fetch.spec.whatwg.org/#http-sec-purpose
also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Purpose

this header has [quite a history][history]. i thought about supporting more permutations but settled on what's in the spec.

[history]: https://lionralfs.dev/blog/exploring-the-usage-of-prefetch-headers/