### PR TITLE
Support rack.request.config :authority key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file. For info on
 - Add support for streaming bodies when using `Rack::Events`. ([#2375](github.com/rack/rack/pull/2375), [@unflxw](https://github.com/unflxw))
 - Add `deflaters` option to `Rack::Deflater` to enable custom compression algorithms like zstd. ([#2168](https://github.com/rack/rack/issues/2168), [@alexanderadam](https://github.com/alexanderadam))
 - Add `Rack::Request#prefetch?` for identifying requests with `Sec-Purpose: prefetch` header set. ([#2405](https://github.com/rack/rack/pull/2405), [@glaszig](https://github.com/glaszig))
-- Add `rack.request.config` environment key to configure Rack::Request behavior.
+- Add `rack.request.config` environment key to configure Rack::Request behavior. ([#2462](https://github.com/rack/rack/pull/2462), [#2493](https://github.com/rack/rack/pull/2493), [@jeremyevans](https://github.com/jeremyevans))
 - Add `Rack::Request#headers` for simpler access to request headers by header name. ([#1881](https://github.com/rack/rack/pull/1881), [@jeremyevans](https://github.com/jeremyevans))
 
 ### Changed

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -350,7 +350,7 @@ module Rack
       # In HTTP/1, this is the `host` header.
       # In HTTP/2, this is the `:authority` pseudo-header.
       def authority
-        forwarded_authority || host_authority || server_authority
+        config_value(:authority) || forwarded_authority || host_authority || server_authority
       end
 
       # The authority as defined by the `SERVER_NAME` and `SERVER_PORT`

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -405,6 +405,22 @@ class RackRequestTest < Minitest::Spec
     req.port.must_equal 443
   end
 
+  it "use rack.request.config :authority for authority host, hostname, host_with_port, and port" do
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "www2.example.org", "rack.request.config" => {authority: "www3.example.org:80"})
+    req.host.must_equal "www3.example.org"
+    req.hostname.must_equal "www3.example.org"
+    req.host_with_port.must_equal "www3.example.org"
+    req.port.must_equal 80
+
+    req = make_request \
+      Rack::MockRequest.env_for("/", "HTTP_HOST" => "www2.example.org", "rack.request.config" => {authority: "www3.example.org:81"})
+    req.host.must_equal "www3.example.org"
+    req.hostname.must_equal "www3.example.org"
+    req.host_with_port.must_equal "www3.example.org:81"
+    req.port.must_equal 81
+  end
+
   [true, false].each do |global|
     it "have forwarded_* methods respect forwarded_priority set #{global ? "globally" : "via rack.request.config"}" do
       begin


### PR DESCRIPTION
This makes Rack::Request#authority use the value of the key if set. This affects the following methods:

* authority
* host
* hostname
* host_with_port
* port

This should be used in any case where you know what the host should be. It can prevent user-submitted overrides via Forwarded or X-Forwarded-Host headers, or the Host header (if the server can be reached by arbitrary hostnames).