### PR TITLE
Clarify timing of patch releases and advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,6 @@ If you believe you have found a security issue in this project, please do not op
 1. Security report is received and reviewed by the Rack maintainers.
 2. The problem is confirmed and a list of all affected versions is determined. Code is audited to find any potential similar problems.
 3. Fixes are prepared for all releases which are still supported.
-4. Patches are released, new gem versions are published to RubyGems, and security advisories are published.
+4. Patches are released, new gem versions are published to RubyGems, and security advisories are published simultaneously.
 
 In cases where coordination with other projects or distributions is necessary, we may implement an embargo period before public disclosure. However, for most security issues, we aim to release fixes and advisories as quickly as possible.


### PR DESCRIPTION
This aligns the rack security policy with other modern security policies, including Ruby's, Rails', and RubyGems', and the model security guidelines from the [Open Source Security Foundation](https://github.com/ossf/oss-vulnerability-guide/blob/main/maintainer-guide.md#publish-your-vulnerability-management-process:~:text=9%20Cut%20a%20release%20and%20publicly%20disclose%20the%20issue)

https://guides.rubygems.org/security/#reporting-security-vulnerabilities:~:text=Reporting%20a%20security%20vulnerability%20with%20your%20own%20gem

Thank you for your hard work in handling Rack's security vulnerabilities and reports! Unlike the Feb 19th release, my team was not notified of any issues with Rack through our normal process, we had to rely on word of mouth from someone who happened to be in the invite-only Slack channel[1] where the release was announced. I suspect very few other people using Rack are in this slack channel (the security announcement only had 6 users reacting to it).

Due to these vulnerabilities not being published publicly, advisory databases that defenders rely on to notify them of security issues, like https://github.com/rubysec/ruby-advisory-db, https://security.snyk.io/package/rubygems/rack and https://github.com/dependabot were not able to pick up this security advisory and notify team members. We got lucky by having an employee active in the development community for Bundler, but most teams do not have that luxury.

[1] At least, I was not able to find a public invite for it anywhere. It seems like the invite for the community has been removed from the Bundler website as of February 