### PR TITLE
Delegate keyword arguments in UploadedFile#method_missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Fixed
 
+- `Rack::Multipart::UploadedFile` now delegates keyword arguments to the wrapped tempfile. Calls such as `uploaded_file.readlines(chomp: true)` raised `TypeError` on Ruby 3.0+. ([#2482](https://github.com/rack/rack/pull/2482), [@SeanLF](https://github.com/SeanLF))
 - Multipart parser: limit MIME header size check to the unread buffer region to avoid false `multipart mime part header too large` errors when previously read data accumulates in the scan buffer. ([#2392](https://github.com/rack/rack/pull/2392), [@alpaca-tc](https://github.com/alpaca-tc), [@willnet](https://github.com/willnet), [@krororo](https://github.com/krororo))
 - Multipart parser: add nil guards to prevent `NoMethodError` crashes when handling `Content-Disposition` without parameters and `Content-Type` parameters without '='. ([@haruki0409](https://github.com/haruki0409))
 

--- a/lib/rack/multipart/uploaded_file.rb
+++ b/lib/rack/multipart/uploaded_file.rb
@@ -77,9 +77,7 @@ module Rack
       def method_missing(method_name, *args, &block) #:nodoc:
         @tempfile.__send__(method_name, *args, &block)
       end
-      # :nocov:
       ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
-      # :nocov:
     end
   end
 end

--- a/lib/rack/multipart/uploaded_file.rb
+++ b/lib/rack/multipart/uploaded_file.rb
@@ -77,6 +77,9 @@ module Rack
       def method_missing(method_name, *args, &block) #:nodoc:
         @tempfile.__send__(method_name, *args, &block)
       end
+      # :nocov:
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+      # :nocov:
     end
   end
 end

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1019,6 +1019,13 @@ content-type: image/jpeg\r
     Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"), binary: true).must_be :binmode?
   end
 
+  it "delegates keyword arguments to the tempfile" do
+    file = Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"))
+    file.readlines(chomp: true).must_equal ['contents']
+    file.rewind
+    file.gets(chomp: true).must_equal 'contents'
+  end
+
   it "builds multipart body" do
     files = Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"))
     data  = Rack::Multipart.build_multipart("submit-name" => "Larry", "files" => files)


### PR DESCRIPTION
Fixes #2481.

`Rack::Multipart::UploadedFile#method_missing` delegates to the wrapped tempfile but was never flagged with `ruby2_keywords`, so keyword arguments are rebuilt as a positional Hash on Ruby 3.0+:

```ruby
uf.readlines(chomp: true)  # => TypeError: no implicit conversion of Hash into Integer
uf.gets(chomp: true)       # => TypeError: no implicit conversion of Hash into Integer
```

This flags the delegator, matching `BodyProxy#method_missing` and `MockResponse::Cookie#method_missing`.

Ruby 2.4 to 2.6 are unaffected either way, since they do not distinguish a trailing Hash from keywords. The `respond_to?` guard is kept because `ruby2_keywords` does not exist before 2.7.

The added test fails without the change (`TypeError`) and passes with it. Verified on Ruby 2.4.10, 2.6.10, 3.0.7 and 4.0.6.