### PR TITLE
Remove Rack::Request#parse_multipart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to this project will be documented in this file. For info on
 - Multipart parser: limit MIME header size check to the unread buffer region to avoid false `multipart mime part header too large` errors when previously read data accumulates in the scan buffer. ([#2392](https://github.com/rack/rack/pull/2392), [@alpaca-tc](https://github.com/alpaca-tc), [@willnet](https://github.com/willnet), [@krororo](https://github.com/krororo))
 - Multipart parser: add nil guards to prevent `NoMethodError` crashes when handling `Content-Disposition` without parameters and `Content-Type` parameters without '='. ([@haruki0409](https://github.com/haruki0409))
 
+### Removed
+
+- `Rack::Request#parse_multipart` (private method designed to be overridden in subclasses) ([#2494](https://github.com/rack/rack/pull/2494), [@jeremyevans](https://github.com/jeremyevans))
+
 ## [3.2.6] - 2026-04-01
 
 ### Security

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -782,11 +782,6 @@ module Rack
         query_parser.parse_nested_query(qs, d)
       end
 
-      def parse_multipart
-        warn "Rack::Request#parse_multipart is deprecated and will be removed in a future version of Rack.", uplevel: 1
-        Rack::Multipart.extract_multipart(self, query_parser)
-      end
-
       def expand_param_pairs(pairs, query_parser = query_parser())
         params = query_parser.make_params
 

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -132,12 +132,6 @@ describe Rack::Multipart do
     params["text/plain; charset=US-ASCII"].must_equal ["contents"]
   end
 
-  deprecated "parses multipart content when called using Rack::Request#parse_multipart" do
-    request = Rack::Request.new(Rack::MockRequest.env_for("/", multipart_fixture(:content_type_and_no_disposition)))
-    params = request.send(:parse_multipart)
-    params["text/plain; charset=US-ASCII"].must_equal ["contents"]
-  end
-
   it "parses multipart content when content type is present but disposition is not when using IO" do
     read, write = IO.pipe
     env = multipart_fixture(:content_type_and_no_disposition)


### PR DESCRIPTION
This is a private method that has not been used since 3855d1d2638af92193c0636107247bc31c98b2f1. It was deprecated in 1ba8ce1f6bb2843485b853c331f8be0ab1c96bd6, before Rack 3.2.0, so it is safe to remove.