### PR TITLE
Drop Ruby v3.2 from external tests as Rails head no longer supports it

### DIFF
--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.2', '3.3', '3.4']
+        ruby: ['3.3', '3.4']
 
     runs-on: ${{matrix.os}}
     env:


### PR DESCRIPTION
Ruby 3.2 support was removed in https://github.com/rails/rails/commit/fc22a8fc62d5240c0d09f1078800900ea2
