### PR TITLE
Consider forwarded_priority and x_forwarded_proto_priority for x-forwarded-ssl

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -40,7 +40,7 @@ module Rack
     end
 
     @forwarded_priority = [:forwarded, :x_forwarded]
-    @x_forwarded_proto_priority = [:proto, :scheme]
+    @x_forwarded_proto_priority = [:ssl, :proto, :scheme]
 
     valid_ipv4_octet = /\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])/
 
@@ -335,12 +335,8 @@ module Rack
       def scheme
         if get_header(HTTPS) == 'on'
           'https'
-        elsif get_header(HTTP_X_FORWARDED_SSL) == 'on'
-          'https'
-        elsif forwarded_scheme
-          forwarded_scheme
         else
-          get_header(RACK_URL_SCHEME)
+          forwarded_scheme || get_header(RACK_URL_SCHEME)
         end
       end
 
@@ -844,7 +840,8 @@ module Rack
 
       FORWARDED_SCHEME_HEADERS = {
         proto: HTTP_X_FORWARDED_PROTO,
-        scheme: HTTP_X_FORWARDED_SCHEME
+        scheme: HTTP_X_FORWARDED_SCHEME,
+        ssl: HTTP_X_FORWARDED_SSL
       }.freeze
       private_constant :FORWARDED_SCHEME_HEADERS
       def forwarded_scheme
@@ -858,9 +855,13 @@ module Rack
           when :x_forwarded
             x_forwarded_proto_priority.each do |x_type|
               if header = FORWARDED_SCHEME_HEADERS[x_type]
-                split_header(get_header(header)).reverse_each do |scheme|
-                  if allowed_scheme(scheme)
-                    return scheme
+                if x_type == :ssl && get_header(header) == 'on'
+                  return 'https'
+                else
+                  split_header(get_header(header)).reverse_each do |scheme|
+                    if allowed_scheme(scheme)
+                      return scheme
+                    end
                   end
                 end
               end

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -421,6 +421,12 @@ class RackRequestTest < Minitest::Spec
         "HTTP_X_FORWARDED_SCHEME" => "http").
         forwarded_scheme.must_equal "ws"
 
+      r = req("HTTP_X_FORWARDED_PROTO" => "ws",
+        "HTTP_X_FORWARDED_SCHEME" => "http",
+        "HTTP_X_FORWARDED_SSL" => "on")
+      r.forwarded_scheme.must_equal "https"
+      r.ssl?.must_equal true
+
       req("HTTP_X_FORWARDED_SCHEME" => "http").
         forwarded_scheme.must_equal "http"
 
@@ -443,6 +449,13 @@ class RackRequestTest < Minitest::Spec
         "HTTP_X_FORWARDED_SCHEME" => "http").
         forwarded_scheme.must_equal "ws"
 
+      r = req("HTTP_FORWARDED"=>"proto=https",
+        "HTTP_X_FORWARDED_PROTO" => "ws",
+        "HTTP_X_FORWARDED_SCHEME" => "http",
+        "HTTP_X_FORWARDED_SSL" => "on")
+      r.forwarded_scheme.must_equal "https"
+      r.ssl?.must_equal true
+
       req("HTTP_FORWARDED"=>"proto=https",
         "HTTP_X_FORWARDED_SCHEME" => "http").
         forwarded_scheme.must_equal "http"
@@ -450,12 +463,14 @@ class RackRequestTest < Minitest::Spec
       req("HTTP_FORWARDED"=>"proto=https").
         forwarded_scheme.must_equal "https"
 
-      Rack::Request.x_forwarded_proto_priority = [nil, :scheme, :proto]
+      Rack::Request.x_forwarded_proto_priority = [nil, :scheme, :proto, :ssl]
 
-      req("HTTP_FORWARDED"=>"proto=https",
+      r = req("HTTP_FORWARDED"=>"proto=https",
+        "HTTP_X_FORWARDED_SSL" => "on",
         "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "http"
+        "HTTP_X_FORWARDED_SCHEME" => "http")
+      r.forwarded_scheme.must_equal "http"
+      r.ssl?.must_equal false
 
       req("HTTP_FORWARDED"=>"proto=https",
         "HTTP_X_FORWARDED_PROTO" => "ws").
@@ -466,10 +481,12 @@ class RackRequestTest < Minitest::Spec
 
       Rack::Request.forwarded_priority = [:x_forwarded]
 
-      req("HTTP_FORWARDED"=>"proto=https",
+      r = req("HTTP_FORWARDED"=>"proto=https",
+        "HTTP_X_FORWARDED_SSL" => "on",
         "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "http"
+        "HTTP_X_FORWARDED_SCHEME" => "http")
+      r.forwarded_scheme.must_equal "http"
+      r.ssl?.must_equal false
 
       req("HTTP_FORWARDED"=>"proto=https",
         "HTTP_X_FORWARDED_PROTO" => "ws").
@@ -481,6 +498,7 @@ class RackRequestTest < Minitest::Spec
       Rack::Request.x_forwarded_proto_priority = [:scheme]
 
       req("HTTP_FORWARDED"=>"proto=https",
+        "HTTP_X_FORWARDED_SSL" => "on",
         "HTTP_X_FORWARDED_PROTO" => "ws",
         "HTTP_X_FORWARDED_SCHEME" => "http").
         forwarded_scheme.must_equal "http"
@@ -495,6 +513,7 @@ class RackRequestTest < Minitest::Spec
       Rack::Request.x_forwarded_proto_priority = [:proto]
 
       req("HTTP_FORWARDED"=>"proto=https",
+        "HTTP_X_FORWARDED_SSL" => "on",
         "HTTP_X_FORWARDED_PROTO" => "ws",
         "HTTP_X_FORWARDED_SCHEME" => "http").
         forwarded_scheme.must_equal "ws"
@@ -509,6 +528,7 @@ class RackRequestTest < Minitest::Spec
       Rack::Request.x_forwarded_proto_priority = []
 
       req("HTTP_FORWARDED"=>"proto=https",
+        "HTTP_X_FORWARDED_SSL" => "on",
         "HTTP_X_FORWARDED_PROTO" => "ws",
         "HTTP_X_FORWARDED_SCHEME" => "http").
         forwarded_scheme.must_be_nil
@@ -549,10 +569,12 @@ class RackRequestTest < Minitest::Spec
         "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
         forwarded_authority.must_be_nil
 
-      req("HTTP_FORWARDED"=>"proto=https",
+      r = req("HTTP_FORWARDED"=>"proto=https",
+        "HTTP_X_FORWARDED_SSL" => "on",
         "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
+        "HTTP_X_FORWARDED_SCHEME" => "http")
+      r.forwarded_scheme.must_be_nil
+      r.ssl?.must_equal false
 
       req("HTTP_FORWARDED"=>"proto=https",
         "HTTP_X_FORWARDED_SCHEME" => "http").


### PR DESCRIPTION
Previously, X-Forwarded-SSL was considered even if forwarded_priority was an empty array. This adds :ssl as the first element to x_forwarded_proto_priority, so by default, it will be considered in preference to x-forwarded-proto and x-forwarded-scheme, but it will only be considered if the forwarded header is not present. This will not consider x-forwarded-ssl header if :x_forwarded is not in forwarded_priority or if :ssl is not in x_forwarded_proto_priority.

Fixes #2433