### PR TITLE
Normalize path before matching Rack::Static header_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file. For info on
 
 - Multipart parser: limit MIME header size check to the unread buffer region to avoid false `multipart mime part header too large` errors when previously read data accumulates in the scan buffer. ([#2392](https://github.com/rack/rack/pull/2392), [@alpaca-tc](https://github.com/alpaca-tc), [@willnet](https://github.com/willnet), [@krororo](https://github.com/krororo))
 - Multipart parser: add nil guards to prevent `NoMethodError` crashes when handling `Content-Disposition` without parameters and `Content-Type` parameters without '='. ([@haruki0409](https://github.com/haruki0409))
+- `Rack::Static`: match `header_rules` against the same normalized path used to decide whether the file is served, so requests containing dot segments or duplicate slashes receive their configured headers. ([@anir0y](https://github.com/anir0y))
 
 ## [3.2.6] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file. For info on
 
 - Multipart parser: limit MIME header size check to the unread buffer region to avoid false `multipart mime part header too large` errors when previously read data accumulates in the scan buffer. ([#2392](https://github.com/rack/rack/pull/2392), [@alpaca-tc](https://github.com/alpaca-tc), [@willnet](https://github.com/willnet), [@krororo](https://github.com/krororo))
 - Multipart parser: add nil guards to prevent `NoMethodError` crashes when handling `Content-Disposition` without parameters and `Content-Type` parameters without '='. ([@haruki0409](https://github.com/haruki0409))
-- `Rack::Static`: match `header_rules` against the same normalized path used to decide whether the file is served, so requests containing dot segments or duplicate slashes receive their configured headers. ([@anir0y](https://github.com/anir0y))
+- `Rack::Static`: match `header_rules` against the same normalized path used to decide whether the file is served, so requests containing dot segments or duplicate slashes receive their configured headers. ([#2491](https://github.com/rack/rack/pull/2491), [@anir0y](https://github.com/anir0y))
 
 ## [3.2.6] - 2026-04-01
 

--- a/lib/rack/static.rb
+++ b/lib/rack/static.rb
@@ -168,7 +168,11 @@ module Rack
 
     # Convert HTTP header rules to HTTP headers
     def applicable_rules(path)
-      path = ::Rack::Utils.unescape_path(path)
+      # Normalize with the same pair used to decide whether the path is servable
+      # (#call) and to locate the file on disk (Rack::Files), so a path
+      # containing dot segments cannot be served while its header rules are
+      # tested against the un-normalized string.
+      path = ::Rack::Utils.clean_path_info(::Rack::Utils.unescape_path(path))
 
       @header_rules.find_all do |rule, new_headers|
         case rule

--- a/test/spec_static.rb
+++ b/test/spec_static.rb
@@ -255,6 +255,50 @@ describe Rack::Static do
     res.headers['cache-control'].must_equal 'public, max-age=600'
   end
 
+  it "applies String header rules to paths containing dot segments" do
+    # /cgi/assets/x/../folder/test.js resolves to /cgi/assets/folder/test.js,
+    # which is what gets served, so the '/cgi/assets/folder/' rule must apply.
+    res = @header_request.get('/cgi/assets/x/../folder/test.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=400'
+  end
+
+  it "applies String header rules to paths containing URL-encoded dot segments" do
+    res = @header_request.get('/cgi/assets/x/%2E%2E/folder/test.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=400'
+  end
+
+  it "applies String header rules without a leading slash to paths containing dot segments" do
+    res = @header_request.get('/cgi/assets/x/../javascripts/app.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=500'
+  end
+
+  it "applies String header rules to paths containing duplicate slashes" do
+    res = @header_request.get('/cgi/assets//folder/test.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=400'
+  end
+
+  it "applies start-anchored Regexp header rules to paths containing dot segments" do
+    opts = OPTIONS.merge(header_rules: [
+      [%r{\A/cgi/assets/folder/}, { 'cache-control' => 'public, max-age=700' }]
+    ])
+    request = Rack::MockRequest.new(static(DummyApp.new, opts))
+    res = request.get('/cgi/assets/x/../folder/test.js')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=700'
+  end
+
+  it "applies extension-anchored Regexp header rules to paths containing dot segments" do
+    # Suffix-matching rules were already unaffected by dot segments; kept as a
+    # control so a regression in normalization shows up as a diff here too.
+    res = @header_request.get('/cgi/assets/x/../stylesheets/app.css')
+    res.must_be :ok?
+    res.headers['cache-control'].must_equal 'public, max-age=600'
+  end
+
   it "escapes Array rule entries when building regexp" do
     opts = OPTIONS.merge(header_rules: [
       [['p.g'], { 'cache-control' => 'public, max-age=999' }]


### PR DESCRIPTION
`Rack::Static` decides whether a request is servable (`#call`), and `Rack::Files` locates the file on disk, using the same normalization pair:

```ruby
Utils.clean_path_info(Utils.unescape_path(path))
```

`applicable_rules` only applied `unescape_path`:

| step | transformation applied | decides |
| --- | --- | --- |
| `Static#call` → `can_serve` | `clean_path_info(unescape_path(path))` | whether to serve |
| `Rack::Files#call` | `clean_path_info(unescape_path(path_info))` | which file is served |
| `Static#applicable_rules` | `unescape_path(path)` only | which headers are applied |

So a request whose path normalizes onto a rule-matched path is served, while the rule is tested against the un-normalized string and fails to match — the file comes back without its configured headers.

Prefix-matching rules are the affected shape, because dot segments change the prefix while normalization restores the served path. Measured before this change, with `header_rules` configured for a `/fonts` directory and a request for `/foo/../fonts/test.woff`:

| rule | result |
| --- | --- |
| `String '/fonts'` | headers missing |
| `String 'fonts'` | headers missing |
| `Regexp %r{\A/fonts/}` | headers missing |
| `Regexp %r{/fonts/}` (unanchored) | headers applied |
| `Regexp %r{\.woff\z}` | headers applied |
| `Array ['woff']`, `:fonts`, `:all` | headers applied |

Suffix-matching and match-anywhere rules are unaffected because the suffix survives the traversal. A `String` rule is the documented way to attach headers to a directory of static assets, so the affected shape is the common configuration.

## The change

Apply the same normalization pair in `applicable_rules`, so all three agree.

I kept the normalization local to the method rather than passing the already-computed `actual_path` down from `#call`. `#call` deliberately re-reads `PATH_INFO` at the end (after the `:urls` hash mapping and the gzip `.gz` handling may have rewritten it), and header rules should keep matching the path actually served rather than the original request path. Passing `actual_path` would silently change behaviour for the `:urls` mapping case.

## Tests

Regression coverage for each affected shape — `String` with and without a leading slash, `\A`-anchored `Regexp`, and duplicate slashes — plus an extension-anchored case as a control for the shapes that already worked.

All five new prefix-rule tests fail without the change (they fall through to the `:all` rule) and pass with it; the extension-anchored control passes either way. `spec_static.rb`, `spec_files.rb` and `spec_utils.rb` are green.

Opening this as a normal pull request as requested.
