### PR TITLE
Make Rack::Files ractor safe.

### DIFF
--- a/lib/rack/files.rb
+++ b/lib/rack/files.rb
@@ -29,11 +29,21 @@ module Rack
 
     attr_reader :root
 
+    class Callable
+      def initialize(files)
+        @files = files
+      end
+
+      def call(env)
+        @files.get env
+      end
+    end
+
     def initialize(root, headers = {}, default_mime = 'text/plain')
       @root = (::File.expand_path(root) if root)
       @headers = headers
       @default_mime = default_mime
-      @head = Rack::Head.new(lambda { |env| get env })
+      @head = Rack::Head.new(Callable.new(self))
     end
 
     def call(env)

--- a/test/spec_files.rb
+++ b/test/spec_files.rb
@@ -382,4 +382,14 @@ content-range: bytes 60-80/209\r
     res.must_be :not_found?
     res.body.must_be :empty?
   end
+
+  if defined?(Ractor)
+    it "can be made ractor shareable" do
+      files = Rack::Files.new(DOCROOT)
+
+      Ractor.make_shareable(files)
+
+      assert Ractor.shareable?(files)
+    end
+  end
 end


### PR DESCRIPTION
I am exploring getting a Rails app running in a Ractor and ran into an issue with `Rack::Files`.

The lambda we store in `@head` needs to be shareable. But it needs to reference the `Rack::Files` instance as `self`, so we can't make it shareable with `Ractor.lamda_shareable` since we haven't finished initializing self yet.

So instead I made a small callbale object which can be frozen later when the application is made shareable.