### PR TITLE
Add getting started with Rack guide

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -4,44 +4,33 @@ This guide demonstrates how to create a basic Rack application and run it using 
 
 ## Creating a Rack Application
 
-A Rack app is a class which implements a `call` method. It is passed an [`env`](./SPEC_rdoc.html#the-request-environment) hash, known as the Rack environment, which is created by parsing the incoming HTTP request.
+A Rack app is an object which implements a `call` method. It is passed an [`env`](./SPEC_rdoc.html#the-request-environment) hash, known as the Rack environment.
 
 ```ruby
-class App
-  def call(env)
-    [200, { "content-type" => "text/plain" }, ["Hello World"]]
-  end
+rack_app = lambda do |env|
+  [200, { "content-type" => "text/plain" }, ["Hello World"]]
 end
 
-run App.new
+run rack_app
 ```
 
-When an HTTP request is made, the Rack-compliant web server parses it to create the `env` hash, and forwards it to the application's `call` method. This method must return an array representing the HTTP response.
+When an HTTP request is made, the Rack-compliant web server parses it to create the `env` hash, and calls the application with `env`. The `call` method must return an array with exactly three elements, representing the HTTP response:
 
-The first element is the HTTP response code, in this case `200`. The second element is a hash containing any Rack and HTTP response headers we wish to send. And the last element is an array of strings representing the response body.
+1. The HTTP response code (`200` in the above example).
+2. A hash containing any HTTP response headers we wish to send.
+3. An enumerable object that yields strings, representing the response body.
 
-You can run this app by organizing it into a folder:
+Rack applications are generally run using the web server's command line program, with the entry point for the application being stored in a `config.ru` file:
 
 ```bash
-$ mkdir rack-demo
-$ cd rack-demo
-$ bundle init
-$ bundle add rack puma
 $ cat > config.ru << APP
-class App
-  def call(env)
-    [200, { "content-type" => "text/plain" }, ["Hello World"]]
-  end
+rack_app = lambda do |env|
+  [200, { "content-type" => "text/plain" }, ["Hello World"]]
 end
-
-run App.new
+run rack_app
 APP
-```
-
-`config.ru` is the conventional entrypoint for Rack applications. Start Puma to run the app:
-
-```bash
-$ bundle exec puma
+$ gem install puma
+$ puma
 ```
 
 Your app should be available at <http://localhost:9292>. 
@@ -51,13 +40,6 @@ $ curl localhost:9292
 Hello World
 ```
 
-You can use a different entrypoint if you wish — as long as the file extension is `.ru`.
-
-```bash
-$ bundle exec puma server.ru
-```
-
-The syntax to manually specify the entrypoint might differ for other servers — consult the documentation.
 
 ### Handling Routes and HTTP Verbs
 
@@ -99,7 +81,7 @@ end
 run App.new
 ```
 
-Rack provides a [`Rack::Request`](./Rack/Request.html) utility class which implements a convenient interface to the Rack environment. It is stateless, meaning the `env` passed to the constructor will be directly accessed and modified.
+Rack provides [`Rack::Request`](./Rack/Request.html), which implements a convenient interface to a Rack environment.
 
 The above examples can be rewritten as:
 
@@ -146,21 +128,18 @@ The below application demonstrates how a `POST` request with a JSON body could b
 ```ruby
 require "json"
 
-class App
-  def call(env)
-    request = Rack::Request.new(env)
-    case request.request_method
-    when "POST"
-      request_body = request.body.read
-      parsed_body = JSON.parse(request_body)
-      [200, { "content-type" => "text/plain" }, ["Hello #{parsed_body['city']}"]]
-    else
-      [200, { "content-type" => "text/plain" }, ["Hello World!"]]
-    end
+app = lambda do |env|
+  body = if env["REQUEST_METHOD"] == "POST"
+    city = JSON.parse(env["rack.input"].read)['city']
+    ["Hello #{city}"]
+  else
+    ["Hello World!"]
   end
+
+  [200, { "content-type" => "text/plain" }, body]
 end
 
-run App.new
+run app
 ```
 
 Run the application and make a request:
@@ -174,25 +153,23 @@ Hello London
 
 ### Streaming Response Bodies
 
-To stream a response back to the client rather than sending a buffered response, a `Proc` can be returned in place of the response body. The `Proc` is yielded a `stream` to write to.
+In addition to the body being an enumerable of strings, the body can also be a callable object, which is yielded a `stream` to write to:
 
 ```ruby
-class App
-  def call(env)
-    response_stream = proc do |stream|
-      5.times do
-        stream.write "#{Time.now}\n\n"
-        sleep 1
-      end
-    ensure
-      stream.close
+app = lambda do |env|
+  body = proc do |stream|
+    5.times do
+      stream.write "#{Time.now}\n\n"
+      sleep 1
     end
-
-    [200, { "content-type" => "text/plain" }, response_stream]
+  ensure
+    stream.close
   end
+
+  [200, { "content-type" => "text/plain" }, body]
 end
 
-run App.new
+run app
 ```
 
 Run this application and then make a request to it:
@@ -203,13 +180,13 @@ $ curl localhost:9292
 
 You'll see the time is printed out 5 times at 1 second intervals and then the connection is closed. 
 
-Streaming responses allow Rack applications to implement communication over persistent connections such as [HTTP Server Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) and [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API).
+Streaming bodies may make it easier for Rack applications to implement communication over persistent connections such as [HTTP Server Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) and [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API).
 
 ## Rack Middleware
 
-Rack applications are built up of a stack of _middleware_ which may operate upon a request before it reaches the main application, and again after the application has processed the request. Middleware is usually used for tasks like logging, caching, authentication, and measuring performance.
+Rack applications can be wrapped using _middleware_ which may operate upon a request before it reaches the main application, and again after the application has returned a response to the request. Middleware is usually used for tasks like logging, caching, authentication, and measuring performance.
 
-A Rack middleware needs to be `initialize`d with the Rack `app` which is passed down through the middleware stack to the main application, and must implement a `call` method which operates on the request:
+A Rack middleware must have a `new` method that accepts the Rack app and any arguments used to configure the middleware. The `new` method must return a Rack application that responds to `call`. Typically, Rack middleware are classes, and each instance of the middleware wraps access to the related application:
 
 ```ruby
 class MyMiddleware
@@ -233,7 +210,7 @@ class MyMiddleware
 end
 ```
 
-Middleware can short-circuit the stack by skipping `@app.call` completely and returning a reponse by itself. This means the request never hits the main application. A middleware to authenticate a request might use this technique.
+Middleware can short-circuit the stack by skipping `@app.call` completely and returning a reponse by itself. This means the request never hits the main application or the remaining middleware in the stack. A middleware to authenticate a request might use this technique.
 
 ```ruby
 class AuthenticateRequest
@@ -262,19 +239,17 @@ class AuthenticateRequest
   # ...
 end
 
-class App
-  def call(env)
-    [200, { "content-type" => "text/plain" }, ["Hello World"]]
-  end
+app = lambda do |env|
+  [200, { "content-type" => "text/plain" }, ["Hello World"]]
 end
 
 use AuthenticateRequest
-run App.new
+run app
 ```
 
-This DSL to construct Rack applications is provided by `Rack::Builder`. Consult the [RDoc](./Rack/Builder.html) for advanced usage.
+This DSL to construct Rack applications is provided by [`Rack::Builder`](./Rack/Builder.html).
 
-Rack [ships with](index.html#available-middleware-shipped-with-rack) several pieces of middleware for common use-cases.
+[Rack ships with several pieces of middleware for common use-cases](index.html#available-middleware-shipped-with-rack).
 
 ## Conclusion
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -59,12 +59,15 @@ Routing to different paths can be handled by querying the `env` hash:
 
 ```ruby
 rack_app = lambda do |env|
-  case env["PATH_INFO"]
-  when "/admin"
-    [200, { "content-type" => "text/plain" }, ["Hello Admin!"]]
-  else
-    [200, { "content-type" => "text/plain" }, ["Hello World"]]
-  end
+  body = \
+    case env["PATH_INFO"]
+    when "/admin"
+      ["Hello Admin"]
+    else
+      ["Hello World"]
+    end
+
+  [200, { "content-type" => "text/plain" }, body]
 end
 
 run rack_app
@@ -87,13 +90,17 @@ The above examples can be rewritten as:
 ```ruby
 rack_app = lambda do |env|
   request = Rack::Request.new(env)
-  case request.path_info
-  when "/admin"
-    [200, { "content-type" => "text/plain" }, ["Hello Admin!"]]
-  else
-    [200, { "content-type" => "text/plain" }, ["Hello World"]]
-  end
+  body = \
+    case request.path_info
+    when "/admin"
+      ["Hello Admin"]
+    else
+      ["Hello World"]
+    end
+
+  [200, { "content-type" => "text/plain" }, body]
 end
+
 
 run rack_app
 ```

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -58,7 +58,7 @@ Hello World
 Routing to different paths can be handled by querying the `env` hash:
 
 ```ruby
-rack_app = lambda do |env|
+app = lambda do |env|
   body = \
     case env["PATH_INFO"]
     when "/admin"
@@ -70,17 +70,17 @@ rack_app = lambda do |env|
   [200, { "content-type" => "text/plain" }, body]
 end
 
-run rack_app
+run app
 ```
 
 The HTTP verb is also available within the `env`:
 
 ```ruby
-rack_app = lambda do |env|
+app = lambda do |env|
   [200, { "content-type" => "text/plain" }, ["HTTP #{env["REQUEST_METHOD"]}"]]
 end
 
-run rack_app
+run app
 ```
 
 Rack provides [`Rack::Request`](./Rack/Request.html), which implements a convenient interface to a Rack environment.
@@ -88,7 +88,7 @@ Rack provides [`Rack::Request`](./Rack/Request.html), which implements a conveni
 The above examples can be rewritten as:
 
 ```ruby
-rack_app = lambda do |env|
+app = lambda do |env|
   request = Rack::Request.new(env)
   body = \
     case request.path_info
@@ -101,17 +101,16 @@ rack_app = lambda do |env|
   [200, { "content-type" => "text/plain" }, body]
 end
 
-
-run rack_app
+run app
 ```
 
 ```ruby
-rack_app = lambda do |env|
+app = lambda do |env|
   request = Rack::Request.new(env)
   [200, { "content-type" => "text/plain" }, ["HTTP #{request.request_method}"]]
 end
 
-run rack_app
+run app
 ```
 
 ### Reading Request Bodies

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -55,7 +55,7 @@ Hello World
 
 ### Handling Routes and HTTP Verbs
 
-Routing to different paths can be handled by querying the `env` Hash:
+Routing to different paths can be handled by querying the `env` hash:
 
 ```ruby
 rack_app = lambda do |env|

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -147,10 +147,10 @@ run app
 Run the application and make a request:
 
 ```bash
-$ curl -X "POST" "http://localhost:9292/" \
+$ curl  -X "POST" "http://localhost:9292/" \
      	-H 'Content-Type: application/json; charset=utf-8' \
      	-d '{ "city": "London" }'
-Hello London     	
+Hello London
 ```
 
 ### Streaming Response Bodies

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -18,12 +18,20 @@ A class can also be used to define a Rack app:
 
 ```ruby
 class App
-  def call(env)
+  def self.call(env)
+    new(env).route
+  end
+
+  def initialize(env)
+    @env = env
+  end
+
+  def route
     [200, { "content-type" => "text/plain" }, ["Hello World"]]
   end
 end
 
-run App.new
+run App
 ```
 
 When an HTTP request is made, the Rack-compliant web server parses it to create the `env` hash, and calls the application with `env`. The `call` method must return an array with exactly three elements, representing the HTTP response:
@@ -58,7 +66,7 @@ Routing to different paths can be handled by querying the `env` hash:
 
 ```ruby
 app = lambda do |env|
-  body = \
+  body = 
     case env["PATH_INFO"]
     when "/admin"
       ["Hello Admin"]
@@ -89,7 +97,7 @@ The above examples can be rewritten as:
 ```ruby
 app = lambda do |env|
   request = Rack::Request.new(env)
-  body = \
+  body = 
     case request.path_info
     when "/admin"
       ["Hello Admin"]

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -52,7 +52,6 @@ $ curl localhost:9292
 Hello World
 ```
 
-
 ### Handling Routes and HTTP Verbs
 
 Routing to different paths can be handled by querying the `env` hash:
@@ -250,4 +249,4 @@ This DSL to construct Rack applications is provided by [`Rack::Builder`](./Rack/
 
 Since Rack provides a standardized interface between web servers and applications, in general, any Rack-compliant web application can run using any Rack-compliant web server. Rack uses a simple request (`env`) to response (`[status, headers, body]`) design, providing the foundation upon which the majority of Ruby web applications are built. 
 
-As Rack is designed to be low-level, Ruby web applications are typically developed using frameworks that build on top of Rack. Access to the low-level Rack API is usually available within all Rack-compliant frameworks.
+As Rack is designed to be low-level, Ruby web applications are typically developed using frameworks that build on top of Rack. Most frameworks offer access to the low-level Rack API.

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -1,10 +1,10 @@
 # Getting Started With Rack
 
-This guide demonstrates how to create a basic Rack application and run it using a Rack-compliant web server. We'll use [Puma](https://puma.io) in this tutorial — alternative web servers can be found in the [Readme](./index.html#supported-web-servers).
+This guide demonstrates how to create a basic Rack application and run it using a Rack-compliant web server. We'll use [Puma](https://puma.io) in this tutorial — alternative web servers can be found in the [Readme](https://github.com/rack/rack?tab=readme-ov-file#supported-web-servers).
 
 ## Creating a Rack Application
 
-A Rack app is an object which implements a `call` method. It is passed an [`env`](./SPEC_rdoc.html#the-request-environment) hash, known as the Rack environment.
+A Rack app is an object which implements a `call` method. It is passed an [`env`](https://github.com/rack/rack/blob/main/SPEC.rdoc#the-request-environment) hash, known as the Rack environment.
 
 ```ruby
 rack_app = lambda do |env|
@@ -90,7 +90,7 @@ end
 run app
 ```
 
-Rack provides [`Rack::Request`](./Rack/Request.html), which implements a convenient interface to a Rack environment.
+Rack provides `Rack::Request`, which implements a convenient interface to a Rack environment.
 
 The above examples can be rewritten as:
 
@@ -122,7 +122,7 @@ run app
 
 ### Reading Request Bodies
 
-If a body is submitted with the HTTP request, Rack provides access to it as an `IO`-like [input stream](SPEC_rdoc.html#the-input-stream) object, via `env["rack.input"]` or `Rack::Request#body`.
+If a body is submitted with the HTTP request, Rack provides access to it as an `IO`-like [input stream](https://github.com/rack/rack/blob/main/SPEC.rdoc#the-input-stream) object, via `env["rack.input"]` or `Rack::Request#body`.
 
 The below application demonstrates how a `POST` request with a JSON body could be handled:
 
@@ -249,9 +249,9 @@ use AuthenticateRequest
 run app
 ```
 
-This DSL to construct Rack applications is provided by [`Rack::Builder`](./Rack/Builder.html).
+This DSL to construct Rack applications is provided by `Rack::Builder`.
 
-[Rack ships with several pieces of middleware for common use-cases](index.html#available-middleware-shipped-with-rack).
+[Rack ships with several pieces of middleware for common use-cases](https://github.com/rack/rack?tab=readme-ov-file#available-middleware-shipped-with-rack).
 
 ## Conclusion
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -121,7 +121,7 @@ run App.new
 
 ### Reading Request Bodies
 
-HTTP requests using verbs other than `GET` or `HEAD` may contain a body. Rack provides access to this via `env["rack.input"]` or `Rack::Request#body`. An `IO`-like [input stream](SPEC_rdoc.html#the-input-stream) object will be returned.
+If a body is submitted with the HTTP request, Rack provides access to it as an `IO`-like [input stream](SPEC_rdoc.html#the-input-stream) object, via `env["rack.input"]` or `Rack::Request#body`.
 
 The below application demonstrates how a `POST` request with a JSON body could be handled:
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -125,7 +125,7 @@ require "json"
 
 app = lambda do |env|
   body = if env["REQUEST_METHOD"] == "POST"
-  	 raw_body = env["rack.input"].read
+  	raw_body = env["rack.input"].read
     city = JSON.parse(raw_body)['city']
     ["Hello #{city}"]
   else

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started With Rack
 
-This guide demonstrates how to create a basic Rack application and run it using a Rack-compliant web server. We'll use [Puma](https://puma.io) in this tutorial — alternative web servers can be found in the [Readme](https://github.com/rack/rack?tab=readme-ov-file#supported-web-servers).
+This guide demonstrates how to create a basic Rack application and run it using a Rack-compliant web server. We'll use [Puma](https://puma.io) in this tutorial (alternative web servers can be found in the [Readme](https://github.com/rack/rack?tab=readme-ov-file#supported-web-servers)).
 
 ## Creating a Rack Application
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started With Rack
 
-This guide demonstrates how to create a basic Rack application and run it using a Rack-compliant web server. We'll use [Puma](https://puma.io) as the web server in this tutorial. Alternatives can be found in the [Readme](./index.html#supported-web-servers).
+This guide demonstrates how to create a basic Rack application and run it using a Rack-compliant web server. We'll use [Puma](https://puma.io) in this tutorial — alternative web servers can be found in the [Readme](./index.html#supported-web-servers).
 
 ## Creating a Rack Application
 
@@ -12,6 +12,18 @@ rack_app = lambda do |env|
 end
 
 run rack_app
+```
+
+A class can also be used to define a Rack app:
+
+```ruby
+class App
+  def call(env)
+    [200, { "content-type" => "text/plain" }, ["Hello World"]]
+  end
+end
+
+run App.new
 ```
 
 When an HTTP request is made, the Rack-compliant web server parses it to create the `env` hash, and calls the application with `env`. The `call` method must return an array with exactly three elements, representing the HTTP response:
@@ -46,39 +58,26 @@ Hello World
 Routing to different paths can be handled by querying the `env` Hash:
 
 ```ruby
-class App
-  def call(env)
-    path = env["PATH_INFO"]
-    case path
-    when "/admin"
-      [200, { "content-type" => "text/plain" }, ["Hello Admin!"]]
-    else
-      [200, { "content-type" => "text/plain" }, ["Hello World"]]
-    end
+rack_app = lambda do |env|
+  case env["PATH_INFO"]
+  when "/admin"
+    [200, { "content-type" => "text/plain" }, ["Hello Admin!"]]
+  else
+    [200, { "content-type" => "text/plain" }, ["Hello World"]]
   end
 end
 
-run App.new
+run rack_app
 ```
 
 The HTTP verb is also available within the `env`:
 
 ```ruby
-class App
-  def call(env)
-    request_method = env["REQUEST_METHOD"]
-    case request_method
-    when "POST"
-      [200, { "content-type" => "text/plain" }, ["Responding to a POST"]]
-    when "GET"
-      [200, { "content-type" => "text/plain" }, ["Responding to a GET"]]      
-    else
-      [200, { "content-type" => "text/plain" }, ["Responding to all other verbs"]]
-    end
-  end
+rack_app = lambda do |env|
+  [200, { "content-type" => "text/plain" }, ["HTTP #{env["REQUEST_METHOD"]}"]]
 end
 
-run App.new
+run rack_app
 ```
 
 Rack provides [`Rack::Request`](./Rack/Request.html), which implements a convenient interface to a Rack environment.
@@ -86,37 +85,26 @@ Rack provides [`Rack::Request`](./Rack/Request.html), which implements a conveni
 The above examples can be rewritten as:
 
 ```ruby
-class App
-  def call(env)
-    request = Rack::Request.new(env)
-    case request.path_info
-    when "/admin"
-      [200, { "content-type" => "text/plain" }, ["Hello Admin!"]]
-    else
-      [200, { "content-type" => "text/plain" }, ["Hello World"]]
-    end
+rack_app = lambda do |env|
+  request = Rack::Request.new(env)
+  case request.path_info
+  when "/admin"
+    [200, { "content-type" => "text/plain" }, ["Hello Admin!"]]
+  else
+    [200, { "content-type" => "text/plain" }, ["Hello World"]]
   end
 end
 
-run App.new
+run rack_app
 ```
 
 ```ruby
-class App
-  def call(env)
-    request = Rack::Request.new(env)
-    case request.request_method
-    when "POST"
-      [200, { "content-type" => "text/plain" }, ["Responding to a POST"]]
-    when "GET"
-      [200, { "content-type" => "text/plain" }, ["Responding to a GET"]]      
-    else
-      [200, { "content-type" => "text/plain" }, ["Responding to all other verbs"]]
-    end
-  end
+rack_app = lambda do |env|
+  request = Rack::Request.new(env)
+  [200, { "content-type" => "text/plain" }, ["HTTP #{request.request_method}"]]
 end
 
-run App.new
+run rack_app
 ```
 
 ### Reading Request Bodies
@@ -130,7 +118,8 @@ require "json"
 
 app = lambda do |env|
   body = if env["REQUEST_METHOD"] == "POST"
-    city = JSON.parse(env["rack.input"].read)['city']
+  	 raw_body = env["rack.input"].read
+    city = JSON.parse(raw_body)['city']
     ["Hello #{city}"]
   else
     ["Hello World!"]
@@ -253,5 +242,6 @@ This DSL to construct Rack applications is provided by [`Rack::Builder`](./Rack/
 
 ## Conclusion
 
-Since Rack provides a standardized interface between web servers and applications, all Rack-compliant web applications allow access to the underlying Rack objects such as the environment and the response. Refer to your chosen framework's documentation for the exact syntax. 
+Since Rack provides a standardized interface between web servers and applications, in general, any Rack-compliant web application can run using any Rack-compliant web server. Rack uses a simple request (`env`) to response (`[status, headers, body]`) design, providing the foundation upon which the majority of Ruby web applications are built. 
 
+As Rack is designed to be low-level, Ruby web applications are typically developed using frameworks that build on top of Rack. Access to the low-level Rack API is usually available within all Rack-compliant frameworks.

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -1,0 +1,282 @@
+# Getting Started With Rack
+
+This guide demonstrates how to create a basic Rack application and run it using a Rack-compliant web server. We'll use [Puma](https://puma.io) as the web server in this tutorial. Alternatives can be found in the [Readme](./index.html#supported-web-servers).
+
+## Creating a Rack Application
+
+A Rack app is a class which implements a `call` method. It is passed an [`env`](./SPEC_rdoc.html#the-request-environment) hash, known as the Rack environment, which is created by parsing the incoming HTTP request.
+
+```ruby
+class App
+  def call(env)
+    [200, { "content-type" => "text/plain" }, ["Hello World"]]
+  end
+end
+
+run App.new
+```
+
+When an HTTP request is made, the Rack-compliant web server parses it to create the `env` hash, and forwards it to the application's `call` method. This method must return an array representing the HTTP response.
+
+The first element is the HTTP response code, in this case `200`. The second element is a hash containing any Rack and HTTP response headers we wish to send. And the last element is an array of strings representing the response body.
+
+You can run this app by organizing it into a folder:
+
+```bash
+$ mkdir rack-demo
+$ cd rack-demo
+$ bundle init
+$ bundle add rack puma
+$ cat > config.ru << APP
+class App
+  def call(env)
+    [200, { "content-type" => "text/plain" }, ["Hello World"]]
+  end
+end
+
+run App.new
+APP
+```
+
+`config.ru` is the conventional entrypoint for Rack applications. Start Puma to run the app:
+
+```bash
+$ bundle exec puma
+```
+
+Your app should be available at <http://localhost:9292>. 
+
+```bash
+$ curl localhost:9292
+Hello World
+```
+
+You can use a different entrypoint if you wish — as long as the file extension is `.ru`.
+
+```bash
+$ bundle exec puma server.ru
+```
+
+The syntax to manually specify the entrypoint might differ for other servers — consult the documentation.
+
+### Handling Routes and HTTP Verbs
+
+Routing to different paths can be handled by querying the `env` Hash:
+
+```ruby
+class App
+  def call(env)
+    path = env["PATH_INFO"]
+    case path
+    when "/admin"
+      [200, { "content-type" => "text/plain" }, ["Hello Admin!"]]
+    else
+      [200, { "content-type" => "text/plain" }, ["Hello World"]]
+    end
+  end
+end
+
+run App.new
+```
+
+The HTTP verb is also available within the `env`:
+
+```ruby
+class App
+  def call(env)
+    request_method = env["REQUEST_METHOD"]
+    case request_method
+    when "POST"
+      [200, { "content-type" => "text/plain" }, ["Responding to a POST"]]
+    when "GET"
+      [200, { "content-type" => "text/plain" }, ["Responding to a GET"]]      
+    else
+      [200, { "content-type" => "text/plain" }, ["Responding to all other verbs"]]
+    end
+  end
+end
+
+run App.new
+```
+
+Rack provides a [`Rack::Request`](./Rack/Request.html) utility class which implements a convenient interface to the Rack environment. It is stateless, meaning the `env` passed to the constructor will be directly accessed and modified.
+
+The above examples can be rewritten as:
+
+```ruby
+class App
+  def call(env)
+    request = Rack::Request.new(env)
+    case request.path_info
+    when "/admin"
+      [200, { "content-type" => "text/plain" }, ["Hello Admin!"]]
+    else
+      [200, { "content-type" => "text/plain" }, ["Hello World"]]
+    end
+  end
+end
+
+run App.new
+```
+
+```ruby
+class App
+  def call(env)
+    request = Rack::Request.new(env)
+    case request.request_method
+    when "POST"
+      [200, { "content-type" => "text/plain" }, ["Responding to a POST"]]
+    when "GET"
+      [200, { "content-type" => "text/plain" }, ["Responding to a GET"]]      
+    else
+      [200, { "content-type" => "text/plain" }, ["Responding to all other verbs"]]
+    end
+  end
+end
+
+run App.new
+```
+
+### Reading Request Bodies
+
+HTTP requests using verbs other than `GET` or `HEAD` may contain a body. Rack provides access to this via `env["rack.input"]` or `Rack::Request#body`. An `IO`-like [input stream](SPEC_rdoc.html#the-input-stream) object will be returned.
+
+The below application demonstrates how a `POST` request with a JSON body could be handled:
+
+```ruby
+require "json"
+
+class App
+  def call(env)
+    request = Rack::Request.new(env)
+    case request.request_method
+    when "POST"
+      request_body = request.body.read
+      parsed_body = JSON.parse(request_body)
+      [200, { "content-type" => "text/plain" }, ["Hello #{parsed_body['city']}"]]
+    else
+      [200, { "content-type" => "text/plain" }, ["Hello World!"]]
+    end
+  end
+end
+
+run App.new
+```
+
+Run the application and make a request:
+
+```bash
+$ curl -X "POST" "http://localhost:9292/" \
+     	-H 'Content-Type: application/json; charset=utf-8' \
+     	-d '{ "city": "London" }'
+Hello London     	
+```
+
+### Streaming Response Bodies
+
+To stream a response back to the client rather than sending a buffered response, a `Proc` can be returned in place of the response body. The `Proc` is yielded a `stream` to write to.
+
+```ruby
+class App
+  def call(env)
+    response_stream = proc do |stream|
+      5.times do
+        stream.write "#{Time.now}\n\n"
+        sleep 1
+      end
+    ensure
+      stream.close
+    end
+
+    [200, { "content-type" => "text/plain" }, response_stream]
+  end
+end
+
+run App.new
+```
+
+Run this application and then make a request to it:
+
+```bash
+$ curl localhost:9292
+```
+
+You'll see the time is printed out 5 times at 1 second intervals and then the connection is closed. 
+
+Streaming responses allow Rack applications to implement communication over persistent connections such as [HTTP Server Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) and [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API).
+
+## Rack Middleware
+
+Rack applications are built up of a stack of _middleware_ which may operate upon a request before it reaches the main application, and again after the application has processed the request. Middleware is usually used for tasks like logging, caching, authentication, and measuring performance.
+
+A Rack middleware needs to be `initialize`d with the Rack `app` which is passed down through the middleware stack to the main application, and must implement a `call` method which operates on the request:
+
+```ruby
+class MyMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    # Operations before the request hits the main application
+    # -------------------------------------------------------
+
+    # Propgate the request down the middleware stack
+    status, headers, body = @app.call(env)
+
+    # ---------------------------------------
+    # Operations after the request comes back
+
+    # Propogate the response up the middleware stack
+    [status, headers, body]
+  end
+end
+```
+
+Middleware can short-circuit the stack by skipping `@app.call` completely and returning a reponse by itself. This means the request never hits the main application. A middleware to authenticate a request might use this technique.
+
+```ruby
+class AuthenticateRequest
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if authenticated?(env["HTTP_AUTHORIZATION"])
+      @app.call(env)
+    else
+      [401, { "content-type" => "text/plain" }, ["Authentication failed"]]
+    end
+  end
+
+  def authenticated?(token)
+    # ...
+  end
+end
+```
+
+Middleware is added to a Rack app with `use`:
+
+```ruby
+class AuthenticateRequest
+  # ...
+end
+
+class App
+  def call(env)
+    [200, { "content-type" => "text/plain" }, ["Hello World"]]
+  end
+end
+
+use AuthenticateRequest
+run App.new
+```
+
+This DSL to construct Rack applications is provided by `Rack::Builder`. Consult the [RDoc](./Rack/Builder.html) for advanced usage.
+
+Rack [ships with](index.html#available-middleware-shipped-with-rack) several pieces of middleware for common use-cases.
+
+## Conclusion
+
+Since Rack provides a standardized interface between web servers and applications, all Rack-compliant web applications allow access to the underlying Rack objects such as the environment and the response. Refer to your chosen framework's documentation for the exact syntax. 
+


### PR DESCRIPTION
An initial stab at writing a "Getting started with Rack" guide.

It covers the topics:

* Creating a basic rack app and running it
* Handing routes and HTTP verbs
* Reading request bodies
* Streaming response bodies
* Creating and adding middleware

The list of topics differs a bit from the issue ticket. As I was writing the guide, I felt this structure suited the narrative better. I excluded details about `Rack::Builder` because I don't think I could improve on what's already there in the RDoc. As such I've just linked to the RDoc page.

I haven't mentioned any frameworks, but I did have to write the guide using a specific server, so I chose Puma as I believe it is the most widely used Rack server. I've signposted alternatives to try and be as agnostic as possible.

This is just an initial draft so obviously open to any and all feedback and I will make any requested changes!

Closes https://github.com/rack/rack/issues/2437