### PR TITLE
Support rack.request.config :multipart_parser

### DIFF
--- a/lib/rack/multipart.rb
+++ b/lib/rack/multipart.rb
@@ -46,23 +46,7 @@ module Rack
 
     class << self
       def parse_multipart(env, params = Rack::Utils.default_query_parser)
-        unless io = env[RACK_INPUT]
-          raise MissingInputError, "Missing input stream!"
-        end
-
-        if content_length = env['CONTENT_LENGTH']
-          content_length = content_length.to_i
-        end
-
-        content_type = env['CONTENT_TYPE']
-
-        tempfile = env[RACK_MULTIPART_TEMPFILE_FACTORY] || Parser::TEMPFILE_FACTORY
-        bufsize = env[RACK_MULTIPART_BUFFER_SIZE] || Parser::BUFSIZE
-
-        info = Parser.parse(io, content_length, content_type, tempfile, bufsize, params)
-        env[RACK_TEMPFILES] = info.tmp_files
-
-        return info.params
+        Parser.parse_from_env(env, query_parser: params)
       end
 
       def extract_multipart(request, params = Rack::Utils.default_query_parser)

--- a/lib/rack/multipart/parser.rb
+++ b/lib/rack/multipart/parser.rb
@@ -134,6 +134,38 @@ module Rack
         data[2]
       end
 
+      def self.default_tempfile_factory
+        TEMPFILE_FACTORY
+      end
+
+      def self.default_bufsize
+        BUFSIZE
+      end
+
+      def self.default_query_parser
+        Rack::Utils.default_query_parser
+      end
+
+      def self.parse_from_env(env, query_parser: default_query_parser)
+        unless io = env[RACK_INPUT]
+          raise MissingInputError, "Missing input stream!"
+        end
+
+        if content_length = env['CONTENT_LENGTH']
+          content_length = content_length.to_i
+        end
+
+        content_type = env['CONTENT_TYPE']
+
+        tempfile = env[RACK_MULTIPART_TEMPFILE_FACTORY] || default_tempfile_factory
+        bufsize = env[RACK_MULTIPART_BUFFER_SIZE] || default_bufsize
+
+        info = parse(io, content_length, content_type, tempfile, bufsize, query_parser)
+        env[RACK_TEMPFILES] = info.tmp_files
+
+        return info.params
+      end
+
       def self.parse(io, content_length, content_type, tmpfile, bufsize, qp)
         return EMPTY if 0 == content_length
 

--- a/lib/rack/request.rb
+++ b/lib/rack/request.rb
@@ -599,7 +599,7 @@ module Rack
           if rack_input.nil?
             set_header(RACK_REQUEST_FORM_PAIRS, [])
           elsif form_data? || parseable_data?
-            if pairs = Rack::Multipart.parse_multipart(env, Rack::Multipart::ParamList)
+            if pairs = multipart_parser.parse_from_env(env)
               set_header RACK_REQUEST_FORM_PAIRS, pairs
             else
               # Add 2 bytes. One to check whether it is over the limit, and a second
@@ -769,6 +769,18 @@ module Rack
 
       def query_parser
         @query_parser || config_value(:query_parser) || Utils.default_query_parser
+      end
+
+      # The default multipart parser
+      class MultipartParser < Multipart::Parser
+        # The default query parser used by the multipart parser.
+        def self.default_query_parser
+          Rack::Multipart::ParamList
+        end
+      end
+
+      def multipart_parser
+        config_value(:multipart_parser) || MultipartParser
       end
 
       def parse_query(qs, d = '&')

--- a/test/spec_request.rb
+++ b/test/spec_request.rb
@@ -732,6 +732,22 @@ class RackRequestTest < Minitest::Spec
     req.params[:quux].must_equal "bla"
   end
 
+  it "should use the multipart_parser from environment for multipart parsing" do
+    input = File.read(File.join(File.dirname(__FILE__), "multipart", "filename_multi"))
+    mp_parser = Class.new(Rack::Request::MultipartParser) do
+      def self.default_tempfile_factory
+        proc { raise "no uploads allowed" }
+      end
+    end
+
+    req = Rack::Request.new Rack::MockRequest.env_for("/",
+                      "rack.request.config" => {multipart_parser: mp_parser},
+                      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+                      "CONTENT_LENGTH" => input.size,
+                      :input => input)
+    proc { req.POST }.must_raise(RuntimeError).message.must_equal "no uploads allowed"
+  end
+
   it "does not use semi-colons as separators for query strings in GET" do
     req = make_request(Rack::MockRequest.env_for("/?foo=bar&quux=b;la;wun=duh"))
     req.query_string.must_equal "foo=bar&quux=b;la;wun=duh"


### PR DESCRIPTION
This allows configuring the multipart parser for a request similar to how the query parser is configured, via rack.request.config.

To enable this, add some class methods to Rack::Multipart::Parser:

* parse_from_env
* default_tempfile_factory
* default_bufsize
* default_query_parser

Most of the logic from Rack::Multipart.parse_multipart is moved to Rack::Multipart::Parser.parse_from_env.

Rack::Request#multipart_parser is added to return the multipart parser to use. The default is a subclass of Rack::Multipart::Parser that will use Rack::Multipart::ParamList as the default query parser.

Rack::Request#POST now calls multipart_parser.parse_from_env(env) to perform the multipart parse.

In the future, we can move more multipart parsing settings (e.g. limits) into class or instance methods of Rack::Multipart::Parser, so that more settings can be configured via rack.request.config :multipart_parser.