### PR TITLE
Make rack/ractorize idempotent

### DIFF
--- a/lib/rack/ractorize.rb
+++ b/lib/rack/ractorize.rb
@@ -1,54 +1,30 @@
 # frozen_string_literal: true
 
 module Rack
-  file_loaded = ->(const) { const_defined?(const, false) && !autoload?(const) }
+  Headers::KNOWN_HEADERS.freeze
 
-  if file_loaded.(:Headers)
-    Headers::KNOWN_HEADERS.freeze
-  end
+  Ractor.make_shareable(Multipart::Parser::TEMPFILE_FACTORY)
+  Multipart::Parser::REENCODE_DUMMY_ENCODINGS.freeze
 
-  if file_loaded.(:Multipart)
-    Ractor.make_shareable(Multipart::Parser::TEMPFILE_FACTORY)
-    Multipart::Parser::REENCODE_DUMMY_ENCODINGS.freeze
-  end
+  Ractor.make_shareable(Request.ip_filter)
+  Request.forwarded_priority.freeze
+  Request.x_forwarded_proto_priority.freeze
 
-  if file_loaded.(:Request)
-    Ractor.make_shareable(Request.ip_filter)
-    Request.forwarded_priority.freeze
-    Request.x_forwarded_proto_priority.freeze
+  Request::Helpers::FORM_DATA_MEDIA_TYPES.freeze
+  Request::Helpers::PARSEABLE_DATA_MEDIA_TYPES.freeze
+  Request::Helpers::DEFAULT_PORTS.freeze
 
-    Request::Helpers::FORM_DATA_MEDIA_TYPES.freeze
-    Request::Helpers::PARSEABLE_DATA_MEDIA_TYPES.freeze
-    Request::Helpers::DEFAULT_PORTS.freeze
-  end
+  Utils::SYMBOL_TO_STATUS_CODE.freeze
+  Utils::HTTP_STATUS_CODES.freeze
 
-  if file_loaded.(:Utils)
-    Utils::SYMBOL_TO_STATUS_CODE.freeze
-    Utils::HTTP_STATUS_CODES.freeze
-  end
+  QueryParser::COMMON_SEP.freeze
 
-  if file_loaded.(:QueryParser)
-    QueryParser::COMMON_SEP.freeze
-  end
+  Directory::FILESIZE_FORMAT.each(&:freeze).freeze
 
-  if file_loaded.(:Directory)
-    Directory::FILESIZE_FORMAT.each(&:freeze).freeze
-  end
+  Files::ALLOWED_VERBS.freeze
+  Files::ALLOW_HEADER.freeze
 
-  if file_loaded.(:Files)
-    Files::ALLOWED_VERBS.freeze
-    Files::ALLOW_HEADER.freeze
-  end
+  Mime::MIME_TYPES.freeze
 
-  if file_loaded.(:Mime)
-    Mime::MIME_TYPES.freeze
-  end
-
-  if file_loaded.(:ShowExceptions)
-    Ractor.make_shareable(ShowExceptions::TEMPLATE)
-  end
-
-  if file_loaded.(:TempfileReaper)
-    Ractor.make_shareable(TempfileReaper.const_get(:RESPONSE_FINISHED_HANDLER))
-  end
+  Ractor.make_shareable(ShowExceptions::TEMPLATE)
 end


### PR DESCRIPTION
The previous approach prevented ractorize from loading any new constants by only freezing things already loaded. However, this could be surprising for apps that don't load everything they need up front, or if the ractorize require happens too early relative to other loads.

This commit removes the conditional freezing and instead just freezes everything. While it may result in a few more constants being loaded, its less likely to cause surprising behavior due to load order.

(Additionally, the "best" solution for loading less constants in this file is to provide proper APIs that don't involve modifying constants).