### PR TITLE
Exclude QUERY from `_method` form-parameter overrides

### DIFF
--- a/lib/rack/method_override.rb
+++ b/lib/rack/method_override.rb
@@ -12,6 +12,14 @@ module Rack
     private_constant :PRIV_HTTP_METHODS
     deprecate_constant :HTTP_METHODS
 
+    # QUERY is excluded from _method parameter overrides by default:
+    # frameworks CSRF-exempt QUERY because HTML forms cannot emit it, and
+    # the _method parameter is reachable from a plain form POST. The
+    # X-HTTP-Method-Override header is not — cross-origin, custom headers
+    # always force a CORS preflight — so QUERY remains overridable there.
+    PARAM_EXCLUDED_METHODS = %w[QUERY]
+    private_constant :PARAM_EXCLUDED_METHODS
+
     METHOD_OVERRIDE_PARAM_KEY = "_method"
     HTTP_METHOD_OVERRIDE_HEADER = "HTTP_X_HTTP_METHOD_OVERRIDE"
     ALLOWED_METHODS = %w[POST]
@@ -20,16 +28,18 @@ module Rack
     private_constant :PRIV_ALLOWED_METHODS
     deprecate_constant :ALLOWED_METHODS
 
-    def initialize(app, allowed_methods: PRIV_ALLOWED_METHODS, allowed_overrides: PRIV_HTTP_METHODS)
+    def initialize(app, allowed_methods: PRIV_ALLOWED_METHODS, allowed_overrides: PRIV_HTTP_METHODS,
+                   allowed_param_overrides: allowed_overrides - PARAM_EXCLUDED_METHODS)
       @app = app
       @allowed_methods = allowed_methods
       @allowed_overrides = allowed_overrides
+      @allowed_param_overrides = allowed_param_overrides
     end
 
     def call(env)
       if allowed_methods.include?(env[REQUEST_METHOD])
         method = method_override(env)
-        if allowed_overrides.include?(method)
+        if allowed_overrides_for(env).include?(method)
           env[RACK_METHODOVERRIDE_ORIGINAL_METHOD] = env[REQUEST_METHOD]
           env[REQUEST_METHOD] = method
         end
@@ -51,7 +61,20 @@ module Rack
 
     private
 
-    attr_reader :allowed_methods, :allowed_overrides
+    attr_reader :allowed_methods, :allowed_overrides, :allowed_param_overrides
+
+    # The _method parameter answers to the narrower parameter policy; the
+    # X-HTTP-Method-Override header to the full one. Probes the form hash
+    # that method_override's Request#POST call cached in the env rather
+    # than parsing the body a second time (which would also duplicate any
+    # parse-error messages written to rack.errors).
+    def allowed_overrides_for(env)
+      if (form = env[RACK_REQUEST_FORM_HASH]) && form[METHOD_OVERRIDE_PARAM_KEY]
+        allowed_param_overrides
+      else
+        allowed_overrides
+      end
+    end
 
     def method_override_param(req)
       req.POST[METHOD_OVERRIDE_PARAM_KEY] if req.form_data? || req.parseable_data?

--- a/test/spec_method_override.rb
+++ b/test/spec_method_override.rb
@@ -43,7 +43,32 @@ describe Rack::MethodOverride do
     env["REQUEST_METHOD"].must_equal "PUT"
   end
 
-  it "modify REQUEST_METHOD for POST requests when _method parameter is set to query" do
+  it "does not modify REQUEST_METHOD for POST requests when _method parameter is set to query" do
+    # QUERY's CSRF exemptions rely on HTML forms being unable to emit it,
+    # so the form-reachable _method parameter may not override to it.
+    env = Rack::MockRequest.env_for("/", method: "POST", input: "_method=query")
+    app.call env
+
+    env["REQUEST_METHOD"].must_equal "POST"
+    env["rack.methodoverride.original_method"].must_be_nil
+  end
+
+  it "modify REQUEST_METHOD for POST requests when X-HTTP-Method-Override is set to QUERY" do
+    # Unlike the _method parameter, the header is not reachable from an
+    # HTML form, and setting it cross-origin forces a CORS preflight.
+    env = Rack::MockRequest.env_for("/",
+            :method => "POST",
+            "HTTP_X_HTTP_METHOD_OVERRIDE" => "QUERY"
+          )
+    app.call env
+
+    env["REQUEST_METHOD"].must_equal "QUERY"
+  end
+
+  it "modify REQUEST_METHOD for _method=query when allowed_param_overrides opts in" do
+    app = Rack::Lint.new(Rack::MethodOverride.new(lambda {|e|
+      [200, { "content-type" => "text/plain" }, []]
+    }, allowed_param_overrides: %w[QUERY]))
     env = Rack::MockRequest.env_for("/", method: "POST", input: "_method=query")
     app.call env
 


### PR DESCRIPTION
#2474 added QUERY to `MethodOverride`'s override targets. Before that ships in a release, this excludes QUERY from the `_method` form-parameter channel while keeping it available via the `X-HTTP-Method-Override` header — the split @samuel-williams-shopify suggested.

Frameworks CSRF-exempt QUERY on the strength of two structural facts: HTML forms cannot emit it, and cross-origin `fetch()` QUERY is never CORS-safelisted, so it always preflights. The `_method` parameter is reachable from a plain form POST, so overriding to QUERY there falsifies the first fact for any framework that checks the post-override method — the natural way to write the check.

The header channel carries no such risk: custom headers always force a CORS preflight, and header tunneling is the standing tool for infrastructure that rejects unfamiliar methods (Puma, for example, accepts only the standard eight by default). So the policy splits by channel: the parameter channel defaults to `allowed_overrides - ["QUERY"]`, and a new `allowed_param_overrides:` keyword makes the parameter policy explicit for apps that want it wider or narrower.

Since #2474 and the override keywords are both unreleased, this is a no-op relative to the last release.

/cc @seanpdoyle
