### PR TITLE
Use explicit keyword arguments instead of ruby2_keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. For info on
 - Multipart parser drops support for RFC 2231 `filename*` parameter (prohibited by RFC 7578) and now properly handles UTF-8 encoded filenames via percent-encoding and direct UTF-8 bytes. ([#2398](https://github.com/rack/rack/pull/2398), [@wtn](https://github.com/wtn))
 - The query parser now raises `Rack::QueryParser::IncompatibleEncodingError` if we try to parse params that are not ASCII compatible. ([#2416](https://github.com/rack/rack/pull/2416), [@bquorning](https://github.com/bquorning))
 - The mime type for `.pem` files has been changed from `application/x-x509-ca-cert` to `application/x-pem-file`. ([#2435](https://github.com/rack/rack/pull/2435), [@jeremyevans](https://github.com/jeremyevans))
+- Use explicit keyword arguments instead of `ruby2_keywords` on Ruby 3.0+, which Ruby proposes to deprecate and remove ([Feature #22205](https://bugs.ruby-lang.org/issues/22205)). Argument forwarding is unchanged on every supported Ruby. ([@SeanLF](https://github.com/SeanLF))
 - Freeze `Rack::Auth::AbstractRequest::AUTHORIZATION_KEYS`, `Rack::Utils::STATUS_WITH_NO_ENTITY_BODY`, `Rack::Multipart::Parser::EMPTY`, `Rack::Utils.default_query_parser`, and internal constants in `Rack::Lint`. ([#2428](https://github.com/rack/rack/pull/2428), [@jhawthorn](https://github.com/jhawthorn))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file. For info on
 
 ### Fixed
 
+- `Rack::Multipart::UploadedFile` now delegates keyword arguments to the wrapped tempfile. Calls such as `uploaded_file.readlines(chomp: true)` raised `TypeError` on Ruby 3.0+. ([#2482](https://github.com/rack/rack/pull/2482), [@SeanLF](https://github.com/SeanLF))
 - Multipart parser: limit MIME header size check to the unread buffer region to avoid false `multipart mime part header too large` errors when previously read data accumulates in the scan buffer. ([#2392](https://github.com/rack/rack/pull/2392), [@alpaca-tc](https://github.com/alpaca-tc), [@willnet](https://github.com/willnet), [@krororo](https://github.com/krororo))
 - Multipart parser: add nil guards to prevent `NoMethodError` crashes when handling `Content-Disposition` without parameters and `Content-Type` parameters without '='. ([@haruki0409](https://github.com/haruki0409))
 

--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -42,7 +42,7 @@ module Rack
     end
 
     # Delegate missing methods to the wrapped body.
-    if RUBY_VERSION >= '3.0'
+    if RUBY_VERSION.to_i >= 3
       def method_missing(method_name, *args, **kwargs, &block)
         case method_name
         when :to_str

--- a/lib/rack/body_proxy.rb
+++ b/lib/rack/body_proxy.rb
@@ -42,22 +42,40 @@ module Rack
     end
 
     # Delegate missing methods to the wrapped body.
-    def method_missing(method_name, *args, &block)
-      case method_name
-      when :to_str
-        super
-      when :to_ary
-        begin
-          @body.__send__(method_name, *args, &block)
-        ensure
-          close
+    if RUBY_VERSION >= '3.0'
+      def method_missing(method_name, *args, **kwargs, &block)
+        case method_name
+        when :to_str
+          super
+        when :to_ary
+          begin
+            @body.__send__(method_name, *args, **kwargs, &block)
+          ensure
+            close
+          end
+        else
+          @body.__send__(method_name, *args, **kwargs, &block)
         end
-      else
-        @body.__send__(method_name, *args, &block)
       end
+    else
+      # :nocov:
+      # See the note in Rack::Builder#use.
+      def method_missing(method_name, *args, &block)
+        case method_name
+        when :to_str
+          super
+        when :to_ary
+          begin
+            @body.__send__(method_name, *args, &block)
+          ensure
+            close
+          end
+        else
+          @body.__send__(method_name, *args, &block)
+        end
+      end
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+      # :nocov:
     end
-    # :nocov:
-    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
-    # :nocov:
   end
 end

--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -156,7 +156,7 @@ module Rack
     # All requests through to this application will first be processed by the middleware class.
     # The +call+ method in this example sets an additional environment key which then can be
     # referenced in the application if required.
-    if RUBY_VERSION >= '3.0'
+    if RUBY_VERSION.to_i >= 3
       def use(middleware, *args, **kwargs, &block)
         add_middleware { |app| middleware.new(app, *args, **kwargs, &block) }
       end

--- a/lib/rack/builder.rb
+++ b/lib/rack/builder.rb
@@ -156,18 +156,21 @@ module Rack
     # All requests through to this application will first be processed by the middleware class.
     # The +call+ method in this example sets an additional environment key which then can be
     # referenced in the application if required.
-    def use(middleware, *args, &block)
-      if @map
-        mapping, @map = @map, nil
-        @use << proc { |app| generate_map(app, mapping) }
+    if RUBY_VERSION >= '3.0'
+      def use(middleware, *args, **kwargs, &block)
+        add_middleware { |app| middleware.new(app, *args, **kwargs, &block) }
       end
-      @use << proc { |app| middleware.new(app, *args, &block) }
-
-      nil
+    else
+      # :nocov:
+      # Ruby < 3.0 does not separate a trailing positional Hash from keywords,
+      # so a `**kwargs` parameter would capture an options Hash and forward it
+      # as keywords.
+      def use(middleware, *args, &block)
+        add_middleware { |app| middleware.new(app, *args, &block) }
+      end
+      ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
+      # :nocov:
     end
-    # :nocov:
-    ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
-    # :nocov:
 
     # Takes a block or argument that is an object that responds to #call and
     # returns a Rack response.
@@ -284,6 +287,18 @@ module Rack
     end
 
     private
+
+    # Append a middleware factory to the stack, flushing any pending map block
+    # first. The factory receives the app it wraps and returns the middleware.
+    def add_middleware(&factory)
+      if @map
+        mapping, @map = @map, nil
+        @use << proc { |app| generate_map(app, mapping) }
+      end
+      @use << factory
+
+      nil
+    end
 
     # Generate a URLMap instance by generating new Rack applications for each
     # map block in this instance.

--- a/lib/rack/mock_response.rb
+++ b/lib/rack/mock_response.rb
@@ -23,12 +23,19 @@ module Rack
         @secure = args["secure"]
       end
 
-      def method_missing(method_name, *args, &block)
-        @value.send(method_name, *args, &block)
+      if RUBY_VERSION >= '3.0'
+        def method_missing(method_name, *args, **kwargs, &block)
+          @value.send(method_name, *args, **kwargs, &block)
+        end
+      else
+        # :nocov:
+        # See the note in Rack::Builder#use.
+        def method_missing(method_name, *args, &block)
+          @value.send(method_name, *args, &block)
+        end
+        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+        # :nocov:
       end
-      # :nocov:
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
-      # :nocov:
 
       def respond_to_missing?(method_name, include_all = false)
         @value.respond_to?(method_name, include_all) || super

--- a/lib/rack/mock_response.rb
+++ b/lib/rack/mock_response.rb
@@ -23,7 +23,7 @@ module Rack
         @secure = args["secure"]
       end
 
-      if RUBY_VERSION >= '3.0'
+      if RUBY_VERSION.to_i >= 3
         def method_missing(method_name, *args, **kwargs, &block)
           @value.send(method_name, *args, **kwargs, &block)
         end

--- a/lib/rack/multipart/uploaded_file.rb
+++ b/lib/rack/multipart/uploaded_file.rb
@@ -74,7 +74,7 @@ module Rack
       end
 
       # Delegate method missing calls to the tempfile.
-      if RUBY_VERSION >= '3.0'
+      if RUBY_VERSION.to_i >= 3
         def method_missing(method_name, *args, **kwargs, &block) #:nodoc:
           @tempfile.__send__(method_name, *args, **kwargs, &block)
         end

--- a/lib/rack/multipart/uploaded_file.rb
+++ b/lib/rack/multipart/uploaded_file.rb
@@ -74,12 +74,19 @@ module Rack
       end
 
       # Delegate method missing calls to the tempfile.
-      def method_missing(method_name, *args, &block) #:nodoc:
-        @tempfile.__send__(method_name, *args, &block)
+      if RUBY_VERSION >= '3.0'
+        def method_missing(method_name, *args, **kwargs, &block) #:nodoc:
+          @tempfile.__send__(method_name, *args, **kwargs, &block)
+        end
+      else
+        # :nocov:
+        # See the note in Rack::Builder#use.
+        def method_missing(method_name, *args, &block) #:nodoc:
+          @tempfile.__send__(method_name, *args, &block)
+        end
+        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+        # :nocov:
       end
-      # :nocov:
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
-      # :nocov:
     end
   end
 end

--- a/lib/rack/multipart/uploaded_file.rb
+++ b/lib/rack/multipart/uploaded_file.rb
@@ -77,6 +77,9 @@ module Rack
       def method_missing(method_name, *args, &block) #:nodoc:
         @tempfile.__send__(method_name, *args, &block)
       end
+      # :nocov:
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
+      # :nocov:
     end
   end
 end

--- a/test/spec_builder.rb
+++ b/test/spec_builder.rb
@@ -11,6 +11,35 @@ separate_testing do
   require_relative '../lib/rack/auth/basic'
 end
 
+# Records exactly what the middleware constructor received.
+class ArgumentRecordingMiddleware
+  class << self; attr_accessor :args, :kwargs; end
+
+  def initialize(app, *args, **kwargs)
+    self.class.args = args
+    self.class.kwargs = kwargs
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env)
+  end
+end
+
+# Takes an options Hash as a required positional argument.
+class OptionsHashMiddleware
+  class << self; attr_accessor :options; end
+
+  def initialize(app, options)
+    self.class.options = options
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env)
+  end
+end
+
 class NothingMiddleware
   def initialize(app, **)
     @app = app
@@ -307,6 +336,41 @@ describe Rack::Builder do
       body = response.instance_variable_get(:@body)
       body.must_equal(['frozen'])
       body[0].frozen?.must_equal true
+    end
+  end
+
+  describe 'argument forwarding to middleware' do
+    def run_with(&block)
+      app = builder_to_app(&block)
+      Rack::MockRequest.new(app).get("/")
+    end
+
+    it "passes keyword arguments as keywords" do
+      run_with do
+        use ArgumentRecordingMiddleware, :positional, answer: 42
+        run lambda { |env| [200, { "content-type" => "text/plain" }, ["OK"]] }
+      end
+      ArgumentRecordingMiddleware.args.must_equal [:positional]
+      ArgumentRecordingMiddleware.kwargs.must_equal(answer: 42)
+    end
+
+    it "passes an empty options Hash through as a positional argument" do
+      options = {}
+      body = run_with do
+        use OptionsHashMiddleware, options
+        run lambda { |env| [200, { "content-type" => "text/plain" }, ["OK"]] }
+      end.body.to_s
+      body.must_equal 'OK'
+      OptionsHashMiddleware.options.must_equal({})
+    end
+
+    it "passes an options Hash with non-Symbol keys through unsplit" do
+      body = run_with do
+        use OptionsHashMiddleware, { "a" => 1, :b => 2 }
+        run lambda { |env| [200, { "content-type" => "text/plain" }, ["OK"]] }
+      end.body.to_s
+      body.must_equal 'OK'
+      OptionsHashMiddleware.options.must_equal({ "a" => 1, :b => 2 })
     end
   end
 

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1019,6 +1019,13 @@ content-type: image/jpeg\r
     Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"), binary: true).must_be :binmode?
   end
 
+  it "delegates keyword arguments to the tempfile" do
+    file = Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"))
+    file.readlines(chomp: true).must_equal ['contents']
+    file.rewind
+    file.gets(chomp: true).must_equal 'contents'
+  end
+
   it "builds multipart body" do
     files = Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"))
     data  = Rack::Multipart.build_multipart("submit-name" => "Larry", "files" => files)


### PR DESCRIPTION
Draft, stacked on #2482. The first commit here is that PR; the diff reduces to a single commit once it merges.

Rack calls `ruby2_keywords` in four places, all behind `respond_to?` guards. Ruby proposes deprecating and removing it ([Feature #22205](https://bugs.ruby-lang.org/issues/22205), currently Open, no target version). Because of the guards, removal would not raise. It would silently skip, and middleware and delegators taking keyword arguments would start receiving a positional Hash.

```
with ruby2_keywords:   args=[:positional]                kwargs={answer: 42}
without:               args=[:positional, {answer: 42}]  kwargs={}
```

This forwards keywords explicitly on Ruby 3.0+ in `Builder#use`, `BodyProxy#method_missing`, `MockResponse::Cookie#method_missing` and `UploadedFile#method_missing`. **Argument forwarding is unchanged on every supported Ruby.**

### Why the definitions are version-gated

Adding `**kwargs` outright regresses Ruby 2.4 to 2.7, where a trailing positional Hash is not distinguished from keywords:

| call | current | naive `**kwargs` |
|---|---|---|
| `use M, opts` where `opts == {}` | `{}` | `ArgumentError (given 1, expected 2)` |
| `use M, {"a" => 1, :b => 2}` | `{"a"=>1, :b=>2}` | `ArgumentError` |

An empty options Hash is dropped entirely; a Hash mixing Symbol and non-Symbol keys is split in two. So the pre-3.0 branch keeps `ruby2_keywords`, which exists on every Ruby that branch can run on. Follows the `if`/`else` version-gate style of `Utils#clock_time` and `Utils#escape_html`.

<details>
<summary>If Rack ever drops Ruby &lt; 3.0</summary>

Every gate collapses and each site becomes a single definition with no duplication and no `:nocov:`. Not proposing that here; #1601 settled the policy and this patch deliberately keeps 2.4 working.
</details>

### Verification

Compared the values actually received by middleware and delegated objects against unpatched `main` on **2.4, 2.6, 2.7, 3.0 and 3.4**: byte-identical for keyword arguments, positional Hash, empty Hash, mixed-key Hash, no-argument middleware and splat middleware. Same for `BodyProxy` (including `close`-on-raise, `to_str`, and `method(:x).call`), for `UploadedFile`, and for consumers that subclass `Builder` or prepend a module over `use`. `Builder#map` flush ordering verified unchanged across four `map`/`use` interleavings.

Three tests added. They fail against a naive `**kwargs` version (2 errors on 2.6) and against the `ruby2_keywords`-removed scenario.

### Notes

- `Builder#use.parameters` gains `[:keyrest, :kwargs]` on 3.0+. Only observable API change.
- `Builder#use` now delegates to a private `add_middleware`, a pure extraction of the existing `@map`/`@use` logic, so the two version branches stay one line each.
- Subclasses overriding `use` with a bare splat already lose keywords on Ruby 3.0+. Pre-existing, unchanged here.
- No documentation changes: `SPEC.rdoc` covers the server/application protocol, not the Builder DSL, and the call syntax is unchanged.

No urgency, since #22205 is still Open. Happy to hold this until it is accepted, or to split it per file if that reviews more easily.
