### PR TITLE
Fix form_data? to return false for GET requests

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -564,7 +564,7 @@ module Rack
         type = media_type
         meth = get_header(RACK_METHODOVERRIDE_ORIGINAL_METHOD) || get_header(REQUEST_METHOD)
 
-        (meth == POST && type.nil?) || FORM_DATA_MEDIA_TYPES.include?(type)
+        (meth == POST && type.nil?) || (meth != GET && FORM_DATA_MEDIA_TYPES.include?(type))
       end
 
       # Determine whether the request body contains data by checking


### PR DESCRIPTION
Based on issue #1994: Go's HTTP client sends form data on GET requests after redirects, which Rack incorrectly tries to parse.

GET requests should not have form data per HTTP spec, so form_data? should return false for GET methods regardless of content-type.

This follows the pattern suggested in the issue and aligns with HTTP specification that GET requests should not have entity bodies.