### PR TITLE
Skip ETag generation for Cache-Control: no-store responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file. For info on
 - The query parser now raises `Rack::QueryParser::IncompatibleEncodingError` if we try to parse params that are not ASCII compatible. ([#2416](https://github.com/rack/rack/pull/2416), [@bquorning](https://github.com/bquorning))
 - The mime type for `.pem` files has been changed from `application/x-x509-ca-cert` to `application/x-pem-file`. ([#2435](https://github.com/rack/rack/pull/2435), [@jeremyevans](https://github.com/jeremyevans))
 - Freeze `Rack::Auth::AbstractRequest::AUTHORIZATION_KEYS`, `Rack::Utils::STATUS_WITH_NO_ENTITY_BODY`, `Rack::Multipart::Parser::EMPTY`, `Rack::Utils.default_query_parser`, and internal constants in `Rack::Lint`. Also make the multipart parser's default Tempfile factory Ractor-compatible. ([#2428](https://github.com/rack/rack/pull/2428), [@jhawthorn](https://github.com/jhawthorn))
+- `Rack::ETag` does not set an `ETag` on `Cache-Control: no-store` responses, since such responses must not be stored and the validator could never be used. ([#2472](https://github.com/rack/rack/pull/2472), [@islue](https://github.com/islue))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file. For info on
 - The query parser now raises `Rack::QueryParser::IncompatibleEncodingError` if we try to parse params that are not ASCII compatible. ([#2416](https://github.com/rack/rack/pull/2416), [@bquorning](https://github.com/bquorning))
 - The mime type for `.pem` files has been changed from `application/x-x509-ca-cert` to `application/x-pem-file`. ([#2435](https://github.com/rack/rack/pull/2435), [@jeremyevans](https://github.com/jeremyevans))
 - Freeze `Rack::Auth::AbstractRequest::AUTHORIZATION_KEYS`, `Rack::Utils::STATUS_WITH_NO_ENTITY_BODY`, `Rack::Multipart::Parser::EMPTY`, `Rack::Utils.default_query_parser`, and internal constants in `Rack::Lint`. ([#2428](https://github.com/rack/rack/pull/2428), [@jhawthorn](https://github.com/jhawthorn))
+- `Rack::ETag` does not set an `ETag` on `Cache-Control: no-store` responses, since such responses must not be stored and the validator could never be used. ([#2472](https://github.com/rack/rack/pull/2472), [@islue](https://github.com/islue))
 
 ### Fixed
 

--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -8,9 +8,11 @@ require_relative 'utils'
 module Rack
   # Automatically sets the etag header on all String bodies.
   #
-  # The etag header is skipped if etag or last-modified headers are sent or if
+  # The etag header is skipped if etag or last-modified headers are sent, if
   # a sendfile body (body.responds_to :to_path) is given (since such cases
-  # should be handled by apache/nginx).
+  # should be handled by apache/nginx), or if the response is marked
+  # cache-control: no-store (since such responses must not be stored, an
+  # entity-tag validator would never be usable).
   #
   # On initialization, you can pass two parameters: a cache-control directive
   # used when etag is absent and a directive when it is present. The first
@@ -55,6 +57,11 @@ module Rack
       end
 
       def skip_caching?(headers)
+        if cache_control = headers[CACHE_CONTROL]
+          # Skip ETag generation if caching is explicitly denied:
+          return true if cache_control.match?(/\bno-store\b/)
+        end
+
         headers.key?(ETAG_STRING) || headers.key?('last-modified')
       end
 

--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -7,9 +7,11 @@ require_relative 'constants'
 module Rack
   # Automatically sets the etag header on all String bodies.
   #
-  # The etag header is skipped if etag or last-modified headers are sent or if
+  # The etag header is skipped if etag or last-modified headers are sent, if
   # a sendfile body (body.responds_to :to_path) is given (since such cases
-  # should be handled by apache/nginx).
+  # should be handled by apache/nginx), or if the response is marked
+  # cache-control: no-store (since such responses must not be stored, an
+  # entity-tag validator would never be usable).
   #
   # On initialization, you can pass two parameters: a cache-control directive
   # used when etag is absent and a directive when it is present. The first
@@ -54,6 +56,11 @@ module Rack
       end
 
       def skip_caching?(headers)
+        if cache_control = headers[CACHE_CONTROL]
+          # Skip ETag generation if caching is explicitly denied:
+          return true if cache_control.match?(/\bno-store\b/)
+        end
+
         headers.key?(ETAG_STRING) || headers.key?('last-modified')
       end
 

--- a/test/spec_etag.rb
+++ b/test/spec_etag.rb
@@ -116,6 +116,18 @@ describe Rack::ETag do
     response[1]['etag'].must_equal "W/\"dffd6021bb2bd5b0af676290809ec3a5\""
   end
 
+  it "not set etag if no-store is given" do
+    app = lambda { |env| [200, { 'content-type' => 'text/plain', 'cache-control' => 'no-store' }, ['Hello, World!']] }
+    response = etag(app).call(request)
+    response[1]['etag'].must_be_nil
+  end
+
+  it "not set etag even if no-store is combined with no-cache" do
+    app = lambda { |env| [200, { 'content-type' => 'text/plain', 'cache-control' => 'no-cache, no-store, must-revalidate' }, ['Hello, World!']] }
+    response = etag(app).call(request)
+    response[1]['etag'].must_be_nil
+  end
+
   it "close the original body" do
     body = StringIO.new
     app = lambda { |env| [200, {}, body] }


### PR DESCRIPTION
## Summary

`Rack::ETag` adds a weak `ETag` to any bufferable (`to_ary`) 200/201 response regardless of `Cache-Control`. This PR makes it skip ETag generation when the response is marked `Cache-Control: no-store`.

## Why

`Cache-Control: no-store` directs that a cache "MUST NOT store any part of either the immediate request or the response" (RFC 9111 §5.2.2.5). An `ETag` is "an opaque validator for distinguishing between multiple representations of the same resource" (RFC 9110 §8.8.3); a cache uses it to revalidate a *stored* representation via a conditional request. If a response may never be stored, there is nothing for a cache to revalidate, so the weak `ETag` that `Rack::ETag` generates can never be used for that purpose — it is dead metadata on a response that has explicitly opted out of caching.

**This is not a revert of #1416.** That change was correct: `no-cache` permits storage but requires revalidation before reuse (RFC 9111 §5.2.2.4), so a validator is genuinely useful there. `no-store` is the opposite — it forbids storage outright. When both directives are present, `no-store` dominates: once nothing may be stored, `no-cache`'s "revalidate before reuse" never comes into play, so the `ETag` is skipped. The existing "set etag even if no-cache is given" behavior is unchanged, and a new test documents the `no-cache, no-store` precedence.

## Scope and motivation

To be upfront: I haven't traced this to a concrete failure — it's a correctness/tidiness change, not a bug report. For a fully conformant client an auto `ETag` on a `no-store` response is harmless, because the response is never stored and the validator is never exercised. But it is equally never *useful*, and it does hand a content-derived validator to clients or intermediaries that mishandle `no-store`: one that stored the response and later revalidated would get a `304 Not Modified` (empty body) back from `Rack::ConditionalGet`, for a response that was never supposed to be stored. Suppressing the validator costs conformant clients nothing — it also skips computing a body digest that would only be discarded — and keeps `Rack::ETag`'s output consistent with the response's own caching intent. It seemed worth keeping clean.

## Tests

- `not set etag if no-store is given`
- `not set etag even if no-store is combined with no-cache` (documents that `no-store` wins over `no-cache`)
