### PR TITLE
Use psych 3.0.2 (default version) on Ruby 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 group :doc do
   gem "rdoc"
-  gem "psych", "< 5" if RUBY_VERSION[0..2] == "2.5"
+  gem "psych", "= 3.0.2" if RUBY_VERSION[0..2] == "2.5"
 end
 
 group :test do


### PR DESCRIPTION
Fixes the following bundle install error in Ruby 2.5 CI:

```
ArgumentError: wrong number of arguments (given 4, expected 1)
```

* Failing on main: https://github.com/rack/rack/actions/runs/21312068303/job/61349741818#step:3:131
* Passing with this PR: https://github.com/jeremyevans/rack/actions/runs/21613025203/job/62285808506#step:4:565
