### PR TITLE
[3.2] Delegate keyword arguments in UploadedFile#method_missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. For info on how to format all future additions to this file please reference [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- `Rack::Multipart::UploadedFile` now delegates keyword arguments to the wrapped tempfile. Calls such as `uploaded_file.readlines(chomp: true)` raised `TypeError` on Ruby 3.0+. ([#2481](https://github.com/rack/rack/issues/2481), [#2501](https://github.com/rack/rack/pull/2501), [@SeanLF](https://github.com/SeanLF))
+
 ## [3.2.7] - 2026-08-13
 
 ### Fixed

--- a/lib/rack/multipart/uploaded_file.rb
+++ b/lib/rack/multipart/uploaded_file.rb
@@ -77,6 +77,7 @@ module Rack
       def method_missing(method_name, *args, &block) #:nodoc:
         @tempfile.__send__(method_name, *args, &block)
       end
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/test/spec_multipart.rb
+++ b/test/spec_multipart.rb
@@ -1019,6 +1019,13 @@ content-type: image/jpeg\r
     Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"), binary: true).must_be :binmode?
   end
 
+  it "delegates keyword arguments to the tempfile" do
+    file = Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"))
+    file.readlines(chomp: true).must_equal ['contents']
+    file.rewind
+    file.gets(chomp: true).must_equal 'contents'
+  end
+
   it "builds multipart body" do
     files = Rack::Multipart::UploadedFile.new(multipart_file("file1.txt"))
     data  = Rack::Multipart.build_multipart("submit-name" => "Larry", "files" => files)


### PR DESCRIPTION
## Summary

Backport the `Rack::Multipart::UploadedFile` keyword-forwarding fix for #2481 to Rack 3.2.

Rack 3.2 supports Ruby 2.4, so it cannot use the `...` forwarding syntax adopted on `main`. This instead uses the guarded `ruby2_keywords` compatibility mechanism from #2482, matching the other delegators on the stable branch. Ruby 2.4-2.6 retain their existing behavior, while Ruby 2.7+ correctly forwards keyword arguments.

The original authorship and changelog credit for @SeanLF are preserved.

## Verification

- `bundle exec ruby -Itest test/spec_multipart.rb -n "/delegates keyword arguments/"`
- `bundle exec ruby -Itest test/spec_multipart.rb` (100 runs, 332 assertions)
- `git diff --check`