### PR TITLE
Support streaming bodies in Rack::Deflater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file. For info on
 - `Rack::Multipart::UploadedFile` now delegates keyword arguments to the wrapped tempfile. Calls such as `uploaded_file.readlines(chomp: true)` raised `TypeError` on Ruby 3.0+. ([#2481](https://github.com/rack/rack/issues/2481), [#2499](https://github.com/rack/rack/pull/2499), [@SeanLF](https://github.com/SeanLF))
 - Multipart parser: limit MIME header size check to the unread buffer region to avoid false `multipart mime part header too large` errors when previously read data accumulates in the scan buffer. ([#2392](https://github.com/rack/rack/pull/2392), [@alpaca-tc](https://github.com/alpaca-tc), [@willnet](https://github.com/willnet), [@krororo](https://github.com/krororo))
 - Multipart parser: add nil guards to prevent `NoMethodError` crashes when handling `Content-Disposition` without parameters and `Content-Type` parameters without '='. ([@haruki0409](https://github.com/haruki0409))
+- `Rack::Deflater` now gzips streaming (call-only) bodies instead of raising `NoMethodError: undefined method 'each'`. ([#2470](https://github.com/rack/rack/issues/2470), [@SAY-5](https://github.com/SAY-5))
 
 ## [3.2.6] - 2026-04-01
 

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -197,6 +197,9 @@ module Rack
         # and with sync enabled every write already flushes.
         @gzip.flush unless @flushed
         @flushed = true
+        # Propagate to the wrapped stream so a write-then-flush (e.g. SSE)
+        # is not left sitting in a buffering server-side wrapper.
+        @stream.flush if @stream.respond_to?(:flush)
         self
       end
 

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -134,6 +134,29 @@ module Rack
         gzip.finish
       end
 
+      # Compress a streaming (call-only) body on the fly, wrapping the
+      # server-provided stream so the body writes plain data and the client
+      # receives gzip.
+      def call(stream)
+        @writer = stream.method(:write)
+        gzip = ::Zlib::GzipWriter.new(self)
+        gzip.mtime = @mtime if @mtime
+        gzip.sync = @sync
+        @body.call(GzipWriterStream.new(gzip, stream))
+      end
+
+      # Treat the wrapped body as the server would: an Enumerable Body responds
+      # to +each+, a Streaming Body responds to +call+. Delegating +respond_to?+
+      # keeps this wrapper on the same side of that contract as the body it wraps.
+      def respond_to?(name, include_all = false)
+        case name
+        when :each, :call
+          @body.respond_to?(name, include_all)
+        else
+          super
+        end
+      end
+
       # Call the block passed to #each with the gzipped data.
       def write(data)
         @writer.call(data)
@@ -142,6 +165,50 @@ module Rack
       # Close the original body if possible.
       def close
         @body.close if @body.respond_to?(:close)
+      end
+    end
+
+    # Stream wrapper handed to a streaming body so that everything it writes is
+    # gzip compressed before reaching the server-provided stream. Closing it
+    # finishes the gzip trailer and then closes the underlying stream.
+    class GzipWriterStream
+      def initialize(gzip, stream)
+        @gzip = gzip
+        @stream = stream
+      end
+
+      def write(data)
+        @gzip.write(data)
+      end
+
+      def <<(data)
+        write(data)
+        self
+      end
+
+      def flush
+        @gzip.flush
+      end
+
+      def close
+        @gzip.finish
+        @stream.close
+      end
+
+      def closed?
+        @stream.closed?
+      end
+
+      def read(*args, &block)
+        @stream.read(*args, &block)
+      end
+
+      def close_read
+        @stream.close_read
+      end
+
+      def close_write
+        close
       end
     end
 

--- a/lib/rack/deflater.rb
+++ b/lib/rack/deflater.rb
@@ -175,10 +175,16 @@ module Rack
       def initialize(gzip, stream)
         @gzip = gzip
         @stream = stream
+        @flushed = false
       end
 
       def write(data)
-        @gzip.write(data)
+        # Skip empty strings: with sync enabled they trigger an empty
+        # Z_SYNC_FLUSH, which raises Zlib::BufError.
+        return 0 if data.empty?
+        result = @gzip.write(data)
+        @flushed = @gzip.sync
+        result
       end
 
       def <<(data)
@@ -187,7 +193,11 @@ module Rack
       end
 
       def flush
-        @gzip.flush
+        # Flushing twice without an intervening write raises Zlib::BufError,
+        # and with sync enabled every write already flushes.
+        @gzip.flush unless @flushed
+        @flushed = true
+        self
       end
 
       def close

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -131,6 +131,30 @@ describe Rack::Deflater do
     Zlib::GzipReader.new(StringIO.new(out.string)).read.must_equal 'foobar'
   end
 
+  it 'be able to gzip streaming bodies that flush between writes' do
+    app_body = Object.new
+    class << app_body
+      def call(stream)
+        stream.write("event: a\n\n")
+        stream.flush
+        stream.write('')
+        stream.flush
+        stream.write("event: b\n\n")
+        stream.flush
+      ensure
+        stream.close
+      end
+    end
+
+    status, headers, body = build_response(200, app_body, 'gzip')
+    status.must_equal 200
+    headers['content-encoding'].must_equal 'gzip'
+
+    out = StringIO.new(String.new)
+    body.call(out)
+    Zlib::GzipReader.new(StringIO.new(out.string)).read.must_equal "event: a\n\nevent: b\n\n"
+  end
+
   it 'should not update vary response header if it includes * or accept-encoding' do
     verify(200, 'foobar', deflate_or_gzip, 'response_headers' => { 'vary' => 'Accept-Encoding' } ) do |status, headers, body|
       headers['vary'].must_equal 'Accept-Encoding'

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -170,7 +170,7 @@ describe Rack::Deflater do
     status.must_equal 200
 
     out = StringIO.new(String.new)
-    def out.flush_count = @flush_count ||= 0
+    def out.flush_count; @flush_count ||= 0; end
     def out.flush; @flush_count = flush_count + 1; super; end
     body.call(out)
     out.flush_count.must_be :>, 0

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -155,6 +155,27 @@ describe Rack::Deflater do
     Zlib::GzipReader.new(StringIO.new(out.string)).read.must_equal "event: a\n\nevent: b\n\n"
   end
 
+  it 'propagate flush to the wrapped stream for streaming gzip bodies' do
+    app_body = Object.new
+    class << app_body
+      def call(stream)
+        stream.write("event: a\n\n")
+        stream.flush
+      ensure
+        stream.close
+      end
+    end
+
+    status, headers, body = build_response(200, app_body, 'gzip')
+    status.must_equal 200
+
+    out = StringIO.new(String.new)
+    def out.flush_count = @flush_count ||= 0
+    def out.flush; @flush_count = flush_count + 1; super; end
+    body.call(out)
+    out.flush_count.must_be :>, 0
+  end
+
   it 'should not update vary response header if it includes * or accept-encoding' do
     verify(200, 'foobar', deflate_or_gzip, 'response_headers' => { 'vary' => 'Accept-Encoding' } ) do |status, headers, body|
       headers['vary'].must_equal 'Accept-Encoding'

--- a/test/spec_deflater.rb
+++ b/test/spec_deflater.rb
@@ -109,6 +109,28 @@ describe Rack::Deflater do
     end
   end
 
+  it 'be able to gzip streaming bodies that respond to call' do
+    app_body = Object.new
+    class << app_body
+      def call(stream)
+        stream.write('foo')
+        stream.write('bar')
+      ensure
+        stream.close
+      end
+    end
+
+    status, headers, body = build_response(200, app_body, 'gzip')
+    status.must_equal 200
+    headers['content-encoding'].must_equal 'gzip'
+    body.respond_to?(:each).must_equal false
+    body.respond_to?(:call).must_equal true
+
+    out = StringIO.new(String.new)
+    body.call(out)
+    Zlib::GzipReader.new(StringIO.new(out.string)).read.must_equal 'foobar'
+  end
+
   it 'should not update vary response header if it includes * or accept-encoding' do
     verify(200, 'foobar', deflate_or_gzip, 'response_headers' => { 'vary' => 'Accept-Encoding' } ) do |status, headers, body|
       headers['vary'].must_equal 'Accept-Encoding'


### PR DESCRIPTION
Deflater wraps the response body in `GzipStream` and consumes it with `@body.each`, but a Rack 3 streaming body only responds to `call(stream)`, so it raises `NoMethodError: undefined method 'each'` and the client gets a truncated gzip stream. This adds a `call` path to `GzipStream` that compresses what the body writes to the stream, and delegates `respond_to?(:each/:call)` to the wrapped body so a server treats the result as enumerable or streaming on the same basis as the original. Same idea as the streaming support added for `Rack::Events` in #2375.

Fixes #2470.
