### PR TITLE
Enable warnings for test:regular

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ end
 Rake::TestTask.new("test:regular") do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb", "test/**/spec_*.rb", "test/gemloader.rb"]
-  t.warning = false
+  t.warning = true
   t.verbose = true
 end
 


### PR DESCRIPTION
test:separate already enables warnings, and in general I think its best to run tests with warnings enabled.