### PR TITLE
Start supporting rack.request.config env key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add support for streaming bodies when using `Rack::Events`. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
 - Add `deflaters` option to `Rack::Deflater` to enable custom compression algorithms like zstd. ([#2168](https://github.com/rack/rack/issues/2168), [@alexanderadam](https://github.com/alexanderadam))
 - Add `Rack::Request#prefetch?` for identifying requests with `Sec-Purpose: prefetch` header set. ([#2405](https://github.com/rack/rack/pull/2405), [@glaszig](https://github.com/glaszig))
-- Add `rack.request.trusted_proxy` environment key to indicate whether the request is coming from a trusted proxy.
+- Add `rack.request.config` environment key to configure Rack::Request behavior.
 - Add `Rack::Request#headers` for simpler access to request headers by header name. ([#1881](https://github.com/rack/rack/pull/1881), [@jeremyevans](https://github.com/jeremyevans))
 
 ### Changed

--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -56,6 +56,7 @@ module Rack
   RACK_MULTIPART_TEMPFILE_FACTORY     = 'rack.multipart.tempfile_factory'
   RACK_RESPONSE_FINISHED              = 'rack.response_finished'
   RACK_PROTOCOL                       = 'rack.protocol'
+  RACK_REQUEST_CONFIG                 = 'rack.request.config'
   RACK_REQUEST_FORM_INPUT             = 'rack.request.form_input'
   RACK_REQUEST_FORM_HASH              = 'rack.request.form_hash'
   RACK_REQUEST_FORM_PAIRS             = 'rack.request.form_pairs'
@@ -65,6 +66,5 @@ module Rack
   RACK_REQUEST_COOKIE_STRING          = 'rack.request.cookie_string'
   RACK_REQUEST_QUERY_HASH             = 'rack.request.query_hash'
   RACK_REQUEST_QUERY_STRING           = 'rack.request.query_string'
-  RACK_REQUEST_TRUSTED_PROXY          = 'rack.request.trusted_proxy'
   RACK_METHODOVERRIDE_ORIGINAL_METHOD = 'rack.methodoverride.original_method'
 end

--- a/lib/rack/constants.rb
+++ b/lib/rack/constants.rb
@@ -55,6 +55,7 @@ module Rack
   RACK_MULTIPART_TEMPFILE_FACTORY     = 'rack.multipart.tempfile_factory'
   RACK_RESPONSE_FINISHED              = 'rack.response_finished'
   RACK_PROTOCOL                       = 'rack.protocol'
+  RACK_REQUEST_CONFIG                 = 'rack.request.config'
   RACK_REQUEST_FORM_INPUT             = 'rack.request.form_input'
   RACK_REQUEST_FORM_HASH              = 'rack.request.form_hash'
   RACK_REQUEST_FORM_PAIRS             = 'rack.request.form_pairs'
@@ -64,6 +65,5 @@ module Rack
   RACK_REQUEST_COOKIE_STRING          = 'rack.request.cookie_string'
   RACK_REQUEST_QUERY_HASH             = 'rack.request.query_hash'
   RACK_REQUEST_QUERY_STRING           = 'rack.request.query_string'
-  RACK_REQUEST_TRUSTED_PROXY          = 'rack.request.trusted_proxy'
   RACK_METHODOVERRIDE_ORIGINAL_METHOD = 'rack.methodoverride.original_method'
 end

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -706,7 +706,7 @@ module Rack
       #
       # @returns [Boolean] true if the given IP is a trusted proxy, false otherwise.
       def trusted_proxy?(ip)
-        trusted_proxy = env.dig(RACK_REQUEST_CONFIG, :trusted_proxy)
+        trusted_proxy = config_value(:trusted_proxy)
 
         case trusted_proxy
         when nil
@@ -721,6 +721,10 @@ module Rack
       end
 
       private
+
+      def config_value(key)
+        env.dig(RACK_REQUEST_CONFIG, key)
+      end
 
       def default_session; {}; end
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -881,11 +881,11 @@ module Rack
       end
 
       def forwarded_priority
-        Request.forwarded_priority
+        config_value(:forwarded_priority) || Request.forwarded_priority
       end
 
       def x_forwarded_proto_priority
-        Request.x_forwarded_proto_priority
+        config_value(:x_forwarded_proto_priority) || Request.x_forwarded_proto_priority
       end
     end
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -771,7 +771,7 @@ module Rack
       end
 
       def query_parser
-        @query_parser || Utils.default_query_parser
+        @query_parser || config_value(:query_parser) || Utils.default_query_parser
       end
 
       def parse_query(qs, d = '&')

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -706,7 +706,7 @@ module Rack
       #
       # @returns [Boolean] true if the given IP is a trusted proxy, false otherwise.
       def trusted_proxy?(ip)
-        trusted_proxy = get_header(RACK_REQUEST_TRUSTED_PROXY)
+        trusted_proxy = env.dig(RACK_REQUEST_CONFIG, :trusted_proxy)
 
         case trusted_proxy
         when nil

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -710,7 +710,7 @@ module Rack
       #
       # @returns [Boolean] true if the given IP is a trusted proxy, false otherwise.
       def trusted_proxy?(ip)
-        trusted_proxy = get_header(RACK_REQUEST_TRUSTED_PROXY)
+        trusted_proxy = env.dig(RACK_REQUEST_CONFIG, :trusted_proxy)
 
         case trusted_proxy
         when nil

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -885,11 +885,11 @@ module Rack
       end
 
       def forwarded_priority
-        Request.forwarded_priority
+        config_value(:forwarded_priority) || Request.forwarded_priority
       end
 
       def x_forwarded_proto_priority
-        Request.x_forwarded_proto_priority
+        config_value(:x_forwarded_proto_priority) || Request.x_forwarded_proto_priority
       end
     end
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -710,7 +710,7 @@ module Rack
       #
       # @returns [Boolean] true if the given IP is a trusted proxy, false otherwise.
       def trusted_proxy?(ip)
-        trusted_proxy = env.dig(RACK_REQUEST_CONFIG, :trusted_proxy)
+        trusted_proxy = config_value(:trusted_proxy)
 
         case trusted_proxy
         when nil
@@ -725,6 +725,10 @@ module Rack
       end
 
       private
+
+      def config_value(key)
+        env.dig(RACK_REQUEST_CONFIG, key)
+      end
 
       def default_session; {}; end
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -775,7 +775,7 @@ module Rack
       end
 
       def query_parser
-        @query_parser || Utils.default_query_parser
+        @query_parser || config_value(:query_parser) || Utils.default_query_parser
       end
 
       def parse_query(qs, d = '&')

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -2191,7 +2191,7 @@ EOF
   it "uses rack.request.trusted_proxy env key when set to nil (default behavior)" do
     # When nil, should fall back to ip_filter
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = nil
+    env[Rack::RACK_REQUEST_CONFIG] = {trusted_proxy: nil}
     req = make_request(env)
     
     req.trusted_proxy?('127.0.0.1').must_equal true
@@ -2202,7 +2202,7 @@ EOF
 
   it "trusts all proxies when rack.request.trusted_proxy is true" do
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = true
+    env[Rack::RACK_REQUEST_CONFIG] = {trusted_proxy: true}
     req = make_request(env)
     
     req.trusted_proxy?('127.0.0.1').must_equal true
@@ -2213,7 +2213,7 @@ EOF
 
   it "trusts no proxies when rack.request.trusted_proxy is false" do
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = false
+    env[Rack::RACK_REQUEST_CONFIG] = {trusted_proxy: false}
     req = make_request(env)
     
     req.trusted_proxy?('127.0.0.1').must_equal false
@@ -2224,7 +2224,7 @@ EOF
 
   it "trusts only specified IPs when rack.request.trusted_proxy is a callable" do
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip| ['10.0.0.1', '192.168.1.100'].include?(ip) }
+    env[Rack::RACK_REQUEST_CONFIG] = {trusted_proxy: lambda { |ip| ['10.0.0.1', '192.168.1.100'].include?(ip) }}
     req = make_request(env)
     
     req.trusted_proxy?('10.0.0.1').must_equal true
@@ -2238,13 +2238,15 @@ EOF
     require 'ipaddr'
     env = Rack::MockRequest.env_for("/")
     ranges = [IPAddr.new('10.0.0.0/24'), IPAddr.new('192.168.1.0/28')]
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip|
-      begin
-        ip_addr = IPAddr.new(ip)
-        ranges.any? { |range| range.include?(ip_addr) }
-      rescue IPAddr::InvalidAddressError
-        false
-      end
+    env[Rack::RACK_REQUEST_CONFIG] = {
+      trusted_proxy: lambda { |ip|
+        begin
+          ip_addr = IPAddr.new(ip)
+          ranges.any? { |range| range.include?(ip_addr) }
+        rescue IPAddr::InvalidAddressError
+          false
+        end
+      }
     }
     req = make_request(env)
     
@@ -2265,13 +2267,15 @@ EOF
     env = Rack::MockRequest.env_for("/")
     ipv6_exact = IPAddr.new('2001:db8::1')
     ipv6_range = IPAddr.new('fd00::/8')
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip|
-      begin
-        ip_addr = IPAddr.new(ip)
-        ip_addr == ipv6_exact || ipv6_range.include?(ip_addr)
-      rescue IPAddr::InvalidAddressError
-        false
-      end
+    env[Rack::RACK_REQUEST_CONFIG] = {
+      trusted_proxy: lambda { |ip|
+        begin
+          ip_addr = IPAddr.new(ip)
+          ip_addr == ipv6_exact || ipv6_range.include?(ip_addr)
+        rescue IPAddr::InvalidAddressError
+          false
+        end
+      }
     }
     req = make_request(env)
     
@@ -2284,8 +2288,8 @@ EOF
 
   it "handles custom logic in rack.request.trusted_proxy callable" do
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip|
-      ip == '10.0.0.1' || ip == 'invalid-ip'
+    env[Rack::RACK_REQUEST_CONFIG] = {
+      trusted_proxy: lambda { |ip| ip == '10.0.0.1' || ip == 'invalid-ip' }
     }
     req = make_request(env)
     
@@ -2294,10 +2298,10 @@ EOF
     req.trusted_proxy?('192.168.1.1').must_equal false
   end
 
-  it "can use Rack::Config to set rack.request.trusted_proxy" do
+  it "can use Rack::Config to set rack.request.config" do
     app = lambda { |env| [200, {}, [Rack::Request.new(env).trusted_proxy?('8.8.8.8').to_s]] }
     config_app = Rack::Config.new(app) do |env|
-      env[Rack::RACK_REQUEST_TRUSTED_PROXY] = true
+      env[Rack::RACK_REQUEST_CONFIG] = { trusted_proxy: true }
     end
     
     mock = Rack::MockRequest.new(config_app)

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -666,7 +666,7 @@ class RackRequestTest < Minitest::Spec
     req.params.must_equal req.GET.merge(req.POST)
   end
 
-  it "should use the query_parser for query parsing" do
+  it "should use the query_parser set via attr_writer for query parsing" do
     c = Class.new(Rack::QueryParser::Params) do
       def initialize(*)
         super(){|h, k| h[k.to_s] if k.is_a?(Symbol)}
@@ -674,6 +674,20 @@ class RackRequestTest < Minitest::Spec
     end
     req = Rack::Request.new(Rack::MockRequest.env_for("/?foo=bar&quux=bla"))
     req.query_parser = Rack::QueryParser.new(c, 100)
+    req.GET[:foo].must_equal "bar"
+    req.GET[:quux].must_equal "bla"
+    req.params[:foo].must_equal "bar"
+    req.params[:quux].must_equal "bla"
+  end
+
+  it "should use the query_parser from environment for query parsing" do
+    c = Class.new(Rack::QueryParser::Params) do
+      def initialize(*)
+        super(){|h, k| h[k.to_s] if k.is_a?(Symbol)}
+      end
+    end
+    req = Rack::Request.new(Rack::MockRequest.env_for("/?foo=bar&quux=bla"))
+    req.env[Rack::RACK_REQUEST_CONFIG] = {query_parser: Rack::QueryParser.new(c, 100)}
     req.GET[:foo].must_equal "bar"
     req.GET[:quux].must_equal "bla"
     req.params[:foo].must_equal "bar"

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -390,202 +390,225 @@ class RackRequestTest < Minitest::Spec
     req.port.must_equal 443
   end
 
-  it "have forwarded_* methods respect forwarded_priority" do
-    begin
-      default_priority = Rack::Request.forwarded_priority
-      default_proto_priority = Rack::Request.x_forwarded_proto_priority
+  [true, false].each do |global|
+    it "have forwarded_* methods respect forwarded_priority set #{global ? "globally" : "via rack.request.config"}" do
+      begin
+        default_priority = Rack::Request.forwarded_priority
+        default_proto_priority = Rack::Request.x_forwarded_proto_priority
 
-      def self.req(headers)
-        req = make_request Rack::MockRequest.env_for("/", headers)
-        req.singleton_class.send(:public, :forwarded_scheme)
-        req
+        define_singleton_method(:req) do |headers|
+          env = Rack::MockRequest.env_for("/", headers)
+          unless global
+            config = env[Rack::RACK_REQUEST_CONFIG] = {
+              forwarded_priority: @forwarded_priority,
+              x_forwarded_proto_priority: @x_forwarded_proto_priority
+            }
+          end
+          req = make_request env
+          req.singleton_class.send(:public, :forwarded_scheme)
+          req
+        end
+
+        define_singleton_method(:set_forwarded_priority) do |val|
+          if global
+            Rack::Request.forwarded_priority = val
+          else
+            @forwarded_priority = val
+          end
+        end
+
+        define_singleton_method(:set_x_forwarded_proto_priority) do |val|
+          if global
+            Rack::Request.x_forwarded_proto_priority = val
+          else
+            @x_forwarded_proto_priority = val
+          end
+        end
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4:1234",
+          "HTTP_X_FORWARDED_PORT" => "2345").
+          forwarded_port.must_equal [1234]
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_PORT" => "2345").
+          forwarded_port.must_equal []
+
+        req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
+          "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
+          forwarded_authority.must_equal '3.4.5.6'
+
+        req("HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "ws"
+
+        r = req("HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http",
+          "HTTP_X_FORWARDED_SSL" => "on")
+        r.forwarded_scheme.must_equal "https"
+        r.ssl?.must_equal true
+
+        req("HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "http"
+
+        set_forwarded_priority([nil, :x_forwarded, :forwarded])
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
+          forwarded_for.must_equal ['2.3.4.5']
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_PORT" => "2345").
+          forwarded_port.must_equal [2345]
+
+        req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
+          "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
+          forwarded_authority.must_equal '4.5.6.7'
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "ws"
+
+        r = req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http",
+          "HTTP_X_FORWARDED_SSL" => "on")
+        r.forwarded_scheme.must_equal "https"
+        r.ssl?.must_equal true
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "http"
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_equal "https"
+
+        set_x_forwarded_proto_priority([nil, :scheme, :proto, :ssl])
+
+        r = req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http")
+        r.forwarded_scheme.must_equal "http"
+        r.ssl?.must_equal false
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws").
+          forwarded_scheme.must_equal "ws"
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_equal "https"
+
+        set_forwarded_priority([:x_forwarded])
+
+        r = req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http")
+        r.forwarded_scheme.must_equal "http"
+        r.ssl?.must_equal false
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws").
+          forwarded_scheme.must_equal "ws"
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+        set_x_forwarded_proto_priority([:scheme])
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "http"
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+        set_x_forwarded_proto_priority([:proto])
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "ws"
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+        set_x_forwarded_proto_priority([])
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+        set_x_forwarded_proto_priority(default_proto_priority)
+        set_forwarded_priority([:forwarded])
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal 'https'
+
+        req("HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_X_FORWARDED_PROTO" => "ws").
+          forwarded_scheme.must_be_nil
+
+        set_forwarded_priority([])
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
+          forwarded_for.must_be_nil
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_PORT" => "2345").
+          forwarded_port.must_be_nil
+
+        req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
+          "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
+          forwarded_authority.must_be_nil
+
+        r = req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http")
+        r.forwarded_scheme.must_be_nil
+        r.ssl?.must_equal false
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+      ensure
+        if global
+          Rack::Request.forwarded_priority = default_priority
+          Rack::Request.x_forwarded_proto_priority = default_proto_priority
+        end
       end
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
-        forwarded_for.must_equal ['1.2.3.4']
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4:1234",
-        "HTTP_X_FORWARDED_PORT" => "2345").
-        forwarded_port.must_equal [1234]
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_PORT" => "2345").
-        forwarded_port.must_equal []
-
-      req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
-        "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
-        forwarded_authority.must_equal '3.4.5.6'
-
-      req("HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "ws"
-
-      r = req("HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http",
-        "HTTP_X_FORWARDED_SSL" => "on")
-      r.forwarded_scheme.must_equal "https"
-      r.ssl?.must_equal true
-
-      req("HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "http"
-
-      Rack::Request.forwarded_priority = [nil, :x_forwarded, :forwarded]
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
-        forwarded_for.must_equal ['2.3.4.5']
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_PORT" => "2345").
-        forwarded_port.must_equal [2345]
-
-      req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
-        "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
-        forwarded_authority.must_equal '4.5.6.7'
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "ws"
-
-      r = req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http",
-        "HTTP_X_FORWARDED_SSL" => "on")
-      r.forwarded_scheme.must_equal "https"
-      r.ssl?.must_equal true
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "http"
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_equal "https"
-
-      Rack::Request.x_forwarded_proto_priority = [nil, :scheme, :proto, :ssl]
-
-      r = req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http")
-      r.forwarded_scheme.must_equal "http"
-      r.ssl?.must_equal false
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws").
-        forwarded_scheme.must_equal "ws"
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_equal "https"
-
-      Rack::Request.forwarded_priority = [:x_forwarded]
-
-      r = req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http")
-      r.forwarded_scheme.must_equal "http"
-      r.ssl?.must_equal false
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws").
-        forwarded_scheme.must_equal "ws"
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.x_forwarded_proto_priority = [:scheme]
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "http"
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.x_forwarded_proto_priority = [:proto]
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "ws"
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.x_forwarded_proto_priority = []
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.x_forwarded_proto_priority = default_proto_priority
-      Rack::Request.forwarded_priority = [:forwarded]
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal 'https'
-
-      req("HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_X_FORWARDED_PROTO" => "ws").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.forwarded_priority = []
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
-        forwarded_for.must_be_nil
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_PORT" => "2345").
-        forwarded_port.must_be_nil
-
-      req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
-        "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
-        forwarded_authority.must_be_nil
-
-      r = req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http")
-      r.forwarded_scheme.must_be_nil
-      r.ssl?.must_equal false
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-    ensure
-      Rack::Request.forwarded_priority = default_priority
-      Rack::Request.x_forwarded_proto_priority = default_proto_priority
     end
   end
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -681,7 +681,7 @@ class RackRequestTest < Minitest::Spec
     req.params.must_equal req.GET.merge(req.POST)
   end
 
-  it "should use the query_parser for query parsing" do
+  it "should use the query_parser set via attr_writer for query parsing" do
     c = Class.new(Rack::QueryParser::Params) do
       def initialize(*)
         super(){|h, k| h[k.to_s] if k.is_a?(Symbol)}
@@ -689,6 +689,20 @@ class RackRequestTest < Minitest::Spec
     end
     req = Rack::Request.new(Rack::MockRequest.env_for("/?foo=bar&quux=bla"))
     req.query_parser = Rack::QueryParser.new(c, 100)
+    req.GET[:foo].must_equal "bar"
+    req.GET[:quux].must_equal "bla"
+    req.params[:foo].must_equal "bar"
+    req.params[:quux].must_equal "bla"
+  end
+
+  it "should use the query_parser from environment for query parsing" do
+    c = Class.new(Rack::QueryParser::Params) do
+      def initialize(*)
+        super(){|h, k| h[k.to_s] if k.is_a?(Symbol)}
+      end
+    end
+    req = Rack::Request.new(Rack::MockRequest.env_for("/?foo=bar&quux=bla"))
+    req.env[Rack::RACK_REQUEST_CONFIG] = {query_parser: Rack::QueryParser.new(c, 100)}
     req.GET[:foo].must_equal "bar"
     req.GET[:quux].must_equal "bla"
     req.params[:foo].must_equal "bar"

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -405,202 +405,225 @@ class RackRequestTest < Minitest::Spec
     req.port.must_equal 443
   end
 
-  it "have forwarded_* methods respect forwarded_priority" do
-    begin
-      default_priority = Rack::Request.forwarded_priority
-      default_proto_priority = Rack::Request.x_forwarded_proto_priority
+  [true, false].each do |global|
+    it "have forwarded_* methods respect forwarded_priority set #{global ? "globally" : "via rack.request.config"}" do
+      begin
+        default_priority = Rack::Request.forwarded_priority
+        default_proto_priority = Rack::Request.x_forwarded_proto_priority
 
-      def self.req(headers)
-        req = make_request Rack::MockRequest.env_for("/", headers)
-        req.singleton_class.send(:public, :forwarded_scheme)
-        req
+        define_singleton_method(:req) do |headers|
+          env = Rack::MockRequest.env_for("/", headers)
+          unless global
+            config = env[Rack::RACK_REQUEST_CONFIG] = {
+              forwarded_priority: @forwarded_priority,
+              x_forwarded_proto_priority: @x_forwarded_proto_priority
+            }
+          end
+          req = make_request env
+          req.singleton_class.send(:public, :forwarded_scheme)
+          req
+        end
+
+        define_singleton_method(:set_forwarded_priority) do |val|
+          if global
+            Rack::Request.forwarded_priority = val
+          else
+            @forwarded_priority = val
+          end
+        end
+
+        define_singleton_method(:set_x_forwarded_proto_priority) do |val|
+          if global
+            Rack::Request.x_forwarded_proto_priority = val
+          else
+            @x_forwarded_proto_priority = val
+          end
+        end
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4:1234",
+          "HTTP_X_FORWARDED_PORT" => "2345").
+          forwarded_port.must_equal [1234]
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_PORT" => "2345").
+          forwarded_port.must_equal []
+
+        req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
+          "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
+          forwarded_authority.must_equal '3.4.5.6'
+
+        req("HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "ws"
+
+        r = req("HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http",
+          "HTTP_X_FORWARDED_SSL" => "on")
+        r.forwarded_scheme.must_equal "https"
+        r.ssl?.must_equal true
+
+        req("HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "http"
+
+        set_forwarded_priority([nil, :x_forwarded, :forwarded])
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
+          forwarded_for.must_equal ['2.3.4.5']
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_PORT" => "2345").
+          forwarded_port.must_equal [2345]
+
+        req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
+          "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
+          forwarded_authority.must_equal '4.5.6.7'
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "ws"
+
+        r = req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http",
+          "HTTP_X_FORWARDED_SSL" => "on")
+        r.forwarded_scheme.must_equal "https"
+        r.ssl?.must_equal true
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "http"
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_equal "https"
+
+        set_x_forwarded_proto_priority([nil, :scheme, :proto, :ssl])
+
+        r = req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http")
+        r.forwarded_scheme.must_equal "http"
+        r.ssl?.must_equal false
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws").
+          forwarded_scheme.must_equal "ws"
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_equal "https"
+
+        set_forwarded_priority([:x_forwarded])
+
+        r = req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http")
+        r.forwarded_scheme.must_equal "http"
+        r.ssl?.must_equal false
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws").
+          forwarded_scheme.must_equal "ws"
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+        set_x_forwarded_proto_priority([:scheme])
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "http"
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+        set_x_forwarded_proto_priority([:proto])
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal "ws"
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+        set_x_forwarded_proto_priority([])
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+        set_x_forwarded_proto_priority(default_proto_priority)
+        set_forwarded_priority([:forwarded])
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_equal 'https'
+
+        req("HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_X_FORWARDED_PROTO" => "ws").
+          forwarded_scheme.must_be_nil
+
+        set_forwarded_priority([])
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
+          forwarded_for.must_be_nil
+
+        req("HTTP_FORWARDED"=>"for=1.2.3.4",
+          "HTTP_X_FORWARDED_PORT" => "2345").
+          forwarded_port.must_be_nil
+
+        req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
+          "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
+          forwarded_authority.must_be_nil
+
+        r = req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SSL" => "on",
+          "HTTP_X_FORWARDED_PROTO" => "ws",
+          "HTTP_X_FORWARDED_SCHEME" => "http")
+        r.forwarded_scheme.must_be_nil
+        r.ssl?.must_equal false
+
+        req("HTTP_FORWARDED"=>"proto=https",
+          "HTTP_X_FORWARDED_SCHEME" => "http").
+          forwarded_scheme.must_be_nil
+
+        req("HTTP_FORWARDED"=>"proto=https").
+          forwarded_scheme.must_be_nil
+
+      ensure
+        if global
+          Rack::Request.forwarded_priority = default_priority
+          Rack::Request.x_forwarded_proto_priority = default_proto_priority
+        end
       end
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
-        forwarded_for.must_equal ['1.2.3.4']
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4:1234",
-        "HTTP_X_FORWARDED_PORT" => "2345").
-        forwarded_port.must_equal [1234]
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_PORT" => "2345").
-        forwarded_port.must_equal []
-
-      req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
-        "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
-        forwarded_authority.must_equal '3.4.5.6'
-
-      req("HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "ws"
-
-      r = req("HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http",
-        "HTTP_X_FORWARDED_SSL" => "on")
-      r.forwarded_scheme.must_equal "https"
-      r.ssl?.must_equal true
-
-      req("HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "http"
-
-      Rack::Request.forwarded_priority = [nil, :x_forwarded, :forwarded]
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
-        forwarded_for.must_equal ['2.3.4.5']
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_PORT" => "2345").
-        forwarded_port.must_equal [2345]
-
-      req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
-        "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
-        forwarded_authority.must_equal '4.5.6.7'
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "ws"
-
-      r = req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http",
-        "HTTP_X_FORWARDED_SSL" => "on")
-      r.forwarded_scheme.must_equal "https"
-      r.ssl?.must_equal true
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "http"
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_equal "https"
-
-      Rack::Request.x_forwarded_proto_priority = [nil, :scheme, :proto, :ssl]
-
-      r = req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http")
-      r.forwarded_scheme.must_equal "http"
-      r.ssl?.must_equal false
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws").
-        forwarded_scheme.must_equal "ws"
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_equal "https"
-
-      Rack::Request.forwarded_priority = [:x_forwarded]
-
-      r = req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http")
-      r.forwarded_scheme.must_equal "http"
-      r.ssl?.must_equal false
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws").
-        forwarded_scheme.must_equal "ws"
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.x_forwarded_proto_priority = [:scheme]
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "http"
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.x_forwarded_proto_priority = [:proto]
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal "ws"
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.x_forwarded_proto_priority = []
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.x_forwarded_proto_priority = default_proto_priority
-      Rack::Request.forwarded_priority = [:forwarded]
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_equal 'https'
-
-      req("HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_X_FORWARDED_PROTO" => "ws").
-        forwarded_scheme.must_be_nil
-
-      Rack::Request.forwarded_priority = []
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_FOR" => "2.3.4.5").
-        forwarded_for.must_be_nil
-
-      req("HTTP_FORWARDED"=>"for=1.2.3.4",
-        "HTTP_X_FORWARDED_PORT" => "2345").
-        forwarded_port.must_be_nil
-
-      req("HTTP_FORWARDED"=>"host=1.2.3.4, host=3.4.5.6",
-        "HTTP_X_FORWARDED_HOST" => "2.3.4.5,4.5.6.7").
-        forwarded_authority.must_be_nil
-
-      r = req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SSL" => "on",
-        "HTTP_X_FORWARDED_PROTO" => "ws",
-        "HTTP_X_FORWARDED_SCHEME" => "http")
-      r.forwarded_scheme.must_be_nil
-      r.ssl?.must_equal false
-
-      req("HTTP_FORWARDED"=>"proto=https",
-        "HTTP_X_FORWARDED_SCHEME" => "http").
-        forwarded_scheme.must_be_nil
-
-      req("HTTP_FORWARDED"=>"proto=https").
-        forwarded_scheme.must_be_nil
-
-    ensure
-      Rack::Request.forwarded_priority = default_priority
-      Rack::Request.x_forwarded_proto_priority = default_proto_priority
     end
   end
 

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -2206,7 +2206,7 @@ EOF
   it "uses rack.request.trusted_proxy env key when set to nil (default behavior)" do
     # When nil, should fall back to ip_filter
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = nil
+    env[Rack::RACK_REQUEST_CONFIG] = {trusted_proxy: nil}
     req = make_request(env)
     
     req.trusted_proxy?('127.0.0.1').must_equal true
@@ -2217,7 +2217,7 @@ EOF
 
   it "trusts all proxies when rack.request.trusted_proxy is true" do
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = true
+    env[Rack::RACK_REQUEST_CONFIG] = {trusted_proxy: true}
     req = make_request(env)
     
     req.trusted_proxy?('127.0.0.1').must_equal true
@@ -2228,7 +2228,7 @@ EOF
 
   it "trusts no proxies when rack.request.trusted_proxy is false" do
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = false
+    env[Rack::RACK_REQUEST_CONFIG] = {trusted_proxy: false}
     req = make_request(env)
     
     req.trusted_proxy?('127.0.0.1').must_equal false
@@ -2239,7 +2239,7 @@ EOF
 
   it "trusts only specified IPs when rack.request.trusted_proxy is a callable" do
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip| ['10.0.0.1', '192.168.1.100'].include?(ip) }
+    env[Rack::RACK_REQUEST_CONFIG] = {trusted_proxy: lambda { |ip| ['10.0.0.1', '192.168.1.100'].include?(ip) }}
     req = make_request(env)
     
     req.trusted_proxy?('10.0.0.1').must_equal true
@@ -2253,13 +2253,15 @@ EOF
     require 'ipaddr'
     env = Rack::MockRequest.env_for("/")
     ranges = [IPAddr.new('10.0.0.0/24'), IPAddr.new('192.168.1.0/28')]
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip|
-      begin
-        ip_addr = IPAddr.new(ip)
-        ranges.any? { |range| range.include?(ip_addr) }
-      rescue IPAddr::InvalidAddressError
-        false
-      end
+    env[Rack::RACK_REQUEST_CONFIG] = {
+      trusted_proxy: lambda { |ip|
+        begin
+          ip_addr = IPAddr.new(ip)
+          ranges.any? { |range| range.include?(ip_addr) }
+        rescue IPAddr::InvalidAddressError
+          false
+        end
+      }
     }
     req = make_request(env)
     
@@ -2280,13 +2282,15 @@ EOF
     env = Rack::MockRequest.env_for("/")
     ipv6_exact = IPAddr.new('2001:db8::1')
     ipv6_range = IPAddr.new('fd00::/8')
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip|
-      begin
-        ip_addr = IPAddr.new(ip)
-        ip_addr == ipv6_exact || ipv6_range.include?(ip_addr)
-      rescue IPAddr::InvalidAddressError
-        false
-      end
+    env[Rack::RACK_REQUEST_CONFIG] = {
+      trusted_proxy: lambda { |ip|
+        begin
+          ip_addr = IPAddr.new(ip)
+          ip_addr == ipv6_exact || ipv6_range.include?(ip_addr)
+        rescue IPAddr::InvalidAddressError
+          false
+        end
+      }
     }
     req = make_request(env)
     
@@ -2299,8 +2303,8 @@ EOF
 
   it "handles custom logic in rack.request.trusted_proxy callable" do
     env = Rack::MockRequest.env_for("/")
-    env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip|
-      ip == '10.0.0.1' || ip == 'invalid-ip'
+    env[Rack::RACK_REQUEST_CONFIG] = {
+      trusted_proxy: lambda { |ip| ip == '10.0.0.1' || ip == 'invalid-ip' }
     }
     req = make_request(env)
     
@@ -2309,10 +2313,10 @@ EOF
     req.trusted_proxy?('192.168.1.1').must_equal false
   end
 
-  it "can use Rack::Config to set rack.request.trusted_proxy" do
+  it "can use Rack::Config to set rack.request.config" do
     app = lambda { |env| [200, {}, [Rack::Request.new(env).trusted_proxy?('8.8.8.8').to_s]] }
     config_app = Rack::Config.new(app) do |env|
-      env[Rack::RACK_REQUEST_TRUSTED_PROXY] = true
+      env[Rack::RACK_REQUEST_CONFIG] = { trusted_proxy: true }
     end
     
     mock = Rack::MockRequest.new(config_app)


### PR DESCRIPTION
This allows for configuring Rack::Request via a single env key. Using
env allows for easy using the same configuration for a single request,
a specific type of request, or all requests. Using a single key avoids
unnecessary performance degradation. Here are the currently recognized
keys:

* :trusted_proxy : replaces rack.request.trusted_proxy, which we have
  not yet shipped
* :query_parser : currently, this can only be overridden per-request
  via an attr_writer. This allows for setting the param_depth_limit,
  bytesize_limit, and params_limit for the request.
* :forwarded_priority: currently, this is only configurable on a
  global basis
* :x_forwarded_proto_priority : also currently only configurable on a
  global basis

This is similar to the rack.limits idea we discussed at the developers
meeting, but that turns out to not to be feasible, for two reasons:

* env is not passed to things that would need to access the limits
  (such as the query parser), and we would probably want to avoid
  allocating unnecessary objects such as query parsers per-request.
* A limit-specific key wouldn't allow for configuring things like
  trusted proxies or forwarding priorities. So you would need
  separate env keys for that, and that is what we are trying to
  avoid.

This does not yet support configuring a multipart_parser in the same
way as the query_parser. I think we want to do that or something
similar, but we'll have to make some API changes to allow it
(probably can make it backwards compatible via optional arguments).
Before working on that, I'd like to get approval for this approach.

Diff best viewed ignoring whitespace.