### PR TITLE
fix: Use Minitest must_raise correctly and handle error message

### DIFF
--- a/test/spec_utils.rb
+++ b/test/spec_utils.rb
@@ -655,9 +655,10 @@ describe Rack::Utils, "cookies" do
   end
 
   it "raises an error if the cookie key is invalid" do
-    lambda do
+    ex = lambda do
       Rack::Utils.set_cookie_header('na e', 'value')
-    end.must_raise(ArgumentError, /invalid cookie key/)
+    end.must_raise(ArgumentError)
+    assert_match(/invalid cookie key/, ex.message)
   end
 
   it "sets partitioned cookie attribute" do


### PR DESCRIPTION
`must_raise` is sort of the alias for `assert_raises`, and actually https://github.com/minitest/minitest/blob/v6.0.5/lib/minitest/assertions.rb#L390 says that `assert_raises` can take an optional "message" (i.e. string) to help explain failures, so not regex or so to test if assertion message matches it.

Up to Minitest 6.0.4, when passing regex for `assert_raises` it was simply ignored, ref:

https://github.com/minitest/minitest/issues/1068
https://bugs.ruby-lang.org/issues/22007

Now Minitest 6.0.5 explicitly refuses this usage as: https://github.com/minitest/minitest/commit/6790f86f894637768a1f64cfe50959d2029b65ed and now `must_raise` also refuses this usage.

Closes #2451 .