### PR TITLE
Allow disabling the query bytesize limit via nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add `Rack::Request#prefetch?` for identifying requests with `Sec-Purpose: prefetch` header set. ([#2405](https://github.com/rack/rack/pull/2405), [@glaszig](https://github.com/glaszig))
 - Add `rack.request.config` environment key to configure Rack::Request behavior.
 - Add `Rack::Request#headers` for simpler access to request headers by header name. ([#1881](https://github.com/rack/rack/pull/1881), [@jeremyevans](https://github.com/jeremyevans))
+- Allow disabling the `Rack::QueryParser` bytesize and params limits by passing `nil` for the `bytesize_limit`/`params_limit` keyword arguments, or a negative value for `RACK_QUERY_PARSER_BYTESIZE_LIMIT`/`RACK_QUERY_PARSER_PARAMS_LIMIT`. ([#2492](https://github.com/rack/rack/pull/2492), [@alpaca-tc](https://github.com/alpaca-tc))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -211,9 +211,11 @@ or application/x-www-form-urlencoded request body that exceeds this number of
 bytes will result in a `Rack::QueryParser::QueryLimitError` exception. If this
 enviroment variable is provided, it must be an integer, or `Rack::QueryParser`
 will raise an exception.
+If the value is negative, the bytesize limit is disabled.
 
 The default limit can be overridden on a per-`Rack::QueryParser` basis using
 the `bytesize_limit` keyword argument when creating the `Rack::QueryParser`.
+Passing `nil` for this keyword argument disables the bytesize limit.
 
 ### `RACK_QUERY_PARSER_PARAMS_LIMIT`
 
@@ -223,9 +225,11 @@ query string or application/x-www-form-urlencoded request body with more
 parameters than this will result in a `Rack::QueryParser::QueryLimitError`
 exception. If this enviroment variable is provided, it must be an integer, or
 `Rack::QueryParser` will raise an exception.
+If the value is negative, the params limit is disabled.
 
 The default limit can be overridden on a per-`Rack::QueryParser` basis using
 the `params_limit` keyword argument when creating the `Rack::QueryParser`.
+Passing `nil` for this keyword argument disables the params limit.
 
 This is implemented by counting the number of parameter separators in the
 query string, before attempting parsing, so if the same parameter key is

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -52,11 +52,10 @@ module Rack
         end
       end
 
-      val
+      val if val >= 0
     end
 
-    bytesize_limit = env_int.call("RACK_QUERY_PARSER_BYTESIZE_LIMIT", 4194304)
-    BYTESIZE_LIMIT = bytesize_limit > 0 ? bytesize_limit : nil
+    BYTESIZE_LIMIT = env_int.call("RACK_QUERY_PARSER_BYTESIZE_LIMIT", 4194304)
     private_constant :BYTESIZE_LIMIT
 
     PARAMS_LIMIT = env_int.call("RACK_QUERY_PARSER_PARAMS_LIMIT", 4096)
@@ -233,9 +232,10 @@ module Rack
         raise QueryLimitError, "total query size exceeds limit (#{@bytesize_limit})"
       end
 
-      pairs = qs.split(separator ? (COMMON_SEP[separator] || /[#{separator}] */n) : DEFAULT_SEP, @params_limit + 1)
+      sep = separator ? (COMMON_SEP[separator] || /[#{separator}] */n) : DEFAULT_SEP
+      pairs = @params_limit ? qs.split(sep, @params_limit + 1) : qs.split(sep)
 
-      if pairs.size > @params_limit
+      if @params_limit && pairs.size > @params_limit
         param_count = pairs.size + pairs.last.count(separator || "&")
         raise QueryLimitError, "total number of query parameters (#{param_count}) exceeds limit (#{@params_limit})"
       end

--- a/lib/rack/query_parser.rb
+++ b/lib/rack/query_parser.rb
@@ -55,7 +55,8 @@ module Rack
       val
     end
 
-    BYTESIZE_LIMIT = env_int.call("RACK_QUERY_PARSER_BYTESIZE_LIMIT", 4194304)
+    bytesize_limit = env_int.call("RACK_QUERY_PARSER_BYTESIZE_LIMIT", 4194304)
+    BYTESIZE_LIMIT = bytesize_limit > 0 ? bytesize_limit : nil
     private_constant :BYTESIZE_LIMIT
 
     PARAMS_LIMIT = env_int.call("RACK_QUERY_PARSER_PARAMS_LIMIT", 4096)
@@ -228,7 +229,7 @@ module Rack
     def each_query_pair(qs, separator, unescaper = nil)
       return if !qs || qs.empty?
 
-      if qs.bytesize > @bytesize_limit
+      if @bytesize_limit && qs.bytesize > @bytesize_limit
         raise QueryLimitError, "total query size exceeds limit (#{@bytesize_limit})"
       end
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -605,7 +605,8 @@ module Rack
               # Add 2 bytes. One to check whether it is over the limit, and a second
               # in case the slice! call below removes the last byte
               # If read returns nil, use the empty string
-              form_vars = get_header(RACK_INPUT).read(query_parser.bytesize_limit + 2) || ''
+              bytesize = query_parser.bytesize_limit ? query_parser.bytesize_limit + 2 : nil
+              form_vars = get_header(RACK_INPUT).read(bytesize) || ''
 
               # Fix for Safari Ajax postings that always append \0
               # form_vars.sub!(/\0\z/, '') # performance replacement:

--- a/test/spec_query_parser.rb
+++ b/test/spec_query_parser.rb
@@ -50,6 +50,12 @@ describe Rack::QueryParser do
     proc { query_parser.parse_query_pairs("a=a&b=b&c=c") }.must_raise Rack::QueryParser::QueryLimitError
   end
 
+  it "does not enforce a params limit when params_limit is nil" do
+    query_parser = Rack::QueryParser.make_default(32, params_limit: nil)
+    query_parser.parse_query("a=a&b=b&c=c").must_equal({"a" => "a", "b" => "b", "c" => "c"})
+    query_parser.parse_nested_query("a=a&b=b&c=c").must_equal({"a" => "a", "b" => "b", "c" => "c"})
+  end
+
   it "raises when normalizing params with incompatible encoding such as UTF-16LE" do
     query_parser = Rack::QueryParser.make_default(8)
     name = "utf-16le".dup.force_encoding("UTF-16LE")

--- a/test/spec_query_parser.rb
+++ b/test/spec_query_parser.rb
@@ -29,6 +29,14 @@ describe Rack::QueryParser do
     proc { query_parser.parse_query_pairs("a=aa") }.must_raise Rack::QueryParser::QueryLimitError
   end
 
+  it "does not enforce a bytesize limit when bytesize_limit is nil" do
+    query_parser = Rack::QueryParser.make_default(32, bytesize_limit: nil)
+    query_parser.parse_query("a=aa").must_equal({"a" => "aa"})
+    query_parser.parse_nested_query("a=aa").must_equal({"a" => "aa"})
+    query_parser.parse_nested_query("a=aa", '&').must_equal({"a" => "aa"})
+    query_parser.parse_query_pairs("a=aa").must_equal([["a", "aa"]])
+  end
+
   it "accepts params_limit to specify maximum number of query parameters to parse" do
     query_parser = Rack::QueryParser.make_default(32, params_limit: 2)
     query_parser.parse_query("a=a&b=b").must_equal({"a" => "a", "b" => "b"})

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -918,6 +918,32 @@ class RackRequestTest < Minitest::Spec
     reads.first.must_equal(request.send(:query_parser).bytesize_limit + 2)
   end
 
+  it "read POST body without a length limit when bytesize_limit is nil" do
+    # Create a mock input that tracks read calls
+    reads = []
+    mock_input = Object.new
+    mock_input.define_singleton_method(:read) do |len=nil|
+      reads << len
+      # Return mutable string
+      "foo=bar".dup
+    end
+
+    request = make_request \
+      Rack::MockRequest.env_for("/",
+        'REQUEST_METHOD' => 'POST',
+        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+        'rack.input' => mock_input)
+    request.define_singleton_method(:query_parser) do
+      Rack::QueryParser.make_default(Rack::Utils.param_depth_limit, bytesize_limit: nil)
+    end
+
+    request.POST.must_equal "foo" => "bar"
+
+    # Verify read was called without a limit (nil), since bytesize_limit is nil
+    reads.size.must_equal 1
+    assert_nil reads.first
+  end
+
   it "handle nil return from rack.input.read when parsing url-encoded data" do
     # Simulate an input that returns nil on read
     mock_input = Object.new


### PR DESCRIPTION
## Background

`Request#POST` reads the request body using:

```ruby
get_header(RACK_INPUT).read(query_parser.bytesize_limit + 2)
```

If `bytesize_limit` is configured close to the OS's `read(2)` size ceiling (`2**32` on many platforms), the `+ 2` padding pushes the requested read size past that ceiling. The resulting behavior is OS-dependent: some platforms raise `Errno::EINVAL`, others silently truncate the read.

Working around this by lowering `RACK_QUERY_PARSER_BYTESIZE_LIMIT` a few bytes below the OS ceiling is fragile: callers have to know about the internal `+ 2` and back it out of a config value, and any change to that offset (or a different OS ceiling) breaks the workaround again.

Some deployments also enforce a request size limit upstream (e.g. in a reverse proxy), making rack's own `bytesize_limit` redundant. Those users currently have no way to fully disable the check; they still have to pick *some* number small enough to stay under the OS read limit, effectively managing the same limit twice.

## What changed

`QueryParser#bytesize_limit` and `QueryParser#params_limit` now accept `nil` to mean "no limit":

- `each_query_pair` skips the bytesize check entirely when `@bytesize_limit` is `nil`, and skips the params-count check entirely when `@params_limit` is `nil`.
- `Request#POST` reads the body with an unbounded `read` (no length argument) when `bytesize_limit` is `nil`, instead of `bytesize_limit + 2`.
- `RACK_QUERY_PARSER_BYTESIZE_LIMIT` and `RACK_QUERY_PARSER_PARAMS_LIMIT` become `nil` (no limit) when set to a **negative** value.

This lets callers who already bound request size elsewhere opt out of the check with `bytesize_limit: nil` / `params_limit: nil`, without having to reason about rack's internal read padding relative to the OS's read size limit.

### Backwards compatibility for `0`

Unlike `Rack::Multipart::Parser::PARSER_BYTESIZE_LIMIT` (where a non-positive `RACK_MULTIPART_PARSER_BYTESIZE_LIMIT` is treated as `nil`), a value of `0` is **not** treated specially here, for either the environment variables or the `bytesize_limit:`/`params_limit:` keyword arguments:

- Before this change, `RACK_QUERY_PARSER_BYTESIZE_LIMIT=0` (or `bytesize_limit: 0`) resulted in a limit of `0`, which effectively rejected every non-empty query string/body. Some deployments may rely on this to reject all query parameters.
- Converting `0` to "no limit" would silently invert that behavior for existing users, so `0` continues to be used as a literal limit of zero. Only a negative value (env var) or explicit `nil` (keyword argument) disables the check.