### PR TITLE
Freeze ShowExceptions::TEMPLATE

### DIFF
--- a/lib/rack/ractorize.rb
+++ b/lib/rack/ractorize.rb
@@ -25,6 +25,4 @@ module Rack
   Files::ALLOW_HEADER.freeze
 
   Mime::MIME_TYPES.freeze
-
-  Ractor.make_shareable(ShowExceptions::TEMPLATE)
 end

--- a/lib/rack/show_exceptions.rb
+++ b/lib/rack/show_exceptions.rb
@@ -133,7 +133,7 @@ module Rack
     # Copyright (c) Django Software Foundation and individual contributors.
     # Used under the modified BSD license:
     # http://www.xfree86.org/3.3.6/COPYRIGHT2.html#5
-    TEMPLATE = ERB.new(<<~'HTML')
+    TEMPLATE = ERB.new(<<~'HTML').freeze
       <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
       <html lang="en">
       <head>


### PR DESCRIPTION
Freezing an ERB instance should be all that's necessary to make it shareable across Ractors.

This commit freezes the ERB instance inline since its below the :stopdoc: marker, meaning it should already not be getting modified by any consumers.