### PR TITLE
Limit rdoc version to < 8 in JRuby CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,12 @@ group :maintenance, optional: true do
 end
 
 group :doc do
-  gem "rdoc"
+  if RUBY_ENGINE == "jruby"
+    gem "rdoc", "< 8"
+  else
+    gem "rdoc"
+  end
+
   gem "psych", "= 3.0.2" if RUBY_VERSION[0..2] == "2.5"
 end
 


### PR DESCRIPTION
This can be removed after rbs provides a java gem.

Attempts to fix following CI error: https://github.com/rack/rack/actions/runs/28822920928/job/85482641338?pr=2475