### PR TITLE
Fix the mime type for .pem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. For info on
 - Rack::Deflater now uses a fixed GZip mtime value. ([#2372](https://github.com/rack/rack/pull/2372), [@bensheldon](https://github.com/bensheldon))
 - Multipart parser drops support for RFC 2231 `filename*` parameter (prohibited by RFC 7578) and now properly handles UTF-8 encoded filenames via percent-encoding and direct UTF-8 bytes. ([#2398](https://github.com/rack/rack/pull/2398), [@wtn](https://github.com/wtn))
 - The query parser now raises `Rack::QueryParser::IncompatibleEncodingError` if we try to parse params that are not ASCII compatible. ([#2416](https://github.com/rack/rack/pull/2416), [@bquorning](https://github.com/bquorning))
+- The mime type for `.pem` files has been changed from `application/x-x509-ca-cert` to `application/x-pem-file`. ([#2435](https://github.com/rack/rack/pull/2435), [@jeremyevans](https://github.com/jeremyevans))
 
 ### Fixed
 

--- a/lib/rack/mime.rb
+++ b/lib/rack/mime.rb
@@ -433,7 +433,7 @@ module Rack
       ".pcx"       => "image/x-pcx",
       ".pdb"       => "chemical/x-pdb",
       ".pdf"       => "application/pdf",
-      ".pem"       => "application/x-x509-ca-cert",
+      ".pem"       => "application/x-pem-file",
       ".pfr"       => "application/font-tdpfr",
       ".pgm"       => "image/x-portable-graymap",
       ".pgn"       => "application/x-chess-pgn",


### PR DESCRIPTION
From my research, application/x-x509-ca-cert is not good as it implies a single CA certificate encoded in DER format, whereas a pem file could include a non-CA certificate, a private key, or something else.

RFC 8894 Section 6.1 states the encoding of
application/x-x509-ca-cert is binary, while pem files are ASCII encoded (https://datatracker.ietf.org/doc/html/rfc8894#section-6.1-1.10)

IANA reflects this in there official documentation https://www.iana.org/assignments/media-types/application/x-x509-ca-cert

application/x-pem-file appears to be the recommended mime type for .pem (https://pki-tutorial.readthedocs.io/en/latest/mime.html).

Linux associates .pem with both application/x-x509-ca-cert and application/x-pem-file.

Even places that include application/x-x509-ca-cert and don't include application/x-pem-file specify that
application/x-x509-ca-cert should be used for .crt and .der, not .pem:

* Apache: https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
* https://mimetype.io/all-types

However, both Nginx and OpenBSD associate .pem with application/x-x509-ca-cert in their default mime type list.