### PR TITLE
keep multi-part buffer as binary internally

### DIFF
--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -249,7 +249,7 @@ module Rack
         @retained_size = 0
         @collector = Collector.new tempfile
 
-        @sbuf = StringScanner.new("".dup)
+        @sbuf = StringScanner.new("".b)
         @body_regex = /(?:#{EOL}|\A)--#{Regexp.quote(boundary)}(?:#{EOL}|--)/m
         @body_regex_at_end = /#{@body_regex}\z/m
         @end_boundary_size = boundary.bytesize + 4 # (-- at start, -- at finish)


### PR DESCRIPTION
what end's up happening if we start with the UTF-8 default (`"".dup`) is that the string will end up doing (unnecessary) code-range/encoding detection as content is read into the scanner. 

have observed that despite reading binary content (as `rack.input` is expected to be) the buffer internally might end up as `UTF-8` while other times it's simply `ASCII-8BIT`.

a bit hard to write a test here without getting into the internals but could try if necessary.