### PR TITLE
fix: keep multipart names UTF-8 & transcode bodies

### DIFF
--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -101,10 +101,10 @@ describe Rack::Multipart do
     params = Rack::Multipart.parse_multipart(env)
     params["text"].encoding.must_equal Encoding::US_ASCII
 
-    # I'm not 100% sure if making the param name encoding match the
-    # content-type charset is the right thing to do.  We should revisit this.
+    # Parameter names always stay UTF-8 to avoid Encoding::CompatibilityError
+    # in the query parser (see issue #2414)
     params.keys.each do |key|
-      key.encoding.must_equal Encoding::US_ASCII
+      key.encoding.must_equal Encoding::UTF_8
     end
   end
 
@@ -113,10 +113,10 @@ describe Rack::Multipart do
     params = Rack::Multipart.parse_multipart(env)
     params["text"].encoding.must_equal Encoding::BINARY
 
-    # I'm not 100% sure if making the param name encoding match the
-    # content-type charset is the right thing to do.  We should revisit this.
+    # Parameter names always stay UTF-8 to avoid Encoding::CompatibilityError
+    # in the query parser (see issue #2414)
     params.keys.each do |key|
-      key.encoding.must_equal Encoding::BINARY
+      key.encoding.must_equal Encoding::UTF_8
     end
   end
 


### PR DESCRIPTION
Soooooo, the way I understand it, the name/field could stay UTF-8 all the time anyway.
While ASCII is _recommended_, UTF-8 is supported if both parties speak it.

> _Some commonly deployed systems use multipart/form-data with file names directly encoded including octets outside the US-ASCII range._
> _The encoding used for the file names is typically UTF-8, although HTML forms will use the charset associated with the form._
> […]
> _If non-ASCII field names are unavoidable, form or application creators SHOULD use UTF-8 uniformly._
> _This will minimize interoperability problems._

So if the client wants to speak UTF-8, so can we. And from ASCII to UTF-8 we have compatibility built-in if I remember correctly.
And we'd not make that special jump from `ISO_2022_JP` to UTF-8 for the field(!) again if we keep UTF-8.
Hence we can save some transcoding work here.

Now, the body is a different story obviously.
And it could be that I'm misunderstanding stuff here.
But I assume that we want to make sense of the body whenever possible.
Thus I'd always _try_ to transcode it into something that we understand.
I know there's a performance impact. But I'd assume that in most of the cases the body will be something that we can handle and we have an early return for that.

But the dummy encodings might include things that will still not transcode into UTF-8. For these things I'd suggest using binary. This way folks who _reeeeally_ want to tackle this can still do whatever they want, without being bothered by an internal Rack exception.

refs #2414

**EDIT:** Why is it _always_ TruffleRuby? :laughing: 
Wow, `ArgumentError: UTF-16 string byte length (51) is not a multiple of 2` - even the error message doesn't look like an `ArgumentError`. But I think encoding-wise there were a few strange things outside of UTF-8 in TruffleRuby. It even rings a bell.

Anyway, I'd like to postpone the fix until it's clear that the PR would be something that we'd like to continue with.


**PS:** I'm looking for a new adventure in case anybody is looking to hire someone or in case someone would like to work with a Ruby/Rails/Crystal dev