### PR TITLE
Have Rack::Directory check paths without ..

### DIFF
--- a/lib/rack/directory.rb
+++ b/lib/rack/directory.rb
@@ -123,8 +123,6 @@ table { width:100%%; }
 
     # Rack response to use for requests with paths outside the root, or nil if path is inside the root.
     def check_forbidden(path_info)
-      return unless path_info.include? ".."
-
       expanded_path = ::File.expand_path(::File.join(@root, path_info))
       return if expanded_path == @root || expanded_path.start_with?(@root_with_separator)
 


### PR DESCRIPTION
While I cannot think of a way to escape out of the root directory without .. in the path, the validation check is cheap compared to the file serving or building the directory index, so as a defense in depth measure, it seems reasonable to always check.

Fixes #2436