### PR TITLE
Make TempfileReaper compatible with Ractors

### DIFF
--- a/lib/rack/tempfile_reaper.rb
+++ b/lib/rack/tempfile_reaper.rb
@@ -9,11 +9,6 @@ module Rack
   # Ideas/strategy based on posts by Eric Wong and Charles Oliver Nutter
   # https://groups.google.com/forum/#!searchin/rack-devel/temp/rack-devel/brK8eh-MByw/sw61oJJCGRMJ
   class TempfileReaper
-    RESPONSE_FINISHED_HANDLER = proc { |env|
-      env[RACK_TEMPFILES]&.each(&:close!)
-    }
-    private_constant :RESPONSE_FINISHED_HANDLER
-
     def initialize(app)
       @app = app
     end
@@ -22,7 +17,7 @@ module Rack
       env[RACK_TEMPFILES] ||= []
 
       if response_finished = env[RACK_RESPONSE_FINISHED]
-        response_finished << RESPONSE_FINISHED_HANDLER
+        response_finished << TempfileReaper
 
         @app.call(env)
       else
@@ -39,6 +34,10 @@ module Rack
 
         response
       end
+    end
+
+    def self.call(env, _status, _headers, _error) # :nodoc:
+      env[RACK_TEMPFILES]&.each(&:close!)
     end
   end
 end


### PR DESCRIPTION
Previously, when used within a Ractor with an env that supports "rack.response_finished", it would raise a RactorIsolationError due to RESPONSE_FINISHED_HANDLER not being shareable.

This commit addresses the shareability by moving the RESPONSE_FINISHED_HANDLER to a class level call, which doesn't have the same restrictions as proc.

(if this is too clever, maybe we could just create the proc inside `call`, or assign it to an ivar in `initialize`, etc.)