### PR TITLE
Undeprecate Rack::Auth::AbstractRequest#request

### DIFF
--- a/lib/rack/auth/abstract/request.rb
+++ b/lib/rack/auth/abstract/request.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# XXX: Remove when removing AbstractRequest#request
 require_relative '../../request'
 
 module Rack
@@ -12,7 +11,6 @@ module Rack
       end
 
       def request
-        warn "Rack::Auth::AbstractRequest#request is deprecated and will be removed in a future version of rack.", uplevel: 1
         @request ||= Request.new(@env)
       end
 

--- a/test/spec_auth_basic.rb
+++ b/test/spec_auth_basic.rb
@@ -101,7 +101,7 @@ describe Rack::Auth::Basic do
     realm.must_equal app.realm
   end
 
-  deprecated "supports #request for a Rack::Request object" do
+  it "supports #request for a Rack::Request object" do
     Rack::Auth::Basic::Request.new({}).request.must_be_kind_of Rack::Request
   end
 end


### PR DESCRIPTION
The method is being used by middlewares in the wild subclassing Rack::Auth::Basic.

This reverts commit 1f5d109e7c8435bedffb1cc0a2026e7f4d012349.

Close https://github.com/rack/rack/issues/2429