### PR TITLE
Ensure streaming response body is closed by `Rack::MockResponse`.

### DIFF
--- a/lib/rack/mock_response.rb
+++ b/lib/rack/mock_response.rb
@@ -83,12 +83,16 @@ module Rack
       #   end
       buffer = @buffered_body = String.new
 
-      if @body.respond_to?(:each)
-        @body.each do |chunk|
-          buffer << chunk
+      begin
+        if @body.respond_to?(:each)
+          @body.each do |chunk|
+            buffer << chunk
+          end
+        else
+          @body.call(StringIO.new(buffer))
         end
-      else
-        @body.call(StringIO.new(buffer))
+      ensure
+        @body.close if @body.respond_to?(:close)
       end
 
       return buffer

--- a/test/spec_mock_response.rb
+++ b/test/spec_mock_response.rb
@@ -245,6 +245,27 @@ describe Rack::MockResponse do
     response.headers.must_equal headers
     response.body.must_equal "Hello, world!"
   end
+
+  it "closes streaming bodies that respond to close" do
+    closed = false
+
+    body = proc do |stream|
+      stream.write("content")
+    end
+
+    # Add a close method to the proc
+    def body.close
+      @closed = true
+    end
+
+    def body.closed?
+      @closed
+    end
+
+    response = Rack::MockResponse[200, {}, body]
+    response.body.must_equal "content"
+    body.must_be :closed?
+  end
 end
 
 describe Rack::MockResponse, 'headers' do


### PR DESCRIPTION
Fixes https://github.com/rack/rack/issues/2422.

As this is a bug fix, can we back port it to 3.2 at least? 3.1 might be nice too. We'd need to include the changes introduced by https://github.com/rack/rack/pull/2420.