### PR TITLE
Rack::RewindableInput: add `seek` method

### DIFF
--- a/lib/rack/rewindable_input.rb
+++ b/lib/rack/rewindable_input.rb
@@ -50,6 +50,11 @@ module Rack
       @rewindable_io.each(&block)
     end
 
+    def seek(*args)
+      make_rewindable unless @rewindable_io
+      @rewindable_io.seek(*args)
+    end
+
     def rewind
       make_rewindable unless @rewindable_io
       @rewindable_io.rewind

--- a/test/spec_rewindable_input.rb
+++ b/test/spec_rewindable_input.rb
@@ -46,6 +46,23 @@ module RewindableTest
     @rio.read.must_equal "hello world"
   end
 
+  it "seek is able to move the cursor" do
+    @rio.seek(1)
+    @rio.read(1).must_equal 'e'
+
+    @rio.seek(3)
+    @rio.read(2).must_equal 'lo'
+
+    @rio.seek(1, IO::SEEK_CUR)
+    @rio.read(5).must_equal 'world'
+
+    @rio.seek(-5, IO::SEEK_END)
+    @rio.read(5).must_equal 'world'
+
+    @rio.rewind
+    @rio.read.must_equal "hello world"
+  end
+
   it "be able to handle gets" do
     @rio.gets.must_equal "hello world"
     @rio.rewind


### PR DESCRIPTION
Since it support `rewind` I don't see why it shouldn't support `seek`. It has come up in `marcel`: https://github.com/rails/marcel/pull/144