### PR TITLE
Fix 'Upgrade Guide' link to 3.0-3.2 pages

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -40,6 +40,8 @@ jobs:
         gem unpack rack -v "< 3.3"
         cd rack-3.2*
         cp ../.rdoc_options .
+        cp ../UPGRADE-GUIDE.md .
+        cp ../SECURITY.md .
         bundle exec rdoc --op ../docs/3.2 --main README.md --template-stylesheets ../contrib/rdoc.css
         cp -r ../contrib ../docs/3.2
 
@@ -50,6 +52,8 @@ jobs:
         gem unpack rack -v "< 3.2"
         cd rack-3.1*
         cp ../.rdoc_options .
+        cp ../UPGRADE-GUIDE.md .
+        cp ../SECURITY.md .
         bundle exec rdoc --op ../docs/3.1 --main README.md --template-stylesheets ../contrib/rdoc.css
         cp -r ../contrib ../docs/3.1
 
@@ -60,6 +64,7 @@ jobs:
         gem unpack rack -v "< 3.1"
         cd rack-3.0*
         cp ../.rdoc_options .
+        cp ../UPGRADE-GUIDE.md .
         bundle exec rdoc --op ../docs/3.0 --main README.md --template-stylesheets ../contrib/rdoc.css
         cp -r ../contrib ../docs/3.0
 


### PR DESCRIPTION
The link "Upgrade Guide" is broken on documentation of 3.0 to 3.2 versions.

Example:
[Upgrade Guide - 3.2 documentation](https://rack.github.io/rack/3.2/UPGRADE-GUIDE_md.html)

<img width="755" height="139" alt="image" src="https://github.com/user-attachments/assets/08e936b4-5cd7-43d0-ad66-3d94493829f3" />

<img width="698" height="483" alt="image" src="https://github.com/user-attachments/assets/5ec93f14-4dd5-40ce-ba67-528c8f61f739" />