### PR TITLE
Raise InvalidPartEncodingError on invalid multipart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file. For info on
 - Raise before exceeding a part limit, not after. ([#2362](https://github.com/rack/rack/pull/2362), [@matthew-puku](https://github.com/matthew-puku))
 - Rack::Deflater now uses a fixed GZip mtime value. ([#2372](https://github.com/rack/rack/pull/2372), [@bensheldon](https://github.com/bensheldon))
 - Multipart parser drops support for RFC 2231 `filename*` parameter (prohibited by RFC 7578) and now properly handles UTF-8 encoded filenames via percent-encoding and direct UTF-8 bytes. ([#2398](https://github.com/rack/rack/pull/2398), [@wtn](https://github.com/wtn))
-- The query parser now raises Rack::QueryParser::IncompatibleEncodingError if we try to parse params that are not ASCII compatible. ([#2416](https://github.com/rack/rack/pull/2416), [@bquorning](https://github.com/bquorning))
+- The query parser now raises `Rack::QueryParser::IncompatibleEncodingError` if we try to parse params that are not ASCII compatible. ([#2416](https://github.com/rack/rack/pull/2416), [@bquorning](https://github.com/bquorning))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file. For info on
 - Raise before exceeding a part limit, not after. ([#2362](https://github.com/rack/rack/pull/2362), [@matthew-puku](https://github.com/matthew-puku))
 - Rack::Deflater now uses a fixed GZip mtime value. ([#2372](https://github.com/rack/rack/pull/2372), [@bensheldon](https://github.com/bensheldon))
 - Multipart parser drops support for RFC 2231 `filename*` parameter (prohibited by RFC 7578) and now properly handles UTF-8 encoded filenames via percent-encoding and direct UTF-8 bytes. ([#2398](https://github.com/rack/rack/pull/2398), [@wtn](https://github.com/wtn))
+- The query parser now raises Rack::QueryParser::IncompatibleEncodingError if we try to parse params that are not ASCII compatible. ([#2416](https://github.com/rack/rack/pull/2416), [@bquorning](https://github.com/bquorning))
 
 ### Fixed
 

--- a/lib/rack/method_override.rb
+++ b/lib/rack/method_override.rb
@@ -47,7 +47,7 @@ module Rack
 
     def method_override_param(req)
       req.POST[METHOD_OVERRIDE_PARAM_KEY] if req.form_data? || req.parseable_data?
-    rescue Utils::InvalidParameterError, Utils::ParameterTypeError, QueryParser::ParamsTooDeepError
+    rescue Utils::InvalidParameterError, Utils::ParameterTypeError, QueryParser::ParamsTooDeepError, QueryParser::IncompatibleEncodingError
       req.get_header(RACK_ERRORS).puts "Invalid or incomplete POST params"
     rescue EOFError
       req.get_header(RACK_ERRORS).puts "Bad request content body"

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -27,6 +27,10 @@ module Rack
       include BadRequest
     end
 
+    class IncompatibleEncodingError < EncodingError
+      include BadRequest
+    end
+
     # ParamsTooDeepError is the old name for the error that is raised when params
     # are recursively nested over the specified limit. Make it the same as
     # as QueryLimitError, so that code that rescues ParamsTooDeepError error
@@ -191,6 +195,8 @@ module Rack
       end
 
       params
+    rescue Encoding::CompatibilityError
+      raise IncompatibleEncodingError
     end
 
     def make_params

--- a/test/spec_query_parser.rb
+++ b/test/spec_query_parser.rb
@@ -41,4 +41,13 @@ describe Rack::QueryParser do
     proc { query_parser.parse_query("b[]=a&b[]=b&b[]=c") }.must_raise Rack::QueryParser::QueryLimitError
     proc { query_parser.parse_query_pairs("a=a&b=b&c=c") }.must_raise Rack::QueryParser::QueryLimitError
   end
+
+  it "raises when normalizing params with incompatible encoding such as UTF-16LE" do
+    query_parser = Rack::QueryParser.make_default(8)
+    name = "utf-16le".dup.force_encoding("UTF-16LE")
+    value = "Alice?".dup.force_encoding("UTF-16LE")
+    lambda {
+      query_parser.normalize_params({}, name, value)
+    }.must_raise(::Rack::QueryParser::IncompatibleEncodingError)
+  end
 end


### PR DESCRIPTION
Multipart parser now raises `Rack::Multipart::InvalidPartEncodingError` if one part uses a non-ASCII compatible, non-dummy encoding.

~The added test case is very similar to one specifying how ISO-2022-JP encoding is handled, so I took the liberty of rewording that a bit.~

Fixes #2414.
