### PR TITLE
Apply header_rules to the same canonical path used to serve the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file. For info on
 
 - Multipart parser: limit MIME header size check to the unread buffer region to avoid false `multipart mime part header too large` errors when previously read data accumulates in the scan buffer. ([#2392](https://github.com/rack/rack/pull/2392), [@alpaca-tc](https://github.com/alpaca-tc), [@willnet](https://github.com/willnet), [@krororo](https://github.com/krororo))
 - Multipart parser: add nil guards to prevent `NoMethodError` crashes when handling `Content-Disposition` without parameters and `Content-Type` parameters without '='. ([@haruki0409](https://github.com/haruki0409))
+- `Rack::Static`: match `header_rules` against the same normalised path used to decide whether the file is served, so requests containing dot segments or duplicate slashes receive their configured headers. ([#2485](https://github.com/rack/rack/pull/2485), [@anir0y](https://github.com/anir0y))
 
 ## [3.2.6] - 2026-04-01
 

--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -168,7 +168,11 @@ module Rack
 
     # Convert HTTP header rules to HTTP headers
     def applicable_rules(path)
-      path = ::Rack::Utils.unescape_path(path)
+      # Canonicalise the same way the serving decision does. `can_serve` and Rack::Files both
+      # apply clean_path_info in addition to unescape_path, so without it a path that normalises
+      # onto a rule-matched path is served while the rule is tested against the un-normalised
+      # string and fails to match.
+      path = ::Rack::Utils.clean_path_info(::Rack::Utils.unescape_path(path))
 
       @header_rules.find_all do |rule, new_headers|
         case rule

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -204,6 +204,29 @@ describe Rack::Static do
     res.headers['cache-control'].must_equal 'public, max-age=300'
   end
 
+  it "applies folder rules to paths that normalise into the folder" do
+    # A path containing dot-segments is normalised before the file is served, so the header rule
+    # has to be evaluated against the same normalised path.
+    res = @header_request.get('/cgi/assets/other/../folder/test.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=400'
+  end
+
+  it "applies folder rules to percent-encoded dot-segments" do
+    # %2E%2E survives client-side canonicalisation, so it reaches the server verbatim.
+    res = @header_request.get('/cgi/assets/other/%2E%2E/folder/test.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=400'
+  end
+
+  it "applies Regexp rules anchored at the start to normalised paths" do
+    opts = OPTIONS.merge(header_rules: [[%r{\A/cgi/assets/folder/}, { 'x-normalised' => 'yes' }]])
+    request = Rack::MockRequest.new(static(DummyApp.new, opts))
+    res = request.get('/cgi/assets/other/../folder/test.js')
+    res.must_be :ok?
+    res.headers['x-normalised'].must_equal 'yes'
+  end
+
   it "supports folder rules provided as a String" do
     # Headers for files in folder via string
     res = @header_request.get('/cgi/assets/folder/test.js')

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -227,6 +227,28 @@ describe Rack::Static do
     res.headers['x-normalised'].must_equal 'yes'
   end
 
+  it "applies folder rules given without a leading slash to normalised paths" do
+    res = @header_request.get('/cgi/assets/other/../javascripts/app.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=500'
+  end
+
+  it "applies folder rules to paths containing duplicate slashes" do
+    # clean_path_info collapses these too, so the served path matches the rule.
+    res = @header_request.get('/cgi/assets//folder/test.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=400'
+  end
+
+  it "applies extension-anchored Regexp rules to normalised paths" do
+    # Suffix-matching rules were already unaffected, since the extension survives
+    # the dot-segments. Kept as a control so a regression in the normalisation
+    # shows up here as well as in the prefix cases above.
+    res = @header_request.get('/cgi/assets/other/../stylesheets/app.css')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=600'
+  end
+
   it "supports folder rules provided as a String" do
     # Headers for files in folder via string
     res = @header_request.get('/cgi/assets/folder/test.js')


### PR DESCRIPTION
Follow-up to `GHSA-q4qf-9j86-f5mh` as requested in GHSA-74qm-qhv6-h593 — sending it as a normal PR since the security implications are minimal.

`Rack::Static#applicable_rules` canonicalises with `unescape_path` only, while the servability decision and the file server both also apply `clean_path_info`:

| step | canonicalisation | decides |
|---|---|---|
| `Static#call` → `can_serve` | `clean_path_info(unescape_path(path))` | whether to serve |
| `Rack::Files#call` | `clean_path_info(unescape_path(path_info))` | which file is served |
| `Static#applicable_rules` | `unescape_path(path)` | which headers are applied |

So a path with dot-segments normalises onto a rule-matched path and is served, while the rule is tested against the un-normalised string and fails to match — the file comes back without its configured headers.

Affected shape is prefix matching: `String` rules and `Regexp`s anchored with `\A`. Extension-anchored (`:fonts`, `Array`, `/\.woff\z/`) and unanchored rules are unaffected, since the suffix survives normalisation.

### Change

```ruby
path = ::Rack::Utils.clean_path_info(::Rack::Utils.unescape_path(path))
```

the same pair the other two call sites already use.

### Tests

Three added to `test/spec_static.rb`, covering a dot-segment path, its percent-encoded form, and a `\A`-anchored `Regexp` rule. Verified in both directions — they fail on unpatched `lib/rack/static.rb` (`max-age=100` instead of `400`, and `nil` for the Regexp case) and pass with the change. `spec_static.rb` 34 runs / 0 failures; `spec_files.rb` and `spec_utils.rb` unaffected.

A longer-term option, if you'd prefer it: compute the canonical path once in `Static#call` and pass it to both `can_serve` and `applicable_rules`, so the two cannot drift again. Happy to redo it that way.