### PR TITLE
Allow minitest 6+ as a development dependency

### DIFF
--- a/rack.gemspec
+++ b/rack.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
     "rubygems_mfa_required" => "true"
   }
 
-  s.add_development_dependency 'minitest', "~> 5.0"
+  s.add_development_dependency 'minitest', "> 5"
   s.add_development_dependency 'minitest-global_expectations'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
Tests run fine on minitest 6. Pessismistic versioning causes more problems than it solves.