### PR TITLE
Backport OBS unfolding for multipart requests to 3-1-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Security
+
+- [CVE-2026-26962](https://github.com/advisories/GHSA-rx22-g9mx-qrhv) Improper unfolding of folded multipart headers preserves CRLF in parsed parameter values.
+
 ## [3.1.21] - 2026-04-01
 
 ### Security

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -360,12 +360,18 @@ module Rack
 
       CONTENT_DISPOSITION_MAX_PARAMS = 16
       CONTENT_DISPOSITION_MAX_BYTES = 1536
+      OBS_UNFOLD = /\r\n([ \t])/
+      private_constant :OBS_UNFOLD
       def handle_mime_head
         if @sbuf.scan_until(@head_regex)
           head = @sbuf[1]
           content_type = head[MULTIPART_CONTENT_TYPE, 1]
+          content_type.gsub!(OBS_UNFOLD, '\\1') if content_type
           if (disposition = head[MULTIPART_CONTENT_DISPOSITION, 1]) &&
               disposition.bytesize <= CONTENT_DISPOSITION_MAX_BYTES
+
+            # Implement OBS unfolding (RFC 5322 Section 2.2.3)
+            disposition.gsub!(OBS_UNFOLD, '\\1')
 
             # ignore actual content-disposition value (should always be form-data)
             i = disposition.index(';')

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1384,4 +1384,28 @@ content-type: image/png\r
     f.write(params["image/png"][0])
     f.length.must_equal 26473
   end
+
+  it "prevents CRLF injection in parameter values via obs-fold" do
+    data = <<~EOF
+      --AaB03x\r
+      Content-Disposition: form-data; name="upload"; filename="test\r
+      \t.txt"\r
+      Content-Type: application/octet-stream;\r
+       name="file.php"\r
+      \r
+      <?php eval($_POST['x']); ?>\r
+      --AaB03x--\r
+    EOF
+
+    options = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+      "CONTENT_LENGTH" => data.length.to_s,
+      :input => StringIO.new(data)
+    }
+    env = Rack::MockRequest.env_for("/", options)
+    params = Rack::Multipart.parse_multipart(env)
+    params["upload"][:filename].must_equal "test\t.txt"
+    params["upload"][:type].must_equal 'application/octet-stream; name="file.php"'
+  end
+
 end


### PR DESCRIPTION
Requested in GHSA-mpw4-4qx9-2625. Backport of d50c4d3d ("Implement OBS unfolding for multipart requests per RFC 5322 2.2.3") from `main`.

`GHSA-rx22-g9mx-qrhv` records its affected range as `>= 3.2.0, < 3.2.6`, so this branch is outside it — but the parser here accepts folded multipart headers and preserves the fold, leaving the CRLF embedded in parsed parameter values:

```
rack 3.1.21   Content-Disposition: ...; filename="a<CRLF> b.txt"   ->  filename == "a\r\n b.txt"
rack 3.2.6    (same input, with the fix)                           ->  filename == "a b.txt"
```

Applies cleanly here — same `handle_mime_head` structure as `main`, so it is the upstream diff unmodified: the `OBS_UNFOLD` constant plus one `gsub!` on each of the Content-Type and Content-Disposition strings.

### Tests

The regression test from the same upstream commit, ported verbatim. Verified in both directions: it fails on this branch without the change and passes with it.

```
without:  96 runs, 323 assertions, 1 failures
with:     96 runs, 324 assertions, 0 failures
```

I appreciate `CONTRIBUTING.md` reserves backports for security patches — sending this because you asked for it on the advisory, and framing it as the correctness fix you described rather than a security one. Happy to close if you would rather it only land on `main`.