### PR TITLE
Fix MockResponse#body when the body is a Proc

### DIFF
--- a/lib/rack/mock_response.rb
+++ b/lib/rack/mock_response.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'stringio'
 require 'time'
 
 require_relative 'response'
@@ -82,8 +83,12 @@ module Rack
       #   end
       buffer = @buffered_body = String.new
 
-      @body.each do |chunk|
-        buffer << chunk
+      if @body.respond_to?(:each)
+        @body.each do |chunk|
+          buffer << chunk
+        end
+      else
+        @body.call(StringIO.new(buffer))
       end
 
       return buffer

--- a/test/spec_mock_response.rb
+++ b/test/spec_mock_response.rb
@@ -230,6 +230,21 @@ describe Rack::MockResponse do
     headers = res[1]
     refute headers.key?("content-length")
   end
+
+  it "handles Proc bodies" do
+    headers = { "content-type" => "text/event-stream" }
+
+    body = proc do |stream|
+      stream.write("Hello, ")
+      stream.write("world!")
+    end
+
+    response = Rack::MockResponse[200, headers, body]
+
+    response.status.must_equal 200
+    response.headers.must_equal headers
+    response.body.must_equal "Hello, world!"
+  end
 end
 
 describe Rack::MockResponse, 'headers' do


### PR DESCRIPTION
Previously, we would see errors like

    NoMethodError: undefined method 'each' for an instance of Proc

in Rails integration tests when using streaming response bodies.
