### PR TITLE
Remove guard for requiring Multipart in Request

### DIFF
--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -3,6 +3,7 @@
 require_relative 'constants'
 require_relative 'utils'
 require_relative 'media_type'
+require_relative 'multipart'
 
 module Rack
   # Rack::Request provides a convenient interface to a Rack
@@ -889,7 +890,3 @@ module Rack
     include Helpers
   end
 end
-
-# :nocov:
-require_relative 'multipart' unless defined?(Rack::Multipart)
-# :nocov:


### PR DESCRIPTION
This was [added][1] so that files in rack could be required individually, and there was a circular dependency between `Rack::Request` and `Rack::Multipart`. However, that circular dependency [no longer exists][2].

Additionally, this guard currently prevents `Rack::Request` from immediately requiring `Rack::Multipart` if rack.rb is required first. Since rack.rb sets up an autoload for `Multipart`, `defined? Multipart` returns true.

This commit removes that `defined?` guard since its no longer necessary, which also fixes `Multipart` not being immediately required by `Request`.

[1]: https://github.com/rack/rack/commit/2833813bd7f2a1872831d83cc9a0bb60f7d94fdd
[2]: https://github.com/rack/rack/commit/11b4ac5237b25ba773ca519cc4e508c9008bed65