### PR TITLE
Backport OBS unfolding for multipart requests to 2-2-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Security
+
+- [CVE-2026-26962](https://github.com/advisories/GHSA-rx22-g9mx-qrhv) Improper unfolding of folded multipart headers preserves CRLF in parsed parameter values.
+
 ## [2.2.23] - 2026-04-01
 
 ### Security

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -314,18 +314,17 @@ module Rack
       def handle_mime_head
         if @sbuf.scan_until(@head_regex)
           head = @sbuf[1]
-          # Implement OBS unfolding (RFC 5322 Section 2.2.3). Done on the whole mime part
-          # header because content type, disposition and filename are all extracted
-          # from it by regex on this branch.
-          head = head.gsub(OBS_UNFOLD, '\\1')
-          content_type = head[MULTIPART_CONTENT_TYPE, 1]
-          if name = head[MULTIPART_CONTENT_DISPOSITION, 1]
+          # Implement OBS unfolding (RFC 5322 Section 2.2.3). Done on a copy
+          # because content type, disposition and filename are extracted by regex.
+          unfolded_head = head.gsub(OBS_UNFOLD, '\\1')
+          content_type = unfolded_head[MULTIPART_CONTENT_TYPE, 1]
+          if name = unfolded_head[MULTIPART_CONTENT_DISPOSITION, 1]
             name = Rack::Auth::Digest::Params::dequote(name)
           else
-            name = head[MULTIPART_CONTENT_ID, 1]
+            name = unfolded_head[MULTIPART_CONTENT_ID, 1]
           end
 
-          filename = get_filename(head)
+          filename = get_filename(unfolded_head)
 
           if name.nil? || name.empty?
             name = filename || "#{content_type || TEXT_PLAIN}[]".dup

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -24,6 +24,10 @@ module Rack
       private_constant :BOUNDARY_START_LIMIT
 
       MIME_HEADER_BYTESIZE_LIMIT = 64 * 1024
+
+      OBS_UNFOLD = /\r\n([ \t])/
+
+      private_constant :OBS_UNFOLD
       private_constant :MIME_HEADER_BYTESIZE_LIMIT
 
       env_int = lambda do |key, val|
@@ -310,6 +314,10 @@ module Rack
       def handle_mime_head
         if @sbuf.scan_until(@head_regex)
           head = @sbuf[1]
+          # Implement OBS unfolding (RFC 5322 Section 2.2.3). Done on the whole mime part
+          # header because content type, disposition and filename are all extracted
+          # from it by regex on this branch.
+          head = head.gsub(OBS_UNFOLD, '\\1')
           content_type = head[MULTIPART_CONTENT_TYPE, 1]
           if name = head[MULTIPART_CONTENT_DISPOSITION, 1]
             name = Rack::Auth::Digest::Params::dequote(name)

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1140,4 +1140,28 @@ Content-Type: image/png\r
     f.write(params["image/png"][0])
     f.length.must_equal 26473
   end
+
+  it "prevents CRLF injection in parameter values via obs-fold" do
+    data = <<~EOF
+      --AaB03x\r
+      Content-Disposition: form-data; name="upload"; filename="test\r
+      \t.txt"\r
+      Content-Type: application/octet-stream;\r
+       name="file.php"\r
+      \r
+      <?php eval($_POST['x']); ?>\r
+      --AaB03x--\r
+    EOF
+
+    options = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+      "CONTENT_LENGTH" => data.length.to_s,
+      :input => StringIO.new(data)
+    }
+    env = Rack::MockRequest.env_for("/", options)
+    params = Rack::Multipart.parse_multipart(env)
+    params["upload"][:filename].must_equal "test\t.txt"
+    params["upload"][:type].must_equal 'application/octet-stream; name="file.php"'
+  end
+
 end


### PR DESCRIPTION
Requested in GHSA-mpw4-4qx9-2625. Backport of d50c4d3d ("Implement OBS unfolding for multipart requests per RFC 5322 2.2.3") from `main`, **adapted** — it does not apply cleanly here.

`main` unfolds the Content-Disposition and Content-Type strings individually. On this branch the content type, disposition and filename are all extracted from the mime part header by regex (`get_filename(head)`, `head[MULTIPART_CONTENT_DISPOSITION, 1]`), so there is no single place per value to unfold. The adaptation applies the unfold once to the header itself, immediately after capture and before any extraction, which covers all three:

```ruby
head = @sbuf[1]
# Implement OBS unfolding (RFC 5322 Section 2.2.3). Done on the whole mime part
# header because content type, disposition and filename are all extracted
# from it by regex on this branch.
head = head.gsub(OBS_UNFOLD, '\1')
```

Non-destructive `gsub` rather than `gsub!` since `head` comes from the scanner. `head.bytesize` is used afterwards for retained-size accounting and is unaffected in kind (marginally smaller).

Same rationale as the 3-1-stable backport: this branch is outside the range on `GHSA-rx22-g9mx-qrhv`, but its parser accepts folded headers and preserves the fold.

### Tests

The regression test from the upstream commit, **unchanged** — it passes as written on this branch, which is a useful check on the adaptation, since it asserts both the unfolded filename (`"test\t.txt"`) and the unfolded content type. Verified in both directions:

```
without:  72 runs, 208 assertions, 1 failures
with:     72 runs, 209 assertions, 0 failures
```

Baseline before the change was 71 runs / 0 failures, so nothing else moved.

Same note as the other backport — `CONTRIBUTING.md` reserves backports for security patches, and this is going in as the correctness fix you described. Happy to close if you would rather it only land on `main`.