### PR TITLE
Freeze more internal constants and improve Ractor compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. For info on
 - Multipart parser drops support for RFC 2231 `filename*` parameter (prohibited by RFC 7578) and now properly handles UTF-8 encoded filenames via percent-encoding and direct UTF-8 bytes. ([#2398](https://github.com/rack/rack/pull/2398), [@wtn](https://github.com/wtn))
 - The query parser now raises `Rack::QueryParser::IncompatibleEncodingError` if we try to parse params that are not ASCII compatible. ([#2416](https://github.com/rack/rack/pull/2416), [@bquorning](https://github.com/bquorning))
 - The mime type for `.pem` files has been changed from `application/x-x509-ca-cert` to `application/x-pem-file`. ([#2435](https://github.com/rack/rack/pull/2435), [@jeremyevans](https://github.com/jeremyevans))
+- Freeze `Rack::Auth::AbstractRequest::AUTHORIZATION_KEYS`, `Rack::Utils::STATUS_WITH_NO_ENTITY_BODY`, `Rack::Multipart::Parser::EMPTY`, `Rack::Utils.default_query_parser`, and internal constants in `Rack::Lint`. Also make the multipart parser's default Tempfile factory Ractor-compatible. ([#2428](https://github.com/rack/rack/pull/2428), [@jhawthorn](https://github.com/jhawthorn))
 
 ### Fixed
 

--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -37,7 +37,7 @@ module Rack
 
       private
 
-      AUTHORIZATION_KEYS = ['HTTP_AUTHORIZATION', 'X-HTTP_AUTHORIZATION', 'X_HTTP_AUTHORIZATION']
+      AUTHORIZATION_KEYS = ['HTTP_AUTHORIZATION', 'X-HTTP_AUTHORIZATION', 'X_HTTP_AUTHORIZATION'].freeze
 
       def authorization_key
         @authorization_key ||= AUTHORIZATION_KEYS.detect { |key| @env.has_key?(key) }

--- a/lib/rack/lint.rb
+++ b/lib/rack/lint.rb
@@ -922,7 +922,7 @@ module Rack
         verify_to_path
       end
 
-      BODY_METHODS = {to_ary: true, each: true, call: true, to_path: true}
+      BODY_METHODS = {to_ary: true, each: true, call: true, to_path: true}.freeze
 
       def to_path
         @body.to_path
@@ -976,7 +976,7 @@ module Rack
         REQUIRED_METHODS = [
           :read, :write, :<<, :flush, :close,
           :close_read, :close_write, :closed?
-        ]
+        ].freeze
 
         def_delegators :@stream, *REQUIRED_METHODS
 

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -117,7 +117,7 @@ module Rack
       end
 
       MultipartInfo = Struct.new :params, :tmp_files
-      EMPTY         = MultipartInfo.new(nil, [])
+      EMPTY         = MultipartInfo.new(nil, [].freeze).freeze
 
       def self.parse_boundary(content_type)
         return unless content_type

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -68,7 +68,6 @@ module Rack
       @param_depth_limit = param_depth_limit
       @bytesize_limit = bytesize_limit
       @params_limit = params_limit
-      freeze
     end
 
     # Stolen from Mongrel, with some small modifications:

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -68,6 +68,7 @@ module Rack
       @param_depth_limit = param_depth_limit
       @bytesize_limit = bytesize_limit
       @params_limit = params_limit
+      freeze
     end
 
     # Stolen from Mongrel, with some small modifications:

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -32,7 +32,7 @@ module Rack
     # The default amount of nesting to allowed by hash parameters.
     # This helps prevent a rogue client from triggering a possible stack overflow
     # when parsing parameters.
-    self.default_query_parser = QueryParser.make_default(32)
+    self.default_query_parser = QueryParser.make_default(32).freeze
 
     module_function
 

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -651,7 +651,7 @@ module Rack
     }
 
     # Responses with HTTP status codes that should not have an entity body
-    STATUS_WITH_NO_ENTITY_BODY = Hash[((100..199).to_a << 204 << 304).product([true])]
+    STATUS_WITH_NO_ENTITY_BODY = Hash[((100..199).to_a << 204 << 304).product([true])].freeze
 
     SYMBOL_TO_STATUS_CODE = Hash[*HTTP_STATUS_CODES.map { |code, message|
       [message.downcase.gsub(/\s|-/, '_').to_sym, code]


### PR DESCRIPTION
This freezes a bunch of constants and replaces some unshareable procs with plain classes. This moves us towards being able to use `Rack::Request` and `Rack::Response` from within a Ractor, as well as can help prevent thread-safety issues.

I tried to be very conservative in limiting this to constants users should not be modifying. For example `FORM_DATA_MEDIA_TYPES`, `PARSEABLE_DATA_MEDIA_TYPES`, `MIME_TYPES`, `Rack::Request.forwarded_priority`, and `Rack::Request.x_forwarded_proto_priority` are documented (or seem likely) to be modifiable by users so they were left unchanged. I also didn't change any optional middleware (some of which have constants that could be frozen) other than `Lint` to keep this focused.

The two procs here could be made safe using Ruby 4.0's `Ractor.shareable_proc`, but it's simpler (and compatible with all versions) to just create a `call`able class.

If any of these we're worried about or are contentious I can back it out and try separately.