### PR TITLE
Cleanup unused requires

### DIFF
--- a/lib/rack/conditional_get.rb
+++ b/lib/rack/conditional_get.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
+require 'time'
+
 require_relative 'constants'
-require_relative 'utils'
-require_relative 'body_proxy'
 
 module Rack
 

--- a/lib/rack/etag.rb
+++ b/lib/rack/etag.rb
@@ -3,7 +3,6 @@
 require 'digest/sha2'
 
 require_relative 'constants'
-require_relative 'utils'
 
 module Rack
   # Automatically sets the etag header on all String bodies.

--- a/lib/rack/head.rb
+++ b/lib/rack/head.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'constants'
-require_relative 'body_proxy'
 
 module Rack
   # Rack::Head returns an empty body for all HEAD requests. It leaves

--- a/lib/rack/utils.rb
+++ b/lib/rack/utils.rb
@@ -10,7 +10,6 @@ require 'erb'
 
 require_relative 'query_parser'
 require_relative 'mime'
-require_relative 'headers'
 require_relative 'constants'
 
 module Rack


### PR DESCRIPTION
- `BodyProxy` removed from `Head` in 9e103900
- `BodyProxy` removed from `ConditionalGet` in 6828a176
- `Utils::HeaderHash` removed from `ConditionalGet` in 472e12f5
  - `ConditionalGet` still depends on `Time`, so that require is added
- `Utils::HeaderHash` removed from `ETag` in 472e12f5
- `Headers` removed from `Utils` (`Utils::HeaderHash` was deleted) in a5762cf6