### PR TITLE
Only parse request body if the content-type is set on the request

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -557,14 +557,8 @@ module Rack
       # "application/x-www-form-urlencoded" or "multipart/form-data". The
       # list of form-data media types can be modified through the
       # +FORM_DATA_MEDIA_TYPES+ array.
-      #
-      # A request body is also assumed to contain form-data when no
-      # content-type header is provided and the request_method is POST.
       def form_data?
-        type = media_type
-        meth = get_header(RACK_METHODOVERRIDE_ORIGINAL_METHOD) || get_header(REQUEST_METHOD)
-
-        (meth == POST && type.nil?) || FORM_DATA_MEDIA_TYPES.include?(type)
+        FORM_DATA_MEDIA_TYPES.include?(media_type)
       end
 
       # Determine whether the request body contains data by checking

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -25,6 +25,7 @@ describe Rack::MethodOverride do
   it "sets rack.errors for invalid UTF8 _method values" do
     errors = StringIO.new
     env = Rack::MockRequest.env_for("/",
+      'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
       :method => "POST",
       :input => "_method=\xBF".b,
       Rack::RACK_ERRORS => errors)
@@ -37,7 +38,7 @@ describe Rack::MethodOverride do
   end
 
   it "modify REQUEST_METHOD for POST requests when _method parameter is set" do
-    env = Rack::MockRequest.env_for("/", method: "POST", input: "_method=put")
+    env = Rack::MockRequest.env_for("/", method: "POST", 'CONTENT_TYPE' => 'application/x-www-form-urlencoded', input: "_method=put")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "PUT"
@@ -54,14 +55,14 @@ describe Rack::MethodOverride do
   end
 
   it "not modify REQUEST_METHOD if the method is unknown" do
-    env = Rack::MockRequest.env_for("/", method: "POST", input: "_method=foo")
+    env = Rack::MockRequest.env_for("/", method: "POST", 'CONTENT_TYPE' => 'application/x-www-form-urlencoded', input: "_method=foo")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "POST"
   end
 
   it "not modify REQUEST_METHOD when _method is nil" do
-    env = Rack::MockRequest.env_for("/", method: "POST", input: "foo=bar")
+    env = Rack::MockRequest.env_for("/", method: "POST", 'CONTENT_TYPE' => 'application/x-www-form-urlencoded', input: "foo=bar")
     app.call env
 
     env["REQUEST_METHOD"].must_equal "POST"
@@ -69,6 +70,7 @@ describe Rack::MethodOverride do
 
   it "store the original REQUEST_METHOD prior to overriding" do
     env = Rack::MockRequest.env_for("/",
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
             method: "POST",
             input: "_method=options")
     app.call env

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -658,6 +658,7 @@ class RackRequestTest < Minitest::Spec
   it "not truncate query strings containing semi-colons #543 only in POST" do
     mr = Rack::MockRequest.env_for("/",
       "REQUEST_METHOD" => 'POST',
+      "CONTENT_TYPE" => 'application/x-www-form-urlencoded',
       :input => "foo=bar&quux=b;la")
     req = make_request mr
     req.query_string.must_equal ""
@@ -716,6 +717,7 @@ class RackRequestTest < Minitest::Spec
   it "not unify GET and POST when calling params" do
     mr = Rack::MockRequest.env_for("/?foo=quux",
       "REQUEST_METHOD" => 'POST',
+      "CONTENT_TYPE" => 'application/x-www-form-urlencoded',
       :input => "foo=bar&quux=bla"
     )
     req = make_request mr
@@ -741,6 +743,7 @@ class RackRequestTest < Minitest::Spec
     end
     mr = Rack::MockRequest.env_for("/?foo=quux",
       "REQUEST_METHOD" => 'POST',
+      "CONTENT_TYPE" => 'application/x-www-form-urlencoded',
       :input => "foo=bar&quux=bla"
     )
     req = c.new mr
@@ -757,6 +760,7 @@ class RackRequestTest < Minitest::Spec
   it "raise if input params has invalid %-encoding" do
     mr = Rack::MockRequest.env_for("/?foo=quux",
       "REQUEST_METHOD" => 'POST',
+      "CONTENT_TYPE" => 'application/x-www-form-urlencoded',
       :input => "a%=1"
     )
     req = make_request mr
@@ -768,19 +772,6 @@ class RackRequestTest < Minitest::Spec
   it "return empty POST data if rack.input is missing" do
     req = make_request({})
     req.POST.must_be_empty
-  end
-
-  it "parse POST data when method is POST and no content-type given" do
-    req = make_request \
-      Rack::MockRequest.env_for("/?foo=quux",
-        "REQUEST_METHOD" => 'POST',
-        :input => "foo=bar&quux=bla")
-    req.content_type.must_be_nil
-    req.media_type.must_be_nil
-    req.query_string.must_equal "foo=quux"
-    req.GET.must_equal "foo" => "quux"
-    req.POST.must_equal "foo" => "bar", "quux" => "bla"
-    req.params.must_equal "foo" => "bar", "quux" => "bla"
   end
 
   it "parse POST data with explicit content type regardless of method" do
@@ -805,6 +796,21 @@ class RackRequestTest < Minitest::Spec
     req.media_type.must_equal 'text/plain'
     req.media_type_params['charset'].must_equal 'utf-8'
     req.content_charset.must_equal 'utf-8'
+    post = req.POST
+    post.must_be_empty
+    req.POST.must_be_same_as post
+    req.params.must_equal "foo" => "quux"
+    req.body.read.must_equal "foo=bar&quux=bla"
+  end
+
+  it "not parse POST data when method is POST and no content-type given" do
+    req = make_request \
+      Rack::MockRequest.env_for("/?foo=quux",
+        "REQUEST_METHOD" => 'POST',
+        :input => "foo=bar&quux=bla")
+    req.content_type.must_be_nil
+    req.media_type.must_be_nil
+    req.query_string.must_equal "foo=quux"
     post = req.POST
     post.must_be_empty
     req.POST.must_be_same_as post
@@ -838,7 +844,9 @@ class RackRequestTest < Minitest::Spec
   it "clean up Safari's ajax POST body" do
     req = make_request \
       Rack::MockRequest.env_for("/",
-        'REQUEST_METHOD' => 'POST', :input => "foo=bar&quux=bla\0")
+        'REQUEST_METHOD' => 'POST',
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+        :input => "foo=bar&quux=bla\0")
     req.POST.must_equal "foo" => "bar", "quux" => "bla"
   end
 
@@ -923,21 +931,26 @@ class RackRequestTest < Minitest::Spec
   it "return form_pairs for url-encoded POST data" do
     req = make_request \
       Rack::MockRequest.env_for("/",
-        'REQUEST_METHOD' => 'POST', :input => "foo=bar&quux=bla")
+        'REQUEST_METHOD' => 'POST',
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+        :input => "foo=bar&quux=bla")
     req.form_pairs.must_equal [["foo", "bar"], ["quux", "bla"]]
   end
 
   it "preserve duplicate keys in form_pairs" do
     req = make_request \
       Rack::MockRequest.env_for("/",
-        'REQUEST_METHOD' => 'POST', :input => "foo=1&foo=2&bar=3")
+        'REQUEST_METHOD' => 'POST',
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+        :input => "foo=1&foo=2&bar=3")
     req.form_pairs.must_equal [["foo", "1"], ["foo", "2"], ["bar", "3"]]
   end
 
   it "handle empty values in form_pairs" do
     req = make_request \
       Rack::MockRequest.env_for("/",
-        'REQUEST_METHOD' => 'POST', :input => "foo=&bar=baz&empty")
+        "CONTENT_TYPE" => 'application/x-www-form-urlencoded',
+        :input => "foo=&bar=baz&empty")
     req.form_pairs.must_equal [["foo", ""], ["bar", "baz"], ["empty", nil]]
   end
 
@@ -951,7 +964,7 @@ class RackRequestTest < Minitest::Spec
     req = make_request \
       Rack::MockRequest.env_for("/",
         'REQUEST_METHOD' => 'POST',
-        "CONTENT_TYPE" => 'text/plain',
+        'CONTENT_TYPE' => 'text/plain',
         :input => "foo=bar")
     req.form_pairs.must_equal []
   end
@@ -959,7 +972,9 @@ class RackRequestTest < Minitest::Spec
   it "raise same error for form_pairs as POST with invalid encoding" do
     req = make_request \
       Rack::MockRequest.env_for("/",
-        'REQUEST_METHOD' => 'POST', :input => "a%=1")
+        'REQUEST_METHOD' => 'POST',
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+        :input => "a%=1")
     lambda { req.form_pairs }.must_raise(Rack::Utils::InvalidParameterError).
       message.must_equal "invalid %-encoding (a%)"
   end
@@ -1228,7 +1243,7 @@ EOF
   end
 
   it "modify params hash if param is in POST" do
-    e = Rack::MockRequest.env_for("", "REQUEST_METHOD" => 'POST', :input => 'foo=duh')
+    e = Rack::MockRequest.env_for("", "REQUEST_METHOD" => 'POST', "CONTENT_TYPE" => 'application/x-www-form-urlencoded', :input => 'foo=duh')
     req1 = make_request(e)
     req1.params.must_equal 'foo' => 'duh'
     req1.update_param 'foo', 'bar'
@@ -1258,7 +1273,7 @@ EOF
   end
 
   it "modify params hash by changing only POST" do
-    e = Rack::MockRequest.env_for("", "REQUEST_METHOD" => 'POST', :input => "foo=duhpost")
+    e = Rack::MockRequest.env_for("", "REQUEST_METHOD" => 'POST',  "CONTENT_TYPE" => 'application/x-www-form-urlencoded', :input => "foo=duhpost")
     req = make_request(e)
     req.GET.must_equal({})
     req.POST.must_equal 'foo' => 'duhpost'
@@ -1268,7 +1283,7 @@ EOF
   end
 
   it "modify params hash, even if param is defined in both POST and GET" do
-    e = Rack::MockRequest.env_for("?foo=duhget", "REQUEST_METHOD" => 'POST', :input => "foo=duhpost")
+    e = Rack::MockRequest.env_for("?foo=duhget", "REQUEST_METHOD" => 'POST', "CONTENT_TYPE" => 'application/x-www-form-urlencoded', :input => "foo=duhpost")
     req1 = make_request(e)
     req1.GET.must_equal 'foo' => 'duhget'
     req1.POST.must_equal 'foo' => 'duhpost'
@@ -1295,7 +1310,7 @@ EOF
   end
 
   it "allow deleting from params hash if param is in POST" do
-    e = Rack::MockRequest.env_for("", "REQUEST_METHOD" => 'POST', :input => 'foo=bar')
+    e = Rack::MockRequest.env_for("", "REQUEST_METHOD" => 'POST', "CONTENT_TYPE" => 'application/x-www-form-urlencoded', :input => 'foo=bar')
     req1 = make_request(e)
     req1.params.must_equal 'foo' => 'bar'
     req1.delete_param('foo').must_equal 'bar'
@@ -1554,9 +1569,9 @@ EOF
       'REQUEST_METHOD' => 'POST',
       'PATH_INFO' => '/foo',
       'rack.input' => StringIO.new('invalid=bar&invalid[foo]=bar'),
-      'HTTP_CONTENT_TYPE' => "application/x-www-form-urlencoded",
+      'CONTENT_TYPE' => "application/x-www-form-urlencoded",
     }
-    
+
     2.times do
       # The actual exception type here is unimportant - just that it fails.
       assert_raises(Rack::Utils::ParameterTypeError) do
@@ -2193,7 +2208,7 @@ EOF
     env = Rack::MockRequest.env_for("/")
     env[Rack::RACK_REQUEST_TRUSTED_PROXY] = nil
     req = make_request(env)
-    
+
     req.trusted_proxy?('127.0.0.1').must_equal true
     req.trusted_proxy?('10.0.0.1').must_equal true
     req.trusted_proxy?('192.168.1.1').must_equal true
@@ -2204,7 +2219,7 @@ EOF
     env = Rack::MockRequest.env_for("/")
     env[Rack::RACK_REQUEST_TRUSTED_PROXY] = true
     req = make_request(env)
-    
+
     req.trusted_proxy?('127.0.0.1').must_equal true
     req.trusted_proxy?('1.2.3.4').must_equal true
     req.trusted_proxy?('8.8.8.8').must_equal true
@@ -2215,7 +2230,7 @@ EOF
     env = Rack::MockRequest.env_for("/")
     env[Rack::RACK_REQUEST_TRUSTED_PROXY] = false
     req = make_request(env)
-    
+
     req.trusted_proxy?('127.0.0.1').must_equal false
     req.trusted_proxy?('10.0.0.1').must_equal false
     req.trusted_proxy?('192.168.1.1').must_equal false
@@ -2226,7 +2241,7 @@ EOF
     env = Rack::MockRequest.env_for("/")
     env[Rack::RACK_REQUEST_TRUSTED_PROXY] = lambda { |ip| ['10.0.0.1', '192.168.1.100'].include?(ip) }
     req = make_request(env)
-    
+
     req.trusted_proxy?('10.0.0.1').must_equal true
     req.trusted_proxy?('192.168.1.100').must_equal true
     req.trusted_proxy?('10.0.0.2').must_equal false
@@ -2247,13 +2262,13 @@ EOF
       end
     }
     req = make_request(env)
-    
+
     # 10.0.0.0/24 covers 10.0.0.0 - 10.0.0.255
     req.trusted_proxy?('10.0.0.1').must_equal true
     req.trusted_proxy?('10.0.0.100').must_equal true
     req.trusted_proxy?('10.0.0.255').must_equal true
     req.trusted_proxy?('10.0.1.1').must_equal false
-    
+
     # 192.168.1.0/28 covers 192.168.1.0 - 192.168.1.15
     req.trusted_proxy?('192.168.1.5').must_equal true
     req.trusted_proxy?('192.168.1.15').must_equal true
@@ -2274,7 +2289,7 @@ EOF
       end
     }
     req = make_request(env)
-    
+
     req.trusted_proxy?('2001:db8::1').must_equal true
     req.trusted_proxy?('2001:db8::2').must_equal false
     req.trusted_proxy?('fd00::1').must_equal true
@@ -2288,7 +2303,7 @@ EOF
       ip == '10.0.0.1' || ip == 'invalid-ip'
     }
     req = make_request(env)
-    
+
     req.trusted_proxy?('10.0.0.1').must_equal true
     req.trusted_proxy?('invalid-ip').must_equal true
     req.trusted_proxy?('192.168.1.1').must_equal false
@@ -2299,7 +2314,7 @@ EOF
     config_app = Rack::Config.new(app) do |env|
       env[Rack::RACK_REQUEST_TRUSTED_PROXY] = true
     end
-    
+
     mock = Rack::MockRequest.new(config_app)
     res = mock.get '/'
     res.body.must_equal 'true'
@@ -2374,6 +2389,7 @@ EOF
     it "handles ASCII NUL input of #{length} bytes" do
       mr = Rack::MockRequest.env_for("/",
         "REQUEST_METHOD" => 'POST',
+        "CONTENT_TYPE" => 'application/x-www-form-urlencoded',
         :input => "\0"*length)
       req = make_request mr
       req.query_string.must_equal ""

--- a/test/spec_show_exceptions.rb
+++ b/test/spec_show_exceptions.rb
@@ -61,7 +61,7 @@ describe Rack::ShowExceptions do
         lambda{|env| raise RuntimeError }
     ))
 
-    res = req.post("/", "HTTP_ACCEPT" => "text/html", "rack.input" => StringIO.new(String.new << '(%bad-params%)'))
+    res = req.post("/", "HTTP_ACCEPT" => "text/html", 'CONTENT_TYPE' => 'application/x-www-form-urlencoded', "rack.input" => StringIO.new(String.new << '(%bad-params%)'))
 
     res.must_be :server_error?
     res.status.must_equal 500


### PR DESCRIPTION
`form_data?` currently returns true for POST requests where the content-type header is not set.

If the request is considered to have form data, the body gets parsed for form parameters.

This was added in commit aea2d608fe592a665741087a8d6d31fcf26848ec. The reason seems to be to fix backwards compatibility after commit 8d01dc0421622f80fddfec52be66c49f8362162f. That commit disallowed PUT requests without content-type header set to parse the request body to prevent Sinatra from ingesting huge file uploads into memory.

[RFC 9110 section 8.3](https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type) states that requests with bodies should include a content-type header:

> A sender that generates a message containing content SHOULD generate a
> Content-Type header field in that message unless the intended media type
> of the enclosed representation is unknown to the sender. If a
> Content-Type header field is not present, the recipient MAY either
> assume a media type of "application/octet-stream" ([RFC2046], Section
> 4.5.1) or examine the data to determine its type.

If the content-type is unknown by the sender it's probably not form data.

Rails overrides `form_data?` to remove this functionality and only return true for valid content-types:

https://github.com/rails/rails/blob/3079e8b0f894e9a7e85a3bbf42383dc0a616af41/actionpack/lib/action_dispatch/http/request.rb#L365